### PR TITLE
hotfix: restore onboarding button interaction

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -17423,7 +17423,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen text-primary">
-      <div className="app-shell mx-auto max-w-7xl px-4 sm:px-6 lg:px-8" inert={isOnboardingActive}>
+      <div className="app-shell mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         {(activePage === "boards" || activePage === "upcoming" || activePage === "wallet-bounties" || activePage === "settings") && (
           <header className="app-header">
             {activePage === "boards" && (
@@ -18733,7 +18733,7 @@ export default function App() {
         </div>
       )}
 
-      <div className="app-tab-switcher" inert={isOnboardingActive}>
+      <div className="app-tab-switcher">
         <div className="app-tab-switcher__pill">
           <div className="relative flex-1 min-w-0">
             <button


### PR DESCRIPTION
## Hotfix: onboarding buttons not clickable after merge

### Root cause
`inert={isOnboardingActive}` was applied to `app-shell` and `app-tab-switcher`. The onboarding modal is rendered inside that subtree, so the modal itself became inert and its buttons were non-interactive.

### Fix
- Removed `inert` from:
  - `app-shell`
  - `app-tab-switcher`
- Kept existing state-level hard-gate logic (nav guards + snap-back) so background navigation remains blocked while onboarding is active.

### Validation
- `npm test` in `taskify-pwa`: **43 passed, 0 failed**
- Live dev-server check:
  - Welcome screen loads
  - "Create new login" button is clickable and transitions correctly

### Docs impact
- No user-facing behavior docs changed; this is a regression hotfix restoring intended onboarding interaction.
