### PR TITLE
feat(cli): taskify-cli — full CLI for Nostr task management (sessions 1-11)

### DIFF
--- a/taskify-cli/.gitignore
+++ b/taskify-cli/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+
+# Local dev secrets — never commit
+dev/

--- a/taskify-cli/README.md
+++ b/taskify-cli/README.md
@@ -1,0 +1,190 @@
+# taskify-cli
+
+A command-line client for managing tasks over the Nostr protocol.
+
+## Global Install
+
+```bash
+cd taskify-cli
+npm install
+npm link        # installs `taskify` globally
+taskify --help
+```
+
+Note: Requires Node.js 22+.
+
+If `npm link` fails due to permissions, try:
+
+```bash
+npm link --prefix ~/.local
+```
+
+Then add `~/.local/bin` to your `PATH`.
+
+## Install & Setup
+
+**Requirements:** Node.js 22+ (for `--experimental-strip-types`)
+
+```bash
+cd taskify-cli
+npm install
+npm link
+```
+
+### Configure your private key
+
+```bash
+# From file
+taskify config set nsec nsec1...
+
+# Or via environment variable (takes precedence over saved config)
+export TASKIFY_NSEC=nsec1...
+```
+
+### Configure relays (optional — defaults provided)
+
+```bash
+taskify config set relay wss://relay.damus.io
+```
+
+### Show current config
+
+```bash
+taskify config show
+```
+
+---
+
+## Command Reference
+
+| Command | Options | Description |
+|---|---|---|
+| `list` | `--board <name>` `--status open\|done\|any` `--json` | List tasks, optionally filtered |
+| `add <title>` | `--board <name>` `--due <YYYY-MM-DD>` `--priority <1\|2\|3>` `--note <text>` `--subtask <text>` | Create a new task |
+| `show <taskId>` | `--board <name>` `--json` | Show full task details |
+| `done <taskId>` | `--board <name>` | Mark a task as done (accepts 8-char prefix or full ID) |
+| `reopen <taskId>` | `--board <name>` | Reopen a completed task (accepts 8-char prefix or full ID) |
+| `delete <taskId>` | `--board <name>` `--force` | Publish status=deleted to Nostr (accepts 8-char prefix or full ID) |
+| `subtask <taskId> <ref>` | `--board <name>` `--done` `--reopen` | Toggle a subtask done/incomplete (ref = 1-based index or title substring) |
+| `update <taskId>` | `--title <t>` `--due <d>` `--priority <p>` `--note <n>` | Update task fields (accepts 8-char prefix or full ID) |
+| `boards` | | List boards with task counts, sorted by count |
+| `trust add <npub>` | | Mark an npub as trusted |
+| `trust remove <npub>` | | Remove a trusted npub |
+| `trust list` | | List all trusted npubs |
+| `config set nsec <nsec>` | | Save your private key |
+| `config set relay <url>` | | Add a relay URL |
+| `config show` | | Show current config |
+
+### `--board` fuzzy match
+
+The `--board` filter is case-insensitive substring match:
+
+```bash
+taskify list --board dev   # matches board "Dev", "Development", etc.
+```
+
+---
+
+## Example Output
+
+### `taskify list`
+
+```
+Board: Dev
+ID        TITLE                                     DUE           PRI   TRUST
+e5100d28  Ship v2 release (2/4)                     2026-03-15    2     ✓ trusted
+a8c2f4b0  Fix login bug                             2026-03-10    3     ✗ untrusted
+```
+
+- **ID** — first 8 hex chars of the Nostr event ID
+- **TITLE** — truncated at 40 chars; `(N/M)` shows completed/total subtasks when present
+- **DUE** — ISO date (YYYY-MM-DD)
+- **PRI** — priority 1 (low) to 3 (high)
+- **TRUST** — `✓ trusted` if `lastEditedBy` matches a trusted npub, `✗ untrusted` otherwise
+
+### `taskify boards`
+
+```
+  Dev           3 tasks (2 open, 1 done)
+  Personal      1 tasks (1 open, 0 done)
+```
+
+Sorted by total task count descending.
+
+### `taskify list --json`
+
+Outputs a JSON array. Each object contains all task fields:
+
+```json
+[
+  {
+    "id": "a8c2f4b0...",
+    "boardId": "Dev",
+    "title": "Ship v2 release",
+    "note": "Includes changelog",
+    "dueISO": "2026-03-15",
+    "dueDateEnabled": true,
+    "priority": 2,
+    "completed": false,
+    "completedAt": null,
+    "createdBy": "1a2988df...",
+    "lastEditedBy": "1a2988df...",
+    "createdAt": 1773019736,
+    "updatedAt": "2026-03-09T01:28:56.902Z"
+  }
+]
+```
+
+---
+
+## Agent Usage
+
+Taskify is designed for use by AI agents via the `--json` flag.
+
+### Trust model
+
+Every Nostr event carries the pubkey of its author (`createdBy`) and optionally an `editor` tag (`lastEditedBy`). The CLI compares `lastEditedBy` against your configured `trustedNpubs` list.
+
+- **`✓ trusted`** — the last editor's npub is in your trusted list
+- **`✗ untrusted`** — last editor is unknown or not in your list
+- **`? unknown`** — no editor information available
+
+### Agent workflow
+
+```bash
+# 1. List open tasks as JSON for processing
+taskify list --status any --json
+
+# 2. Update a task
+taskify update <id> --title "New title" --priority 2
+
+# 3. Mark done
+taskify done <id>
+```
+
+All commands exit with code `0` on success, `1` on error. They do not hang — a 10-second relay timeout is enforced and WebSocket connections are torn down on exit.
+
+### Environment override
+
+Set `TASKIFY_NSEC` to override the saved private key without modifying config:
+
+```bash
+TASKIFY_NSEC=nsec1... taskify list --json
+```
+
+## Shell Completions
+
+```bash
+# zsh
+taskify completions --shell zsh > ~/.zsh/completions/_taskify
+echo "fpath=(~/.zsh/completions $fpath)" >> ~/.zshrc
+echo "autoload -U compinit && compinit" >> ~/.zshrc
+source ~/.zshrc
+
+# bash
+taskify completions --shell bash > ~/.bash_completion.d/taskify
+source ~/.bash_completion.d/taskify
+
+# fish
+taskify completions --shell fish > ~/.config/fish/completions/taskify.fish
+```

--- a/taskify-cli/README.md
+++ b/taskify-cli/README.md
@@ -2,7 +2,7 @@
 
 A command-line client for managing tasks over the Nostr protocol.
 
-## Global Install
+## Install
 
 ```bash
 cd taskify-cli
@@ -11,43 +11,36 @@ npm link        # installs `taskify` globally
 taskify --help
 ```
 
-Note: Requires Node.js 22+.
+**Requirements:** Node.js 22+ (for `--experimental-strip-types`)
 
-If `npm link` fails due to permissions, try:
+If `npm link` fails due to permissions:
 
 ```bash
 npm link --prefix ~/.local
+# then add ~/.local/bin to your PATH
 ```
 
-Then add `~/.local/bin` to your `PATH`.
+---
 
-## Install & Setup
+## Setup
 
-**Requirements:** Node.js 22+ (for `--experimental-strip-types`)
-
-```bash
-cd taskify-cli
-npm install
-npm link
-```
-
-### Configure your private key
+### Private key
 
 ```bash
-# From file
 taskify config set nsec nsec1...
-
-# Or via environment variable (takes precedence over saved config)
+# or via environment variable (takes precedence):
 export TASKIFY_NSEC=nsec1...
 ```
 
-### Configure relays (optional — defaults provided)
+### Relays (optional — defaults provided)
 
 ```bash
 taskify config set relay wss://relay.damus.io
+taskify relay list
+taskify relay status
 ```
 
-### Show current config
+### Show config
 
 ```bash
 taskify config show
@@ -57,128 +50,106 @@ taskify config show
 
 ## Command Reference
 
+### Task commands
+
 | Command | Options | Description |
 |---|---|---|
-| `list` | `--board <name>` `--status open\|done\|any` `--json` | List tasks, optionally filtered |
-| `add <title>` | `--board <name>` `--due <YYYY-MM-DD>` `--priority <1\|2\|3>` `--note <text>` `--subtask <text>` | Create a new task |
-| `show <taskId>` | `--board <name>` `--json` | Show full task details |
-| `done <taskId>` | `--board <name>` | Mark a task as done (accepts 8-char prefix or full ID) |
-| `reopen <taskId>` | `--board <name>` | Reopen a completed task (accepts 8-char prefix or full ID) |
-| `delete <taskId>` | `--board <name>` `--force` | Publish status=deleted to Nostr (accepts 8-char prefix or full ID) |
-| `subtask <taskId> <ref>` | `--board <name>` `--done` `--reopen` | Toggle a subtask done/incomplete (ref = 1-based index or title substring) |
-| `update <taskId>` | `--title <t>` `--due <d>` `--priority <p>` `--note <n>` | Update task fields (accepts 8-char prefix or full ID) |
-| `boards` | | List boards with task counts, sorted by count |
-| `trust add <npub>` | | Mark an npub as trusted |
-| `trust remove <npub>` | | Remove a trusted npub |
-| `trust list` | | List all trusted npubs |
-| `config set nsec <nsec>` | | Save your private key |
-| `config set relay <url>` | | Add a relay URL |
-| `config show` | | Show current config |
+| `list` | `--board` `--status open\|done\|any` `--column` `--json` | List tasks |
+| `add <title>` | `--board` `--due` `--priority 1\|2\|3` `--note` `--subtask` `--column` | Create a task |
+| `show <taskId>` | `--board` `--json` | Show full task details |
+| `update <taskId>` | `--title` `--due` `--priority` `--note` `--column` | Update task fields |
+| `done <taskId>` | `--board` | Mark a task done |
+| `reopen <taskId>` | `--board` | Reopen a completed task |
+| `delete <taskId>` | `--board` `--force` | Delete a task |
+| `search <query>` | `--board` `--status` `--json` | Full-text search across tasks |
+| `subtask <taskId> <ref>` | `--board` `--done` `--reopen` | Toggle a subtask (ref = index or title substring) |
+| `remind <taskId> <presets...>` | `--board` | Set reminder presets (e.g. `1d 1h`) |
+| `assign <taskId> <npub\|hex>` | `--board` | Assign a user to a task |
+| `unassign <taskId> <npub\|hex>` | `--board` | Unassign a user from a task |
 
-### `--board` fuzzy match
+### Inbox
 
-The `--board` filter is case-insensitive substring match:
+| Command | Options | Description |
+|---|---|---|
+| `inbox list` | `--board` | List inbox items (tasks flagged for triage) |
+| `inbox add <title>` | `--board` | Quick-capture a task to inbox |
+| `inbox triage <taskId>` | `--board` `--column` `--priority` `--due` `--yes` | Interactively triage an inbox item |
 
-```bash
-taskify list --board dev   # matches board "Dev", "Development", etc.
-```
+### Export / Import
 
----
+| Command | Options | Description |
+|---|---|---|
+| `export` | `--board` `--format json\|csv\|md` `--status` `--output <file>` | Export tasks |
+| `import <file>` | `--board` `--dry-run` `--yes` | Import tasks from JSON or CSV |
 
-## Example Output
+Export formats:
+- `json` — JSON array (default)
+- `csv` — RFC 4180 with headers: `id,title,status,priority,dueISO,column,boardName,note,subtasks,createdAt`
+- `md` — Markdown checklist grouped by column
 
-### `taskify list`
+Import accepts `.json` (array of `{title, note?, priority?, dueISO?, column?, subtasks?}`) or `.csv` (same schema as export). Duplicate titles on the same board are skipped.
 
-```
-Board: Dev
-ID        TITLE                                     DUE           PRI   TRUST
-e5100d28  Ship v2 release (2/4)                     2026-03-15    2     ✓ trusted
-a8c2f4b0  Fix login bug                             2026-03-10    3     ✗ untrusted
-```
+### Board management
 
-- **ID** — first 8 hex chars of the Nostr event ID
-- **TITLE** — truncated at 40 chars; `(N/M)` shows completed/total subtasks when present
-- **DUE** — ISO date (YYYY-MM-DD)
-- **PRI** — priority 1 (low) to 3 (high)
-- **TRUST** — `✓ trusted` if `lastEditedBy` matches a trusted npub, `✗ untrusted` otherwise
+| Command | Options | Description |
+|---|---|---|
+| `boards` | `--json` | List all boards with task counts |
+| `board list` | | List joined boards |
+| `board join <boardId>` | `--name` `--relay` | Join a board by Nostr event id |
+| `board leave <boardId>` | | Leave a board |
+| `board create <name>` | `--kind lists\|week` `--relay` | Create and publish a new board |
+| `board sync [boardId]` | | Sync board metadata and columns from relay |
+| `board columns [board]` | | List columns for a board |
+| `board children <board>` | | List child boards (compound boards only) |
 
-### `taskify boards`
+### Relay management
 
-```
-  Dev           3 tasks (2 open, 1 done)
-  Personal      1 tasks (1 open, 0 done)
-```
+| Command | Description |
+|---|---|
+| `relay status` | Show relay connection status |
+| `relay list` | List configured relays |
+| `relay add <url>` | Add a relay |
+| `relay remove <url>` | Remove a relay |
 
-Sorted by total task count descending.
+### Trust
 
-### `taskify list --json`
+| Command | Description |
+|---|---|
+| `trust add <npub>` | Mark an npub as trusted |
+| `trust remove <npub>` | Remove a trusted npub |
+| `trust list` | List all trusted npubs |
 
-Outputs a JSON array. Each object contains all task fields:
+### AI agent (`taskify agent`)
 
-```json
-[
-  {
-    "id": "a8c2f4b0...",
-    "boardId": "Dev",
-    "title": "Ship v2 release",
-    "note": "Includes changelog",
-    "dueISO": "2026-03-15",
-    "dueDateEnabled": true,
-    "priority": 2,
-    "completed": false,
-    "completedAt": null,
-    "createdBy": "1a2988df...",
-    "lastEditedBy": "1a2988df...",
-    "createdAt": 1773019736,
-    "updatedAt": "2026-03-09T01:28:56.902Z"
-  }
-]
-```
+| Command | Options | Description |
+|---|---|---|
+| `agent config show` | | Show AI agent config (key masked) |
+| `agent config set-key <key>` | | Set OpenAI API key |
+| `agent config set-model <model>` | | Set model (default: `gpt-4o-mini`) |
+| `agent config set-url <url>` | | Set base URL (default: OpenAI) |
+| `agent add <description>` | `--board` `--yes` `--dry-run` `--json` | NL → task via AI extraction |
+| `agent triage` | `--board` `--yes` `--dry-run` `--json` | AI priority suggestions across open tasks |
 
----
+`agent add` extracts title, note, priority, due date, column, and subtasks from a natural language description. Reviews extracted fields before creating (skippable with `--yes`).
 
-## Agent Usage
+`agent triage` sends all open tasks to the AI for priority scoring, prints a suggestion table, then applies changes on confirmation.
 
-Taskify is designed for use by AI agents via the `--json` flag.
+API key can also be set via `TASKIFY_AGENT_API_KEY` environment variable.
 
-### Trust model
+### Cache
 
-Every Nostr event carries the pubkey of its author (`createdBy`) and optionally an `editor` tag (`lastEditedBy`). The CLI compares `lastEditedBy` against your configured `trustedNpubs` list.
+| Command | Description |
+|---|---|
+| `cache status` | Show cache age and task counts |
+| `cache clear` | Clear the local task cache |
 
-- **`✓ trusted`** — the last editor's npub is in your trusted list
-- **`✗ untrusted`** — last editor is unknown or not in your list
-- **`? unknown`** — no editor information available
-
-### Agent workflow
-
-```bash
-# 1. List open tasks as JSON for processing
-taskify list --status any --json
-
-# 2. Update a task
-taskify update <id> --title "New title" --priority 2
-
-# 3. Mark done
-taskify done <id>
-```
-
-All commands exit with code `0` on success, `1` on error. They do not hang — a 10-second relay timeout is enforced and WebSocket connections are torn down on exit.
-
-### Environment override
-
-Set `TASKIFY_NSEC` to override the saved private key without modifying config:
-
-```bash
-TASKIFY_NSEC=nsec1... taskify list --json
-```
-
-## Shell Completions
+### Shell completions
 
 ```bash
 # zsh
 taskify completions --shell zsh > ~/.zsh/completions/_taskify
-echo "fpath=(~/.zsh/completions $fpath)" >> ~/.zshrc
-echo "autoload -U compinit && compinit" >> ~/.zshrc
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+echo 'autoload -U compinit && compinit' >> ~/.zshrc
 source ~/.zshrc
 
 # bash
@@ -188,3 +159,113 @@ source ~/.bash_completion.d/taskify
 # fish
 taskify completions --shell fish > ~/.config/fish/completions/taskify.fish
 ```
+
+---
+
+## Column support
+
+Boards with columns (`kind: lists` or `kind: week`) support column-aware operations:
+
+```bash
+# Add a task to a specific column
+taskify add "Fix auth bug" --board "Dev" --column "Bugs"
+
+# Filter list by column
+taskify list --board "Dev" --column "In Progress"
+
+# Move a task to a different column
+taskify update <taskId> --column "Done"
+```
+
+Week boards auto-assign tasks to today's column (YYYY-MM-DD) when no `--column` is specified.
+
+Use `taskify board sync` to pull the latest column definitions from the relay, then `taskify board columns` to list them.
+
+---
+
+## Compound boards
+
+Compound boards aggregate multiple child boards. `taskify list` on a compound board fetches and merges tasks from all children automatically.
+
+```bash
+taskify board sync
+taskify board children "My Compound Board"
+taskify list --board "My Compound Board"   # merges all children
+```
+
+Adding tasks to a compound board directly is not allowed — use a child board instead.
+
+---
+
+## Example output
+
+### `taskify list`
+
+```
+Board: Dev
+ID        TITLE                                     DUE           PRI   COL        TRUST
+e5100d28  Ship v2 release (2/4)                     2026-03-15    2     Backlog    ✓
+a8c2f4b0  Fix login bug                             2026-03-10    3     Bugs       ✓
+```
+
+- **ID** — 8-char prefix (accepted by all commands)
+- **TITLE** — truncated at 40 chars; `(N/M)` = completed/total subtasks
+- **COL** — column name if on a lists/compound board
+- **TRUST** — `✓` if `lastEditedBy` is a trusted npub
+
+### `taskify list --json`
+
+```json
+[
+  {
+    "id": "a8c2f4b0...",
+    "boardId": "...",
+    "boardName": "Dev",
+    "title": "Fix login bug",
+    "note": "",
+    "dueISO": "2026-03-10",
+    "priority": 3,
+    "column": "bugs-col-id",
+    "completed": false,
+    "subtasks": [],
+    "assignees": [],
+    "inboxItem": false,
+    "createdAt": 1773019736
+  }
+]
+```
+
+---
+
+## Agent usage
+
+Taskify is built for AI agent workflows. All commands support `--json` output and exit `0` on success / `1` on error. A 10-second relay timeout is enforced; connections are torn down on exit.
+
+```bash
+# List open tasks as JSON
+taskify list --status any --json
+
+# Create a task with AI assistance
+taskify agent add "urgent: fix the login crash by tomorrow" --board Dev --yes
+
+# Triage priorities across the board
+taskify agent triage --board Dev --yes
+
+# Bulk import from JSON
+taskify import tasks.json --board Dev --yes
+```
+
+### Trust model
+
+- **`✓ trusted`** — `lastEditedBy` pubkey is in your trusted list
+- **`✗ untrusted`** — editor unknown or not in list
+- **`? unknown`** — no editor information
+
+---
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `TASKIFY_NSEC` | Override saved private key |
+| `TASKIFY_AGENT_API_KEY` | OpenAI API key for `taskify agent` |

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -1,0 +1,1010 @@
+{
+  "name": "taskify-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "taskify-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/hashes": "^1.4.0",
+        "@nostr-dev-kit/ndk": "^2.18.1",
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0",
+        "nostr-tools": "^2.16.2"
+      },
+      "bin": {
+        "taskify": "src/index.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^25.4.0"
+      }
+    },
+    "node_modules/@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "license": "SEE LICENSE IN ./LICENSE",
+      "dependencies": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-client": {
+      "version": "2.19.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
+      "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "mime-db": "^1.52.0",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
+      "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nostr-dev-kit/ndk": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.18.1.tgz",
+      "integrity": "sha512-LTXXheGfmyN1y8x+8v/Dmkx8YX7LqaoVk0DTSaigETB5RZsxw7dLBKK++kZd4DVIxtj0tRfmSOsTr1E+M4653Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codesandbox/sandpack-client": "^2.19.8",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@noble/secp256k1": "^2.1.0",
+        "@scure/base": "^1.1.9",
+        "debug": "^4.3.7",
+        "light-bolt11-decoder": "^3.2.0",
+        "shiki": "^3.13.0",
+        "tseep": "^1.3.1",
+        "typescript-lru-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "nostr-tools": "^2.17.0"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/light-bolt11-decoder": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
+      "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "1.1.1"
+      }
+    },
+    "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nostr-tools": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
+      "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
+      "license": "Unlicense",
+      "dependencies": {
+        "@noble/ciphers": "2.1.1",
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0",
+        "@scure/bip32": "2.0.1",
+        "@scure/bip39": "2.0.1",
+        "nostr-wasm": "0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "license": "MIT"
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tseep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
+      "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
+      "license": "MIT"
+    },
+    "node_modules/typescript-lru-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-lru-cache/-/typescript-lru-cache-2.0.0.tgz",
+      "integrity": "sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "taskify-cli",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "taskify": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "node --experimental-strip-types src/index.ts"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.4.0",
+    "@nostr-dev-kit/ndk": "^2.18.1",
+    "chalk": "^5.3.0",
+    "commander": "^12.0.0",
+    "nostr-tools": "^2.16.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0"
+  }
+}

--- a/taskify-cli/src/aiClient.ts
+++ b/taskify-cli/src/aiClient.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimal fetch-based OpenAI-compatible AI client.
+ * No npm packages — uses Node 18+ built-in fetch.
+ */
+
+export async function callAI(opts: {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  systemPrompt: string;
+  userMessage: string;
+  timeoutMs?: number;
+}): Promise<string> {
+  const timeout = opts.timeoutMs ?? 30_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  let response: Response;
+  try {
+    response = await fetch(`${opts.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${opts.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        messages: [
+          { role: "system", content: opts.systemPrompt },
+          { role: "user", content: opts.userMessage },
+        ],
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`AI API error ${response.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = await response.json() as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("AI API returned no content in choices[0].message.content");
+  }
+  return content;
+}

--- a/taskify-cli/src/completions.ts
+++ b/taskify-cli/src/completions.ts
@@ -1,0 +1,644 @@
+// Shell completion scripts for taskify CLI.
+// Generated programmatically — do NOT use a completion library.
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+function readBoardNames(): string[] {
+  try {
+    const configPath = join(homedir(), ".taskify-cli", "config.json");
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw);
+    return (cfg.boards ?? []).map((b: { name: string }) => b.name);
+  } catch {
+    return [];
+  }
+}
+
+export function zshCompletion(): string {
+  const boards = readBoardNames();
+  const boardList = boards.length > 0
+    ? boards.map((n) => `'${n.replace(/'/g, "'\\''")}'`).join(" ")
+    : "";
+  const boardComplete = boardList
+    ? `    local boards=(${boardList})\n    _describe 'board' boards`
+    : `    # no boards configured`;
+
+  return `#compdef taskify
+# taskify zsh completion
+# Install: taskify completions --shell zsh > ~/.zsh/completions/_taskify
+
+_taskify() {
+  local state
+  typeset -A opt_args
+
+  _arguments -C \\
+    '(-h --help)'{-h,--help}'[Show help]' \\
+    '(-V --version)'{-V,--version}'[Show version]' \\
+    '1: :->command' \\
+    '*:: :->args'
+
+  case $state in
+    command)
+      local commands
+      commands=(
+        'board:Manage boards'
+        'boards:List configured boards'
+        'list:List tasks'
+        'show:Show full task details'
+        'search:Search tasks by title or note'
+        'add:Create a new task'
+        'done:Mark a task as done'
+        'reopen:Reopen a completed task'
+        'update:Update task fields'
+        'delete:Delete a task'
+        'subtask:Toggle a subtask done/incomplete'
+        'remind:Set device-local reminders on a task'
+        'relay:Manage relay connections'
+        'cache:Manage task cache'
+        'trust:Manage trusted npubs'
+        'config:Manage CLI config'
+        'completions:Generate shell completions'
+      )
+      _describe 'command' commands
+      ;;
+    args)
+      case $words[1] in
+        board)
+          _taskify_board
+          ;;
+        list)
+          _arguments \\
+            '--board[Filter by board]:board:_taskify_boards' \\
+            '--status[Filter status]:status:(open done any)' \\
+            '--column[Filter by column]:column:' \\
+            '--refresh[Bypass cache and fetch live]' \\
+            '--json[Output as JSON]'
+          ;;
+        show)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '--board[Board to search in]:board:_taskify_boards' \\
+            '--json[Output as JSON]'
+          ;;
+        search)
+          _arguments \\
+            '1:search query:' \\
+            '--board[Limit to board]:board:_taskify_boards' \\
+            '--json[Output as JSON]'
+          ;;
+        add)
+          _arguments \\
+            '1:task title:' \\
+            '--board[Board to add to]:board:_taskify_boards' \\
+            '--due[Due date (YYYY-MM-DD)]:date:' \\
+            '--priority[Priority]:priority:(1 2 3)' \\
+            '--note[Note text]:note:' \\
+            '--subtask[Add subtask (repeatable)]:subtask:' \\
+            '--json[Output as JSON]'
+          ;;
+        done)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '--board[Board]:board:_taskify_boards' \\
+            '--json[Output as JSON]'
+          ;;
+        reopen)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '--board[Board]:board:_taskify_boards' \\
+            '--json[Output as JSON]'
+          ;;
+        update)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '--board[Board]:board:_taskify_boards' \\
+            '--title[New title]:title:' \\
+            '--due[New due date]:date:' \\
+            '--priority[New priority]:priority:(1 2 3)' \\
+            '--note[New note]:note:' \\
+            '--json[Output as JSON]'
+          ;;
+        delete)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '--board[Board]:board:_taskify_boards' \\
+            '--force[Skip confirmation]' \\
+            '--json[Output deleted task as JSON]'
+          ;;
+        subtask)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '2:subtask ref (index or title):' \\
+            '--board[Board]:board:_taskify_boards' \\
+            '--done[Mark completed]' \\
+            '--reopen[Mark incomplete]' \\
+            '--json[Output as JSON]'
+          ;;
+        remind)
+          _arguments \\
+            '1:task id:_taskify_cached_task_ids' \\
+            '*:preset:(0h 5m 15m 30m 1h 1d 1w)' \\
+            '--board[Board]:board:_taskify_boards'
+          ;;
+        relay)
+          _taskify_relay
+          ;;
+        cache)
+          _taskify_cache
+          ;;
+        trust)
+          _taskify_trust
+          ;;
+        config)
+          _taskify_config
+          ;;
+        completions)
+          _arguments \\
+            '--shell[Shell type]:shell:(zsh bash fish)'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_taskify_board() {
+  local state
+  _arguments -C \\
+    '1: :->subcommand' \\
+    '*:: :->args'
+  case $state in
+    subcommand)
+      local subcommands
+      subcommands=(
+        'list:List configured boards'
+        'join:Join a board by UUID'
+        'leave:Remove a board from config'
+        'sync:Sync board metadata from Nostr'
+        'columns:Show cached columns for all boards'
+      )
+      _describe 'board subcommand' subcommands
+      ;;
+    args)
+      case $words[1] in
+        join)
+          _arguments \\
+            '1:board UUID:' \\
+            '--name[Board name]:name:' \\
+            '--relay[Relay URL]:url:'
+          ;;
+        leave)
+          _arguments '1:board id:_taskify_boards'
+          ;;
+        sync)
+          _arguments '1:board id or name:_taskify_boards'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_taskify_relay() {
+  local state
+  _arguments -C \\
+    '1: :->subcommand' \\
+    '*:: :->args'
+  case $state in
+    subcommand)
+      local subcommands
+      subcommands=(
+        'status:Show NDK pool relay connection status'
+        'list:Show configured relays with live check'
+        'add:Add a relay URL to config'
+        'remove:Remove a relay URL from config'
+      )
+      _describe 'relay subcommand' subcommands
+      ;;
+    args)
+      case $words[1] in
+        add|remove)
+          _arguments '1:relay url:'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_taskify_cache() {
+  local state
+  _arguments -C \\
+    '1: :->subcommand' \\
+    '*:: :->args'
+  case $state in
+    subcommand)
+      local subcommands
+      subcommands=(
+        'clear:Delete the task cache file'
+        'status:Show per-board cache age and task count'
+      )
+      _describe 'cache subcommand' subcommands
+      ;;
+  esac
+}
+
+_taskify_trust() {
+  local state
+  _arguments -C \\
+    '1: :->subcommand' \\
+    '*:: :->args'
+  case $state in
+    subcommand)
+      local subcommands
+      subcommands=('add:Add trusted npub' 'remove:Remove trusted npub' 'list:List trusted npubs')
+      _describe 'trust subcommand' subcommands
+      ;;
+  esac
+}
+
+_taskify_config() {
+  local state
+  _arguments -C \\
+    '1: :->subcommand' \\
+    '*:: :->args'
+  case $state in
+    subcommand)
+      local subcommands
+      subcommands=('set:Set config values' 'show:Show current config')
+      _describe 'config subcommand' subcommands
+      ;;
+  esac
+}
+
+_taskify_boards() {
+${boardComplete}
+}
+
+# Complete open task IDs from local cache (reads ~/.config/taskify/cache.json at completion time)
+_taskify_cached_task_ids() {
+  local cache_file="\${HOME}/.config/taskify/cache.json"
+  [[ -f "\${cache_file}" ]] || return
+  local -a tasks
+  local raw
+  raw=\$(node -e "
+try {
+  const fs=require('fs');
+  const c=JSON.parse(fs.readFileSync(process.env.HOME+'/.config/taskify/cache.json','utf8'));
+  const now=Date.now();
+  Object.values(c.boards||{}).forEach(b=>{
+    if(now-b.fetchedAt<300000){
+      (b.tasks||[]).forEach(t=>{
+        if(t.status==='open'){
+          const title=(t.title||'').replace(/[:\\n]/g,' ').slice(0,60);
+          process.stdout.write(t.id.slice(0,8)+':'+title+'\\n');
+        }
+      });
+    }
+  });
+}catch(e){}" 2>/dev/null)
+  [[ -n "\${raw}" ]] || return
+  tasks=(\${(f)raw})
+  _describe 'task id' tasks
+}
+
+_taskify
+`;
+}
+
+export function bashCompletion(): string {
+  const boards = readBoardNames();
+  const boardList = boards.map((n) => `"${n.replace(/"/g, '\\"')}"`).join(" ");
+
+  return `# taskify bash completion
+# Install: taskify completions --shell bash > ~/.bash_completion.d/taskify
+#          source ~/.bash_completion.d/taskify
+
+_taskify_boards() {
+  local boards=(${boardList})
+  COMPREPLY=(\$(compgen -W "\${boards[*]}" -- "\${cur}"))
+}
+
+_taskify_cached_task_ids() {
+  local cache_file="\${HOME}/.config/taskify/cache.json"
+  [[ -f "\${cache_file}" ]] || return
+  local raw
+  raw=\$(node -e "
+try {
+  const fs=require('fs');
+  const c=JSON.parse(fs.readFileSync(process.env.HOME+'/.config/taskify/cache.json','utf8'));
+  const now=Date.now();
+  Object.values(c.boards||{}).forEach(b=>{
+    if(now-b.fetchedAt<300000){
+      (b.tasks||[]).forEach(t=>{
+        if(t.status==='open') process.stdout.write(t.id.slice(0,8)+'\\n');
+      });
+    }
+  });
+}catch(e){}" 2>/dev/null)
+  COMPREPLY=(\$(compgen -W "\${raw}" -- "\${cur}"))
+}
+
+_taskify() {
+  local cur prev words cword
+  _init_completion 2>/dev/null || {
+    COMPREPLY=()
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+    prev="\${COMP_WORDS[COMP_CWORD-1]}"
+    words=("\${COMP_WORDS[@]}")
+    cword=\$COMP_CWORD
+  }
+
+  local commands="board boards list show search add done reopen update delete subtask remind relay cache trust config completions"
+  local board_subcmds="list join leave sync columns"
+  local relay_subcmds="status list add remove"
+  local cache_subcmds="clear status"
+  local trust_subcmds="add remove list"
+
+  # If completing the first argument
+  if [[ \$cword -eq 1 ]]; then
+    COMPREPLY=(\$(compgen -W "\$commands" -- "\$cur"))
+    return
+  fi
+
+  local cmd="\${words[1]}"
+
+  case "\$cmd" in
+    board)
+      if [[ \$cword -eq 2 ]]; then
+        COMPREPLY=(\$(compgen -W "\$board_subcmds" -- "\$cur"))
+        return
+      fi
+      local subcmd="\${words[2]}"
+      case "\$subcmd" in
+        join)
+          case "\$prev" in
+            --name|--relay) return ;;
+          esac
+          COMPREPLY=(\$(compgen -W "--name --relay" -- "\$cur"))
+          ;;
+        leave|sync)
+          _taskify_boards
+          ;;
+      esac
+      ;;
+    list)
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+        --status) COMPREPLY=(\$(compgen -W "open done any" -- "\$cur")) ; return ;;
+        --column) return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --status --column --refresh --json" -- "\$cur"))
+      ;;
+    show)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --json" -- "\$cur"))
+      ;;
+    search)
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --json" -- "\$cur"))
+      ;;
+    add)
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+        --priority) COMPREPLY=(\$(compgen -W "1 2 3" -- "\$cur")) ; return ;;
+        --due|--note|--subtask) return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --due --priority --note --subtask --json" -- "\$cur"))
+      ;;
+    done|reopen)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --json" -- "\$cur"))
+      ;;
+    update)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+        --priority) COMPREPLY=(\$(compgen -W "1 2 3" -- "\$cur")) ; return ;;
+        --title|--due|--note) return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --title --due --priority --note --json" -- "\$cur"))
+      ;;
+    delete)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --force --json" -- "\$cur"))
+      ;;
+    subtask)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--board --done --reopen --json" -- "\$cur"))
+      ;;
+    remind)
+      if [[ \$cword -eq 2 ]]; then _taskify_cached_task_ids ; return ; fi
+      case "\$prev" in
+        --board) _taskify_boards ; return ;;
+        remind) return ;; # task id
+      esac
+      if [[ \$cword -gt 2 ]]; then
+        COMPREPLY=(\$(compgen -W "0h 5m 15m 30m 1h 1d 1w --board" -- "\$cur"))
+      fi
+      ;;
+    relay)
+      if [[ \$cword -eq 2 ]]; then
+        COMPREPLY=(\$(compgen -W "\$relay_subcmds" -- "\$cur"))
+      fi
+      ;;
+    cache)
+      if [[ \$cword -eq 2 ]]; then
+        COMPREPLY=(\$(compgen -W "\$cache_subcmds" -- "\$cur"))
+      fi
+      ;;
+    trust)
+      if [[ \$cword -eq 2 ]]; then
+        COMPREPLY=(\$(compgen -W "\$trust_subcmds" -- "\$cur"))
+      fi
+      ;;
+    completions)
+      case "\$prev" in
+        --shell) COMPREPLY=(\$(compgen -W "zsh bash fish" -- "\$cur")) ; return ;;
+      esac
+      COMPREPLY=(\$(compgen -W "--shell" -- "\$cur"))
+      ;;
+  esac
+}
+
+complete -F _taskify taskify
+`;
+}
+
+export function fishCompletion(): string {
+  const boards = readBoardNames();
+  const boardCompletions = boards
+    .map((n) => `complete -c taskify -n '__taskify_using_board_opt' -a '${n.replace(/'/g, "\\'")}' -d 'Board'`)
+    .join("\n");
+
+  return `# taskify fish completion
+# Install: taskify completions --shell fish > ~/.config/fish/completions/taskify.fish
+
+function __taskify_no_subcommand
+  set -l cmd (commandline -poc)
+  set -e cmd[1]
+  for c in $cmd
+    if string match -qr '^[^-]' -- $c
+      return 1
+    end
+  end
+  return 0
+end
+
+function __taskify_subcommand_is
+  set -l cmd (commandline -poc)
+  set -e cmd[1]
+  for c in $cmd
+    if string match -qr '^[^-]' -- $c
+      test "$c" = "$argv[1]"
+      return
+    end
+  end
+  return 1
+end
+
+function __taskify_board_subcommand_is
+  set -l cmd (commandline -poc)
+  set -e cmd[1]
+  set -l saw_board 0
+  for c in $cmd
+    if string match -qr '^[^-]' -- $c
+      if test $saw_board -eq 0
+        if test "$c" = "board"
+          set saw_board 1
+        else
+          return 1
+        end
+      else
+        test "$c" = "$argv[1]"
+        return
+      end
+    end
+  end
+  return 1
+end
+
+function __taskify_using_board_opt
+  set -l cmd (commandline -poc)
+  string match -q -- '--board' $cmd[-1]
+end
+
+# Top-level subcommands
+complete -c taskify -f -n '__taskify_no_subcommand' -a board       -d 'Manage boards'
+complete -c taskify -f -n '__taskify_no_subcommand' -a boards      -d 'List configured boards'
+complete -c taskify -f -n '__taskify_no_subcommand' -a list        -d 'List tasks'
+complete -c taskify -f -n '__taskify_no_subcommand' -a show        -d 'Show full task details'
+complete -c taskify -f -n '__taskify_no_subcommand' -a search      -d 'Search tasks'
+complete -c taskify -f -n '__taskify_no_subcommand' -a add         -d 'Create a new task'
+complete -c taskify -f -n '__taskify_no_subcommand' -a done        -d 'Mark a task as done'
+complete -c taskify -f -n '__taskify_no_subcommand' -a reopen      -d 'Reopen a completed task'
+complete -c taskify -f -n '__taskify_no_subcommand' -a update      -d 'Update task fields'
+complete -c taskify -f -n '__taskify_no_subcommand' -a delete      -d 'Delete a task'
+complete -c taskify -f -n '__taskify_no_subcommand' -a subtask     -d 'Toggle a subtask'
+complete -c taskify -f -n '__taskify_no_subcommand' -a remind      -d 'Set reminders on a task'
+complete -c taskify -f -n '__taskify_no_subcommand' -a relay       -d 'Manage relay connections'
+complete -c taskify -f -n '__taskify_no_subcommand' -a cache       -d 'Manage task cache'
+complete -c taskify -f -n '__taskify_no_subcommand' -a trust       -d 'Manage trusted npubs'
+complete -c taskify -f -n '__taskify_no_subcommand' -a config      -d 'Manage CLI config'
+complete -c taskify -f -n '__taskify_no_subcommand' -a completions -d 'Generate shell completions'
+
+# board subcommands
+complete -c taskify -f -n '__taskify_subcommand_is board' -a list    -d 'List configured boards'
+complete -c taskify -f -n '__taskify_subcommand_is board' -a join    -d 'Join a board by UUID'
+complete -c taskify -f -n '__taskify_subcommand_is board' -a leave   -d 'Remove a board from config'
+complete -c taskify -f -n '__taskify_subcommand_is board' -a sync    -d 'Sync board metadata from Nostr'
+complete -c taskify -f -n '__taskify_subcommand_is board' -a columns -d 'Show cached columns'
+
+# relay subcommands
+complete -c taskify -f -n '__taskify_subcommand_is relay' -a status  -d 'Show NDK pool relay status'
+complete -c taskify -f -n '__taskify_subcommand_is relay' -a list    -d 'Show configured relays'
+complete -c taskify -f -n '__taskify_subcommand_is relay' -a add     -d 'Add a relay URL'
+complete -c taskify -f -n '__taskify_subcommand_is relay' -a remove  -d 'Remove a relay URL'
+
+# cache subcommands
+complete -c taskify -f -n '__taskify_subcommand_is cache' -a clear   -d 'Delete the task cache'
+complete -c taskify -f -n '__taskify_subcommand_is cache' -a status  -d 'Show cache status'
+
+# board join options
+complete -c taskify -f -n '__taskify_board_subcommand_is join' -l name  -d 'Board name'
+complete -c taskify -f -n '__taskify_board_subcommand_is join' -l relay -d 'Relay URL'
+
+# board sync / leave — complete board names
+${boardCompletions || "# (no boards configured)"}
+
+# list options
+complete -c taskify -n '__taskify_subcommand_is list' -l board    -d 'Filter by board'
+complete -c taskify -n '__taskify_subcommand_is list' -l status   -d 'Filter status' -a 'open done any'
+complete -c taskify -n '__taskify_subcommand_is list' -l column   -d 'Filter by column'
+complete -c taskify -n '__taskify_subcommand_is list' -l refresh  -d 'Bypass cache'
+complete -c taskify -n '__taskify_subcommand_is list' -l json     -d 'Output as JSON'
+
+# show options
+complete -c taskify -n '__taskify_subcommand_is show' -l board -d 'Board to search in'
+complete -c taskify -n '__taskify_subcommand_is show' -l json  -d 'Output as JSON'
+
+# search options
+complete -c taskify -n '__taskify_subcommand_is search' -l board -d 'Limit to board'
+complete -c taskify -n '__taskify_subcommand_is search' -l json  -d 'Output as JSON'
+
+# add options
+complete -c taskify -n '__taskify_subcommand_is add' -l board    -d 'Board to add to'
+complete -c taskify -n '__taskify_subcommand_is add' -l due      -d 'Due date (YYYY-MM-DD)'
+complete -c taskify -n '__taskify_subcommand_is add' -l priority -d 'Priority' -a '1 2 3'
+complete -c taskify -n '__taskify_subcommand_is add' -l note     -d 'Note text'
+complete -c taskify -n '__taskify_subcommand_is add' -l subtask  -d 'Add subtask (repeatable)'
+complete -c taskify -n '__taskify_subcommand_is add' -l json     -d 'Output as JSON'
+
+# done options
+complete -c taskify -n '__taskify_subcommand_is done' -l board -d 'Board'
+complete -c taskify -n '__taskify_subcommand_is done' -l json  -d 'Output as JSON'
+
+# reopen options
+complete -c taskify -n '__taskify_subcommand_is reopen' -l board -d 'Board'
+complete -c taskify -n '__taskify_subcommand_is reopen' -l json  -d 'Output as JSON'
+
+# update options
+complete -c taskify -n '__taskify_subcommand_is update' -l board    -d 'Board'
+complete -c taskify -n '__taskify_subcommand_is update' -l title    -d 'New title'
+complete -c taskify -n '__taskify_subcommand_is update' -l due      -d 'New due date'
+complete -c taskify -n '__taskify_subcommand_is update' -l priority -d 'New priority' -a '1 2 3'
+complete -c taskify -n '__taskify_subcommand_is update' -l note     -d 'New note'
+complete -c taskify -n '__taskify_subcommand_is update' -l json     -d 'Output as JSON'
+
+# delete options
+complete -c taskify -n '__taskify_subcommand_is delete' -l board -d 'Board'
+complete -c taskify -n '__taskify_subcommand_is delete' -l force -d 'Skip confirmation'
+complete -c taskify -n '__taskify_subcommand_is delete' -l json  -d 'Output deleted task as JSON'
+
+# subtask options
+complete -c taskify -n '__taskify_subcommand_is subtask' -l board  -d 'Board'
+complete -c taskify -n '__taskify_subcommand_is subtask' -l done   -d 'Mark completed'
+complete -c taskify -n '__taskify_subcommand_is subtask' -l reopen -d 'Mark incomplete'
+complete -c taskify -n '__taskify_subcommand_is subtask' -l json   -d 'Output as JSON'
+
+# remind options
+complete -c taskify -n '__taskify_subcommand_is remind' -l board -d 'Board'
+complete -c taskify -f -n '__taskify_subcommand_is remind' -a '0h 5m 15m 30m 1h 1d 1w' -d 'Reminder preset'
+
+# trust subcommands
+complete -c taskify -f -n '__taskify_subcommand_is trust' -a add    -d 'Add trusted npub'
+complete -c taskify -f -n '__taskify_subcommand_is trust' -a remove -d 'Remove trusted npub'
+complete -c taskify -f -n '__taskify_subcommand_is trust' -a list   -d 'List trusted npubs'
+
+# completions options
+complete -c taskify -n '__taskify_subcommand_is completions' -l shell -d 'Shell type' -a 'zsh bash fish'
+`;
+}

--- a/taskify-cli/src/config.ts
+++ b/taskify-cli/src/config.ts
@@ -1,0 +1,69 @@
+import { readFile, writeFile } from "fs/promises";
+import { mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { ReminderPreset } from "./shared/taskTypes.ts";
+
+export const CONFIG_DIR = join(homedir(), ".taskify-cli");
+export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+
+export type BoardEntry = {
+  id: string;
+  name: string;
+  relays?: string[];
+  kind?: "week" | "lists" | "compound" | "bible";
+  columns?: { id: string; name: string }[];
+  children?: string[];
+};
+
+export type TaskifyConfig = {
+  nsec?: string;
+  relays: string[];
+  defaultBoard: string;
+  trustedNpubs: string[];
+  securityMode: "moderate" | "strict" | "off";
+  securityEnabled: boolean;
+  boards: BoardEntry[];
+  taskReminders: Record<string, ReminderPreset[]>;
+  agent?: {
+    apiKey?: string;
+    baseUrl?: string;   // default: https://api.openai.com/v1
+    model?: string;     // default: gpt-4o-mini
+    defaultBoardId?: string;
+  };
+};
+
+const DEFAULT_CONFIG: TaskifyConfig = {
+  relays: [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+    "wss://relay.snort.social",
+    "wss://relay.primal.net",
+  ],
+  defaultBoard: "Personal",
+  trustedNpubs: [],
+  securityMode: "moderate",
+  securityEnabled: true,
+  boards: [],
+  taskReminders: {},
+};
+
+export async function loadConfig(): Promise<TaskifyConfig> {
+  let cfg: TaskifyConfig;
+  try {
+    const raw = await readFile(CONFIG_PATH, "utf-8");
+    cfg = { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
+  } catch {
+    cfg = { ...DEFAULT_CONFIG };
+  }
+  if (process.env.TASKIFY_NSEC) {
+    cfg.nsec = process.env.TASKIFY_NSEC;
+    process.stderr.write("\x1b[2m(using TASKIFY_NSEC from env)\x1b[0m\n");
+  }
+  return cfg;
+}
+
+export async function saveConfig(cfg: TaskifyConfig): Promise<void> {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  await writeFile(CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf-8");
+}

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -1,0 +1,1436 @@
+#!/usr/bin/env node --experimental-strip-types
+import { Command } from "commander";
+import chalk from "chalk";
+import { loadConfig, saveConfig } from "./config.ts";
+import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.ts";
+import { renderTable, renderTaskCard, renderJson } from "./render.ts";
+import { zshCompletion, bashCompletion, fishCompletion } from "./completions.ts";
+import { readCache, clearCache, CACHE_PATH, CACHE_TTL_MS } from "./taskCache.ts";
+
+const program = new Command();
+
+program
+  .name("taskify")
+  .version("0.1.0")
+  .description("Taskify CLI — manage tasks over Nostr");
+
+// ---- Validation helpers ----
+
+function validateDue(due: string | undefined): void {
+  if (!due) return;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(due)) {
+    console.error(chalk.red(`Invalid --due format: "${due}". Expected YYYY-MM-DD.`));
+    process.exit(1);
+  }
+}
+
+function validatePriority(pri: string | undefined): void {
+  if (!pri) return;
+  if (!["1", "2", "3"].includes(pri)) {
+    console.error(chalk.red(`Invalid --priority: "${pri}". Must be 1, 2, or 3.`));
+    process.exit(1);
+  }
+}
+
+function warnShortTaskId(taskId: string): void {
+  if (taskId.length < 8) {
+    console.warn(chalk.yellow(`Warning: taskId "${taskId}" is suspiciously short (< 8 chars). Attempting anyway.`));
+  }
+}
+
+const VALID_REMINDER_PRESETS = new Set(["0h", "5m", "15m", "30m", "1h", "1d", "1w"]);
+
+function initRuntime(config: Parameters<typeof createNostrRuntime>[0]): NostrRuntime {
+  try {
+    return createNostrRuntime(config);
+  } catch (err) {
+    console.error(chalk.red(String(err)));
+    process.exit(1);
+  }
+}
+
+/**
+ * Resolve a boardId for commands that need it.
+ * - If --board given: look it up in config.boards by UUID or name; error if not found.
+ * - If no --board and exactly one board configured: use it automatically.
+ * - If no --board and multiple boards: print list and error.
+ */
+async function resolveBoardId(
+  boardOpt: string | undefined,
+  config: Awaited<ReturnType<typeof loadConfig>>,
+): Promise<string> {
+  if (boardOpt) {
+    const entry =
+      config.boards.find((b) => b.id === boardOpt) ??
+      config.boards.find((b) => b.name.toLowerCase() === boardOpt.toLowerCase());
+    if (!entry) {
+      console.error(chalk.red(`Board not found: "${boardOpt}". Known boards:`));
+      for (const b of config.boards) {
+        console.error(`  ${b.name} (${b.id})`);
+      }
+      process.exit(1);
+    }
+    return entry.id;
+  }
+  if (config.boards.length === 1) {
+    return config.boards[0].id;
+  }
+  if (config.boards.length === 0) {
+    console.error(chalk.red("No boards configured. Use: taskify board join <id> --name <name>"));
+    process.exit(1);
+  }
+  console.error(chalk.red("Multiple boards configured. Specify one with --board <id|name>:"));
+  for (const b of config.boards) {
+    console.error(`  ${b.name} (${b.id})`);
+  }
+  process.exit(1);
+}
+
+// ---- board command group ----
+const boardCmd = program
+  .command("board")
+  .description("Manage boards");
+
+boardCmd
+  .command("list")
+  .description("List all configured boards")
+  .action(async () => {
+    const config = await loadConfig();
+    if (config.boards.length === 0) {
+      console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
+    } else {
+      for (const b of config.boards) {
+        const relays = b.relays?.length ? `  [${b.relays.join(", ")}]` : "";
+        console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}${relays}`);
+      }
+    }
+    process.exit(0);
+  });
+
+boardCmd
+  .command("join <boardId>")
+  .description("Join a board by its UUID")
+  .option("--name <name>", "Human-readable name for this board")
+  .option("--relay <url>", "Additional relay URL for this board")
+  .action(async (boardId: string, opts) => {
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(boardId)) {
+      console.warn(chalk.yellow(`Warning: "${boardId}" does not look like a UUID.`));
+    }
+    const config = await loadConfig();
+    const existing = config.boards.find((b) => b.id === boardId);
+    if (existing) {
+      console.log(chalk.dim(`Already on board ${existing.name} (${boardId})`));
+      process.exit(0);
+    }
+    const name = opts.name ?? boardId.slice(0, 8);
+    const entry: { id: string; name: string; relays?: string[] } = { id: boardId, name };
+    if (opts.relay) {
+      entry.relays = [opts.relay];
+    }
+    config.boards.push(entry);
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Joined board ${name} (${boardId})`));
+    // Auto-sync board metadata immediately after joining
+    try {
+      const runtime = initRuntime(config);
+      const meta = await runtime.syncBoard(boardId);
+      if (meta.kind || (meta.columns && meta.columns.length > 0)) {
+        const colCount = meta.columns?.length ?? 0;
+        console.log(chalk.dim(`  Synced: kind=${meta.kind ?? "?"}, columns=${colCount}`));
+      }
+      await runtime.disconnect();
+    } catch { /* non-fatal if sync fails on join */ }
+    process.exit(0);
+  });
+
+boardCmd
+  .command("sync [boardId]")
+  .description("Sync board metadata (kind, columns) from Nostr")
+  .action(async (boardId?: string) => {
+    const config = await loadConfig();
+    if (config.boards.length === 0) {
+      console.error(chalk.red("No boards configured."));
+      process.exit(1);
+    }
+    const toSync = boardId
+      ? (() => {
+          const entry =
+            config.boards.find((b) => b.id === boardId) ??
+            config.boards.find((b) => b.name.toLowerCase() === boardId.toLowerCase());
+          if (!entry) {
+            console.error(chalk.red(`Board not found: "${boardId}"`));
+            process.exit(1);
+          }
+          return [entry];
+        })()
+      : config.boards;
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      for (const entry of toSync) {
+        try {
+          const meta = await runtime.syncBoard(entry.id);
+          const colCount = meta.columns?.length ?? 0;
+          const kindStr = meta.kind ?? "unknown";
+          const reloadedEntry = (await loadConfig()).boards.find((b) => b.id === entry.id);
+          const childrenCount = reloadedEntry?.children?.length ?? 0;
+          const childrenStr = kindStr === "compound" ? `, children: ${childrenCount}` : "";
+          console.log(chalk.green(`✓ Synced: ${entry.name} (kind: ${kindStr}, columns: ${colCount}${childrenStr})`));
+        } catch (err) {
+          console.error(chalk.red(`  ✗ Failed to sync ${entry.name}: ${String(err)}`));
+          exitCode = 1;
+        }
+      }
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+boardCmd
+  .command("leave <boardId>")
+  .description("Remove a board from config")
+  .action(async (boardId: string) => {
+    const config = await loadConfig();
+    const before = config.boards.length;
+    config.boards = config.boards.filter((b) => b.id !== boardId);
+    if (config.boards.length === before) {
+      console.error(chalk.red(`Board not found: ${boardId}`));
+      process.exit(1);
+    }
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Left board ${boardId}`));
+    process.exit(0);
+  });
+
+boardCmd
+  .command("columns")
+  .description("Show cached columns for all configured boards")
+  .action(async () => {
+    const config = await loadConfig();
+    if (config.boards.length === 0) {
+      console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
+      process.exit(0);
+    }
+    for (const b of config.boards) {
+      const kindStr = b.kind ? ` (${b.kind})` : "";
+      console.log(chalk.bold(`${b.name}${kindStr}:`));
+      if (!b.columns || b.columns.length === 0) {
+        console.log(chalk.dim(`  — no columns cached (run: taskify board sync)`));
+      } else {
+        for (const col of b.columns) {
+          console.log(`  [${chalk.cyan(col.id)}] ${col.name}`);
+        }
+      }
+    }
+    process.exit(0);
+  });
+
+boardCmd
+  .command("children <board>")
+  .description("List children of a compound board")
+  .action(async (boardArg: string) => {
+    const config = await loadConfig();
+    const entry =
+      config.boards.find((b) => b.id === boardArg) ??
+      config.boards.find((b) => b.name.toLowerCase() === boardArg.toLowerCase());
+    if (!entry) {
+      console.error(chalk.red(`Board not found: "${boardArg}"`));
+      process.exit(1);
+    }
+    if (entry.kind !== "compound") {
+      console.log(chalk.dim(`Board is not a compound board (kind: ${entry.kind ?? "unknown"})`));
+      process.exit(0);
+    }
+    if (!entry.children || entry.children.length === 0) {
+      console.log(chalk.dim("No children cached — run: taskify board sync"));
+      process.exit(0);
+    }
+    console.log(chalk.bold(`Children of ${entry.name}:`));
+    for (const childId of entry.children) {
+      const childEntry = config.boards.find((b) => b.id === childId);
+      if (childEntry) {
+        console.log(`  ${chalk.cyan(childEntry.name.padEnd(16))} ${chalk.dim(childId)}`);
+      } else {
+        console.log(`  ${chalk.dim(childId)} ${chalk.yellow("(not in local config)")}`);
+      }
+    }
+    process.exit(0);
+  });
+
+// ---- boards (alias for board list) ----
+program
+  .command("boards")
+  .description("List configured boards (alias for: board list)")
+  .action(async () => {
+    const config = await loadConfig();
+    if (config.boards.length === 0) {
+      console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
+    } else {
+      for (const b of config.boards) {
+        console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}`);
+      }
+    }
+    process.exit(0);
+  });
+
+const WEEK_DAY_MAP: Record<string, number> = {
+  mon: 0, tue: 1, wed: 2, thu: 3, fri: 4, sat: 5, sun: 6,
+};
+
+/** Resolve a week-board day name to the ISO date for that day in the current week (Mon-based). */
+function resolveWeekDayToISO(dayKey: string): string {
+  const offset = WEEK_DAY_MAP[dayKey];
+  if (offset === undefined) return dayKey;
+  const today = new Date();
+  // JavaScript: 0=Sun, 1=Mon … 6=Sat
+  const jsDay = today.getDay();
+  // Offset from Monday: Mon=0 … Sun=6
+  const mondayShift = jsDay === 0 ? -6 : 1 - jsDay;
+  const monday = new Date(today);
+  monday.setDate(today.getDate() + mondayShift);
+  monday.setHours(0, 0, 0, 0);
+  const target = new Date(monday);
+  target.setDate(monday.getDate() + offset);
+  const y = target.getFullYear();
+  const m = String(target.getMonth() + 1).padStart(2, "0");
+  const d = String(target.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// Resolve --column value to { id, name } given a board entry.
+function resolveColumn(
+  entry: Awaited<ReturnType<typeof loadConfig>>["boards"][number],
+  columnArg: string,
+): { id: string; name: string } | null {
+  const dayKey = columnArg.toLowerCase();
+  // Week board: day name → ISO date
+  if (dayKey in WEEK_DAY_MAP && entry.kind === "week") {
+    const isoDate = resolveWeekDayToISO(dayKey);
+    return { id: isoDate, name: columnArg };
+  }
+  if (!entry.columns || entry.columns.length === 0) return null;
+  // Exact id match
+  const byId = entry.columns.find((c) => c.id === columnArg);
+  if (byId) return byId;
+  // Case-insensitive name substring
+  const lower = columnArg.toLowerCase();
+  const byName = entry.columns.find((c) => c.name.toLowerCase().includes(lower));
+  return byName ?? null;
+}
+
+// ---- list ----
+program
+  .command("list")
+  .description("List tasks")
+  .option("--board <id|name>", "Filter by board (UUID or name)")
+  .option("--status <status>", "Filter: open (default), done, or any", "open")
+  .option("--column <id|name>", "Filter by column id or name (use day names for week boards)")
+  .option("--refresh", "Bypass cache and fetch live from relay")
+  .option("--no-cache", "Do not fall back to stale cache if relay returns empty")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      let columnId: string | undefined;
+      let columnName: string | undefined;
+
+      if (opts.column) {
+        // Column requires a single board to be resolvable
+        const singleBoardId = opts.board
+          ? await resolveBoardId(opts.board, config)
+          : config.boards.length === 1
+            ? config.boards[0].id
+            : undefined;
+        if (!singleBoardId) {
+          console.error(chalk.red("--column requires --board when multiple boards are configured"));
+          process.exit(1);
+        }
+        const boardEntry = config.boards.find((b) => b.id === singleBoardId)!;
+        const resolved = resolveColumn(boardEntry, opts.column);
+        if (!resolved) {
+          console.error(chalk.red(`Unknown column: ${opts.column}. Run: taskify board sync`));
+          process.exit(1);
+        }
+        columnId = resolved.id;
+        columnName = resolved.name;
+      }
+
+      const tasks = await runtime.listTasks({
+        boardId: opts.board,
+        status: opts.status as "open" | "done" | "any",
+        columnId,
+        refresh: !!opts.refresh,
+        noCache: !opts.cache,
+      });
+      if (opts.json) {
+        renderJson(tasks);
+      } else {
+        if (tasks.length === 0) {
+          console.log(chalk.dim("No tasks found."));
+        } else {
+          renderTable(tasks, config.trustedNpubs, columnName);
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- show ----
+program
+  .command("show <taskId>")
+  .description("Show full task details (accepts 8-char prefix or full UUID)")
+  .option("--board <id|name>", "Board to search in (optional; scans all if omitted)")
+  .option("--json", "Output raw task fields as JSON")
+  .action(async (taskId: string, opts) => {
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.getTask(taskId, opts.board);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else if (opts.json) {
+        renderJson(task);
+      } else {
+        const localReminders = runtime.getLocalReminders(task.id);
+        renderTaskCard(task, config.trustedNpubs, localReminders);
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- search ----
+program
+  .command("search <query>")
+  .description("Full-text search tasks by title or note across all configured boards")
+  .option("--board <id|name>", "Limit to a specific board")
+  .option("--json", "Output as JSON")
+  .action(async (query: string, opts) => {
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const allTasks = await runtime.listTasks({
+        boardId: opts.board,
+        status: "any",
+      });
+      const q = query.toLowerCase();
+      const matched = allTasks.filter((t) => {
+        const inTitle = t.title.toLowerCase().includes(q);
+        const inNote = t.note ? t.note.toLowerCase().includes(q) : false;
+        return inTitle || inNote;
+      });
+      if (opts.json) {
+        renderJson(matched);
+      } else {
+        if (matched.length === 0) {
+          console.log(chalk.dim(`No tasks matching "${query}".`));
+        } else {
+          renderTable(matched, config.trustedNpubs);
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- remind ----
+program
+  .command("remind <taskId> <presets...>")
+  .description("Set device-local reminders on a task. Presets: 0h, 5m, 15m, 30m, 1h, 1d, 1w")
+  .option("--board <id|name>", "Board the task belongs to")
+  .action(async (taskId: string, presets: string[], opts) => {
+    warnShortTaskId(taskId);
+    const invalid = presets.filter((p) => !VALID_REMINDER_PRESETS.has(p));
+    if (invalid.length > 0) {
+      console.error(
+        chalk.red(
+          `Invalid reminder preset(s): ${invalid.join(", ")}. Valid: ${[...VALID_REMINDER_PRESETS].join(", ")}`,
+        ),
+      );
+      process.exit(1);
+    }
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      // Try to fetch task title for a nicer success message
+      let title = taskId.slice(0, 8);
+      try {
+        const hasSingleOrSpecifiedBoard = opts.board || config.boards.length === 1;
+        if (hasSingleOrSpecifiedBoard) {
+          const boardId = await resolveBoardId(opts.board, config);
+          const task = await runtime.getTask(taskId, boardId);
+          if (task?.title) title = task.title;
+        }
+      } catch { /* title lookup is best-effort */ }
+      await runtime.remindTask(taskId, presets as Parameters<typeof runtime.remindTask>[1]);
+      console.log(
+        chalk.green(`✓ Reminders set for ${title}: ${presets.join(", ")} (device-local only, will not sync)`),
+      );
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- add ----
+program
+  .command("add <title>")
+  .description("Create a new task")
+  .option("--board <id|name>", "Board to add to (required if multiple boards configured)")
+  .option("--due <YYYY-MM-DD>", "Due date")
+  .option("--priority <1|2|3>", "Priority (1=low, 3=high)")
+  .option("--note <text>", "Note")
+  .option(
+    "--subtask <text>",
+    "Add a subtask (repeatable)",
+    (val: string, arr: string[]) => [...arr, val],
+    [] as string[],
+  )
+  .option("--column <id|name>", "Column to place task in")
+  .option("--json", "Output created task as JSON")
+  .action(async (title: string, opts) => {
+    validateDue(opts.due);
+    validatePriority(opts.priority);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const boardEntry = config.boards.find((b) => b.id === boardId)!;
+
+    // Block add on compound boards
+    if (boardEntry.kind === "compound") {
+      const childNames = (boardEntry.children ?? []).map((cid) => {
+        const ce = config.boards.find((b) => b.id === cid);
+        return ce ? `  ${ce.name} (${cid})` : `  ${cid}`;
+      }).join("\n");
+      console.error(chalk.red("Cannot add tasks directly to a compound board. Use one of its child boards:"));
+      if (childNames) console.error(childNames);
+      process.exit(1);
+    }
+
+    // Resolve --column
+    let resolvedColumnId: string | undefined;
+    let resolvedColumnName: string | undefined;
+    if (opts.column) {
+      const col = resolveColumn(boardEntry, opts.column);
+      if (!col) {
+        process.stderr.write(`⚠ Column not found in board config — run: taskify board sync\n`);
+      } else {
+        resolvedColumnId = col.id;
+        resolvedColumnName = col.name;
+      }
+    }
+
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const subtasks = (opts.subtask as string[]).map((text) => ({
+        id: crypto.randomUUID(),
+        title: text,
+        completed: false,
+      }));
+      const task = await runtime.createTaskFull({
+        title,
+        note: opts.note ?? "",
+        boardId,
+        dueISO: opts.due,
+        priority: opts.priority ? (parseInt(opts.priority, 10) as 1 | 2 | 3) : undefined,
+        subtasks: subtasks.length > 0 ? subtasks : undefined,
+        columnId: resolvedColumnId,
+      });
+      if (opts.json) {
+        renderJson(task);
+      } else {
+        const colStr = task.column
+          ? chalk.dim(`  [col: ${resolvedColumnName ?? task.column}]`)
+          : "";
+        console.log(
+          chalk.green(`✓ Created: ${task.title}`) + colStr,
+        );
+        if (subtasks.length > 0) {
+          console.log(chalk.dim(`  Subtasks: ${subtasks.map((s) => s.title).join(", ")}`));
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- done ----
+program
+  .command("done <taskId>")
+  .description("Mark a task as done (accepts 8-char prefix or full UUID)")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--json", "Output updated task as JSON")
+  .action(async (taskId: string, opts) => {
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.setTaskStatus(taskId, "done", boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else if (opts.json) {
+        renderJson(task);
+      } else {
+        console.log(chalk.green(`✓ Marked done: ${task.title}`));
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- reopen ----
+program
+  .command("reopen <taskId>")
+  .description("Reopen a completed task (accepts 8-char prefix or full UUID)")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--json", "Output updated task as JSON")
+  .action(async (taskId: string, opts) => {
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.setTaskStatus(taskId, "open", boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else if (opts.json) {
+        renderJson(task);
+      } else {
+        console.log(chalk.green(`✓ Reopened: ${task.title}`));
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- delete ----
+program
+  .command("delete <taskId>")
+  .description("Delete a task (publishes status=deleted to Nostr; accepts 8-char prefix or full UUID)")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--force", "Skip confirmation prompt")
+  .option("--json", "Output deleted task as JSON")
+  .action(async (taskId: string, opts) => {
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      // Fetch task first so we can show the title in the prompt
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else {
+        if (!opts.force) {
+          const { createInterface } = await import("readline");
+          const confirmed = await new Promise<boolean>((resolve) => {
+            const rl = createInterface({ input: process.stdin, output: process.stdout });
+            rl.question(
+              `Delete task: ${task.title} (${task.id.slice(0, 8)})? [y/N] `,
+              (ans: string) => {
+                rl.close();
+                resolve(ans === "y" || ans === "Y");
+              },
+            );
+          });
+          if (!confirmed) {
+            console.log("Aborted.");
+            await runtime.disconnect();
+            process.exit(0);
+          }
+        }
+        const deleted = await runtime.deleteTask(taskId, boardId);
+        if (!deleted) {
+          console.error(chalk.red(`Task not found: ${taskId}`));
+          exitCode = 1;
+        } else if (opts.json) {
+          renderJson(deleted);
+        } else {
+          console.log(chalk.green(`✓ Deleted: ${deleted.title}`));
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- subtask ----
+program
+  .command("subtask <taskId> <subtaskRef>")
+  .description(
+    "Toggle a subtask done/incomplete. subtaskRef can be a 1-based index or partial title match.",
+  )
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--done", "Mark subtask completed")
+  .option("--reopen", "Mark subtask incomplete")
+  .option("--json", "Output updated full task as JSON")
+  .action(async (taskId: string, subtaskRef: string, opts) => {
+    if (!opts.done && !opts.reopen) {
+      console.error(chalk.red("Specify --done or --reopen."));
+      process.exit(1);
+    }
+    if (opts.done && opts.reopen) {
+      console.error(chalk.red("Specify only one of --done or --reopen."));
+      process.exit(1);
+    }
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const completed = !!opts.done;
+      const task = await runtime.toggleSubtask(taskId, boardId, subtaskRef, completed);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else if (opts.json) {
+        renderJson(task);
+      } else {
+        // Find the subtask that was toggled (by ref) to display its title
+        const subtasks = task.subtasks ?? [];
+        const indexNum = parseInt(subtaskRef, 10);
+        let found: { title: string; completed?: boolean } | undefined;
+        if (!isNaN(indexNum) && indexNum >= 1 && indexNum <= subtasks.length) {
+          found = subtasks[indexNum - 1];
+        } else {
+          const lower = subtaskRef.toLowerCase();
+          found = subtasks.find((s) => s.title.toLowerCase().includes(lower));
+        }
+        const check = completed ? "x" : " ";
+        const stitle = found?.title ?? subtaskRef;
+        console.log(chalk.green(`✓ Subtask [${check}] ${stitle}  (task: ${task.title})`));
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- update ----
+program
+  .command("update <taskId>")
+  .description("Update task fields (accepts 8-char prefix or full UUID)")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--title <t>", "New title")
+  .option("--due <d>", "New due date")
+  .option("--priority <p>", "New priority")
+  .option("--note <n>", "New note")
+  .option("--column <id|name>", "Move task to a different column")
+  .option("--json", "Output updated task as JSON")
+  .action(async (taskId: string, opts) => {
+    warnShortTaskId(taskId);
+    validateDue(opts.due);
+    validatePriority(opts.priority);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const patch: Record<string, unknown> = {};
+      if (opts.title !== undefined) patch.title = opts.title;
+      if (opts.due !== undefined) patch.dueISO = opts.due;
+      if (opts.priority !== undefined) patch.priority = parseInt(opts.priority, 10);
+      if (opts.note !== undefined) patch.note = opts.note;
+      if (opts.column !== undefined) {
+        const bEntry = config.boards.find((b) => b.id === boardId);
+        if (bEntry) {
+          const col = resolveColumn(bEntry, opts.column);
+          if (col) {
+            patch.columnId = col.id;
+          } else {
+            process.stderr.write(`⚠ Column not found in board config — run: taskify board sync\n`);
+          }
+        }
+      }
+      const task = await runtime.updateTask(taskId, boardId, patch);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else if (opts.json) {
+        renderJson(task);
+      } else {
+        console.log(chalk.green(`✓ Updated: ${task.id.slice(0, 8)}  ${task.title}  ${task.boardId}`));
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- trust ----
+const trust = program.command("trust").description("Manage trusted npubs");
+
+trust
+  .command("add <npub>")
+  .description("Add a trusted npub")
+  .action(async (npub: string) => {
+    const config = await loadConfig();
+    if (!config.trustedNpubs.includes(npub)) {
+      config.trustedNpubs.push(npub);
+    }
+    await saveConfig(config);
+    console.log(chalk.green("✓ Added"));
+    process.exit(0);
+  });
+
+trust
+  .command("remove <npub>")
+  .description("Remove a trusted npub")
+  .action(async (npub: string) => {
+    const config = await loadConfig();
+    config.trustedNpubs = config.trustedNpubs.filter((n) => n !== npub);
+    await saveConfig(config);
+    console.log(chalk.green("✓ Removed"));
+    process.exit(0);
+  });
+
+trust
+  .command("list")
+  .description("List trusted npubs")
+  .action(async () => {
+    const config = await loadConfig();
+    if (config.trustedNpubs.length === 0) {
+      console.log(chalk.dim("No trusted npubs."));
+    } else {
+      for (const npub of config.trustedNpubs) {
+        console.log(npub);
+      }
+    }
+    process.exit(0);
+  });
+
+// ---- relay command group ----
+const relayCmd = program.command("relay").description("Manage relay connections");
+
+relayCmd
+  .command("status")
+  .description("Show connection status of relays in the NDK pool")
+  .action(async () => {
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const statuses = await runtime.getRelayStatus();
+      if (statuses.length === 0) {
+        console.log(chalk.dim("No relays configured."));
+      } else {
+        for (const { url, connected } of statuses) {
+          if (connected) {
+            console.log(chalk.green(`✓ ${url}`) + chalk.dim("  connected"));
+          } else {
+            console.log(chalk.red(`✗ ${url}`) + chalk.dim("  disconnected"));
+          }
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+relayCmd
+  .command("list")
+  .description("Show configured relays with live connection check")
+  .action(async () => {
+    const config = await loadConfig();
+    if (config.relays.length === 0) {
+      console.log(chalk.dim("No relays configured."));
+      process.exit(0);
+    }
+    console.log(chalk.dim(`Checking ${config.relays.length} relay(s)...`));
+    for (const relay of config.relays) {
+      const ok = await checkRelay(relay);
+      if (ok) {
+        console.log(chalk.green(`✓ ${relay}`) + chalk.dim("  connected"));
+      } else {
+        console.log(chalk.red(`✗ ${relay}`) + chalk.dim("  disconnected"));
+      }
+    }
+    process.exit(0);
+  });
+
+relayCmd
+  .command("add <url>")
+  .description("Add a relay URL to config")
+  .action(async (url: string) => {
+    const config = await loadConfig();
+    if (!config.relays.includes(url)) {
+      config.relays.push(url);
+      await saveConfig(config);
+      console.log(chalk.green(`✓ Relay added: ${url}`));
+    } else {
+      console.log(chalk.dim(`Relay already configured: ${url}`));
+    }
+    process.exit(0);
+  });
+
+relayCmd
+  .command("remove <url>")
+  .description("Remove a relay URL from config")
+  .action(async (url: string) => {
+    const config = await loadConfig();
+    const before = config.relays.length;
+    config.relays = config.relays.filter((r) => r !== url);
+    if (config.relays.length === before) {
+      console.error(chalk.red(`Relay not found in config: ${url}`));
+      process.exit(1);
+    }
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Relay removed: ${url}`));
+    process.exit(0);
+  });
+
+// ---- cache command group ----
+const cacheCmd = program.command("cache").description("Manage task cache");
+
+cacheCmd
+  .command("clear")
+  .description("Delete the task cache file")
+  .action(() => {
+    clearCache();
+    console.log(chalk.green("✓ Cache cleared"));
+    process.exit(0);
+  });
+
+cacheCmd
+  .command("status")
+  .description("Show per-board cache age and task count")
+  .action(async () => {
+    const config = await loadConfig();
+    const cache = readCache();
+    const now = Date.now();
+    if (Object.keys(cache.boards).length === 0) {
+      console.log(chalk.dim("No cache."));
+      process.exit(0);
+    }
+    for (const board of config.boards) {
+      const bc = cache.boards[board.id];
+      if (!bc) {
+        console.log(`${board.name}: ${chalk.dim("No cache")}`);
+        continue;
+      }
+      const ageMs = now - bc.fetchedAt;
+      const ageSec = Math.floor(ageMs / 1000);
+      let ageStr: string;
+      if (ageSec < 60) {
+        ageStr = `${ageSec}s ago`;
+      } else if (ageSec < 3600) {
+        ageStr = `${Math.floor(ageSec / 60)}m ago`;
+      } else {
+        ageStr = `${Math.floor(ageSec / 3600)}h ago`;
+      }
+      const stale = ageMs > CACHE_TTL_MS ? chalk.yellow(" (stale)") : "";
+      const openCount = bc.tasks.filter((t) => t.status === "open").length;
+      console.log(`${chalk.bold(board.name)}: ${bc.tasks.length} tasks (${openCount} open), cached ${ageStr}${stale}`);
+    }
+    // Show boards in cache that aren't in config
+    for (const [boardId, bc] of Object.entries(cache.boards)) {
+      if (!config.boards.find((b) => b.id === boardId)) {
+        console.log(chalk.dim(`  [orphan ${boardId.slice(0, 8)}]: ${bc.tasks.length} tasks`));
+      }
+    }
+    process.exit(0);
+  });
+
+// ---- config ----
+const configCmd = program.command("config").description("Manage CLI config");
+
+const configSet = configCmd.command("set").description("Set config values");
+
+configSet
+  .command("nsec <nsec>")
+  .description("Set your nsec private key")
+  .action(async (nsec: string) => {
+    if (!nsec.startsWith("nsec1")) {
+      console.error(chalk.red(`Invalid nsec: must start with "nsec1".`));
+      process.exit(1);
+    }
+    const config = await loadConfig();
+    config.nsec = nsec;
+    await saveConfig(config);
+    console.log(chalk.green("✓ nsec saved"));
+    process.exit(0);
+  });
+
+configSet
+  .command("relay <url>")
+  .description("Add a relay URL")
+  .action(async (url: string) => {
+    const config = await loadConfig();
+    if (!config.relays.includes(url)) {
+      config.relays.push(url);
+    }
+    await saveConfig(config);
+    console.log(chalk.green("✓ Relay added"));
+    process.exit(0);
+  });
+
+async function checkRelay(url: string, timeoutMs: number = 5000): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (!settled) {
+        settled = true;
+        resolve(ok);
+      }
+    };
+    const timer = setTimeout(() => {
+      ws.close();
+      done(false);
+    }, timeoutMs);
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+      ws.onopen = () => {
+        clearTimeout(timer);
+        ws.close();
+        done(true);
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        done(false);
+      };
+    } catch {
+      clearTimeout(timer);
+      done(false);
+    }
+  });
+}
+
+configCmd
+  .command("show")
+  .description("Show current config")
+  .action(async () => {
+    const config = await loadConfig();
+    const display = {
+      ...config,
+      nsec: config.nsec ? "nsec1****" : undefined,
+    };
+    console.log(JSON.stringify(display, null, 2));
+
+    console.log("\nChecking relays...");
+    for (const relay of config.relays) {
+      const ok = await checkRelay(relay);
+      if (ok) {
+        console.log(chalk.green(`✓ ${relay}`) + chalk.dim("  (connected)"));
+      } else {
+        console.log(chalk.red(`✗ ${relay}`) + chalk.dim("  (timeout)"));
+      }
+    }
+    process.exit(0);
+  });
+
+// ---- completions ----
+program
+  .command("completions")
+  .description("Generate shell completion scripts")
+  .option("--shell <zsh|bash|fish>", "Shell type (defaults to current shell)")
+  .action((opts) => {
+    let shell = opts.shell as string | undefined;
+    if (!shell) {
+      const envShell = process.env.SHELL ?? "";
+      if (envShell.includes("zsh")) shell = "zsh";
+      else if (envShell.includes("bash")) shell = "bash";
+      else {
+        // Print all three if shell cannot be determined
+        process.stdout.write(zshCompletion());
+        process.stdout.write("\n");
+        process.stdout.write(bashCompletion());
+        process.stdout.write("\n");
+        process.stdout.write(fishCompletion());
+        process.exit(0);
+      }
+    }
+    switch (shell) {
+      case "zsh":
+        process.stdout.write(zshCompletion());
+        break;
+      case "bash":
+        process.stdout.write(bashCompletion());
+        break;
+      case "fish":
+        process.stdout.write(fishCompletion());
+        break;
+      default:
+        console.error(chalk.red(`Unknown shell: "${shell}". Use: zsh, bash, or fish`));
+        process.exit(1);
+    }
+    process.exit(0);
+  });
+
+// ---- agent command group ----
+const agentCmd = program
+  .command("agent")
+  .description("AI-powered task commands");
+
+const agentConfigCmd = agentCmd
+  .command("config")
+  .description("Manage agent AI configuration");
+
+agentConfigCmd
+  .command("set-key <key>")
+  .description("Set the AI API key")
+  .action(async (key: string) => {
+    const config = await loadConfig();
+    if (!config.agent) config.agent = {};
+    config.agent.apiKey = key;
+    await saveConfig(config);
+    console.log(chalk.green("✓ Agent API key saved"));
+    process.exit(0);
+  });
+
+agentConfigCmd
+  .command("set-model <model>")
+  .description("Set the AI model")
+  .action(async (model: string) => {
+    const config = await loadConfig();
+    if (!config.agent) config.agent = {};
+    config.agent.model = model;
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Agent model set to: ${model}`));
+    process.exit(0);
+  });
+
+agentConfigCmd
+  .command("set-url <url>")
+  .description("Set the AI base URL (OpenAI-compatible)")
+  .action(async (url: string) => {
+    const config = await loadConfig();
+    if (!config.agent) config.agent = {};
+    config.agent.baseUrl = url;
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Agent base URL set to: ${url}`));
+    process.exit(0);
+  });
+
+agentConfigCmd
+  .command("show")
+  .description("Show current agent config (masks API key)")
+  .action(async () => {
+    const config = await loadConfig();
+    const ag = config.agent ?? {};
+    const rawKey = ag.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
+    let maskedKey = "(not set)";
+    if (rawKey.length > 7) {
+      maskedKey = rawKey.slice(0, 3) + "..." + rawKey.slice(-3);
+    } else if (rawKey.length > 0) {
+      maskedKey = "***";
+    }
+    console.log(`  apiKey:         ${maskedKey}`);
+    console.log(`  baseUrl:        ${ag.baseUrl ?? "https://api.openai.com/v1"}`);
+    console.log(`  model:          ${ag.model ?? "gpt-4o-mini"}`);
+    console.log(`  defaultBoardId: ${ag.defaultBoardId ?? "(not set)"}`);
+    process.exit(0);
+  });
+
+agentCmd
+  .command("add <description>")
+  .description("AI-powered task creation from natural language")
+  .option("--board <id|name>", "Target board")
+  .option("--yes", "Skip confirmation prompt")
+  .option("--dry-run", "Show extracted fields without creating")
+  .option("--json", "Output created task as JSON")
+  .action(async (description: string, opts) => {
+    const config = await loadConfig();
+    const apiKey = config.agent?.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
+    if (!apiKey) {
+      console.error(chalk.red("No AI API key configured. Run: taskify agent config set-key <key>"));
+      console.error(chalk.dim("  or set TASKIFY_AGENT_API_KEY environment variable"));
+      process.exit(1);
+    }
+    const baseUrl = config.agent?.baseUrl ?? "https://api.openai.com/v1";
+    const model = config.agent?.model ?? "gpt-4o-mini";
+    const boardId = await resolveBoardId(opts.board ?? config.agent?.defaultBoardId, config);
+    const boardEntry = config.boards.find((b) => b.id === boardId)!;
+
+    if (boardEntry.kind === "compound") {
+      const childNames = (boardEntry.children ?? []).map((cid) => {
+        const ce = config.boards.find((b) => b.id === cid);
+        return ce ? `  ${ce.name} (${cid})` : `  ${cid}`;
+      }).join("\n");
+      console.error(chalk.red("Cannot add tasks directly to a compound board. Use one of its child boards:"));
+      if (childNames) console.error(childNames);
+      process.exit(1);
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    const { callAI } = await import("./aiClient.ts");
+
+    const SYSTEM_PROMPT = `You are a task extraction assistant. Extract fields from the description.
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "title": "concise task title (max 80 chars)",
+  "note": "additional detail or empty string",
+  "priority": 1|2|3|null,
+  "dueISO": "YYYY-MM-DD"|null,
+  "column": "column name/id hint or null",
+  "subtasks": ["subtask 1", "subtask 2"] or []
+}
+Today is ${today}.`;
+
+    let extracted: {
+      title: string;
+      note: string;
+      priority: 1 | 2 | 3 | null;
+      dueISO: string | null;
+      column: string | null;
+      subtasks: string[];
+    };
+
+    console.log(chalk.dim("Calling AI..."));
+    try {
+      const raw = await callAI({ apiKey, baseUrl, model, systemPrompt: SYSTEM_PROMPT, userMessage: description });
+      // Strip markdown code fences if present
+      const cleaned = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+      extracted = JSON.parse(cleaned);
+    } catch (err) {
+      console.error(chalk.red(`AI extraction failed: ${String(err)}`));
+      process.exit(1);
+    }
+
+    // Resolve column hint
+    let resolvedColumnId: string | undefined;
+    let resolvedColumnName: string | undefined;
+    if (extracted.column) {
+      const col = resolveColumn(boardEntry, extracted.column);
+      if (col) {
+        resolvedColumnId = col.id;
+        resolvedColumnName = col.name;
+      }
+    }
+
+    // Print extracted fields
+    console.log(chalk.bold("\nExtracted task:"));
+    console.log(`  title:    ${extracted.title}`);
+    if (extracted.note) console.log(`  note:     ${extracted.note}`);
+    if (extracted.priority) console.log(`  priority: ${extracted.priority}`);
+    if (extracted.dueISO) console.log(`  due:      ${extracted.dueISO}`);
+    if (resolvedColumnName) console.log(`  column:   ${resolvedColumnName}`);
+    if (extracted.subtasks?.length > 0) {
+      console.log(`  subtasks: ${extracted.subtasks.join(", ")}`);
+    }
+
+    if (opts.dryRun) {
+      console.log(chalk.dim("\n[dry-run] No task created."));
+      process.exit(0);
+    }
+
+    if (!opts.yes) {
+      const { createInterface } = await import("readline");
+      const confirmed = await new Promise<boolean>((resolve) => {
+        const rl = createInterface({ input: process.stdin, output: process.stdout });
+        rl.question("\nCreate this task? [Y/n] ", (ans: string) => {
+          rl.close();
+          resolve(ans === "" || ans.toLowerCase() === "y");
+        });
+      });
+      if (!confirmed) {
+        console.log("Aborted.");
+        process.exit(0);
+      }
+    }
+
+    const runtime = initRuntime(config);
+    try {
+      const subtasks = (extracted.subtasks ?? []).map((text) => ({
+        id: crypto.randomUUID(),
+        title: text,
+        completed: false,
+      }));
+      const task = await runtime.createTaskFull({
+        title: extracted.title,
+        note: extracted.note ?? "",
+        boardId,
+        dueISO: extracted.dueISO ?? undefined,
+        priority: extracted.priority ?? undefined,
+        columnId: resolvedColumnId,
+        subtasks: subtasks.length > 0 ? subtasks : undefined,
+      });
+      if (opts.json) {
+        renderJson(task);
+      } else {
+        const colStr = task.column ? chalk.dim(`  [col: ${resolvedColumnName ?? task.column}]`) : "";
+        console.log(chalk.green(`✓ Created: ${task.title}`) + colStr);
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      process.exit(1);
+    } finally {
+      await runtime.disconnect();
+    }
+    process.exit(0);
+  });
+
+agentCmd
+  .command("triage")
+  .description("AI-powered task prioritization suggestions")
+  .option("--board <id|name>", "Target board")
+  .option("--yes", "Apply changes without confirmation")
+  .option("--dry-run", "Show suggestions without applying")
+  .option("--json", "Output suggestions as JSON")
+  .action(async (opts) => {
+    const config = await loadConfig();
+    const apiKey = config.agent?.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
+    if (!apiKey) {
+      console.error(chalk.red("No AI API key configured. Run: taskify agent config set-key <key>"));
+      process.exit(1);
+    }
+    const baseUrl = config.agent?.baseUrl ?? "https://api.openai.com/v1";
+    const model = config.agent?.model ?? "gpt-4o-mini";
+    const boardId = await resolveBoardId(opts.board ?? config.agent?.defaultBoardId, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const tasks = await runtime.listTasks({ boardId, status: "open" });
+      if (tasks.length === 0) {
+        console.log(chalk.dim("No open tasks to triage."));
+        process.exit(0);
+      }
+
+      const { callAI } = await import("./aiClient.ts");
+
+      const SYSTEM_PROMPT = `You are a task prioritization assistant. Given open tasks, suggest priority (1=low, 2=medium, 3=high) for each.
+Return ONLY a valid JSON array (no markdown):
+[{"id":"<taskId>","priority":1|2|3,"reason":"one sentence"}]`;
+
+      const taskList = tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        note: t.note || undefined,
+        dueISO: t.dueISO || undefined,
+        currentPriority: t.priority,
+      }));
+
+      console.log(chalk.dim(`Analyzing ${tasks.length} tasks...`));
+      let suggestions: Array<{ id: string; priority: 1 | 2 | 3; reason: string }>;
+      try {
+        const raw = await callAI({
+          apiKey, baseUrl, model,
+          systemPrompt: SYSTEM_PROMPT,
+          userMessage: `Tasks: ${JSON.stringify(taskList)}`,
+        });
+        const cleaned = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+        suggestions = JSON.parse(cleaned);
+      } catch (err) {
+        console.error(chalk.red(`AI triage failed: ${String(err)}`));
+        process.exit(1);
+      }
+
+      // Filter to only changes
+      const changes = suggestions.filter((s) => {
+        const task = tasks.find((t) => t.id === s.id);
+        return task && task.priority !== s.priority;
+      });
+
+      if (opts.json) {
+        renderJson(suggestions);
+        process.exit(0);
+      }
+
+      if (changes.length === 0) {
+        console.log(chalk.dim("No priority changes suggested."));
+        process.exit(0);
+      }
+
+      console.log(chalk.bold("\nSuggested priority changes:"));
+      const PRIO_LABELS: Record<number, string> = { 1: "low", 2: "medium", 3: "high" };
+      for (const s of changes) {
+        const task = tasks.find((t) => t.id === s.id);
+        const oldPrio = task?.priority ? PRIO_LABELS[task.priority] : "none";
+        const newPrio = PRIO_LABELS[s.priority] ?? String(s.priority);
+        console.log(`  ${s.id.slice(0, 8)}  ${(task?.title ?? "").slice(0, 40).padEnd(40)}  ${oldPrio} → ${newPrio}`);
+        console.log(chalk.dim(`           ${s.reason}`));
+      }
+
+      if (opts.dryRun) {
+        console.log(chalk.dim("\n[dry-run] No changes applied."));
+        process.exit(0);
+      }
+
+      if (!opts.yes) {
+        const { createInterface } = await import("readline");
+        const confirmed = await new Promise<boolean>((resolve) => {
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          rl.question("\nApply these priority changes? [Y/n] ", (ans: string) => {
+            rl.close();
+            resolve(ans === "" || ans.toLowerCase() === "y");
+          });
+        });
+        if (!confirmed) {
+          console.log("Aborted.");
+          process.exit(0);
+        }
+      }
+
+      for (const s of changes) {
+        await runtime.updateTask(s.id, boardId, { priority: s.priority });
+      }
+      console.log(chalk.green(`✓ Applied ${changes.length} priority update(s)`));
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+program.parse(process.argv);

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node --experimental-strip-types
 import { Command } from "commander";
 import chalk from "chalk";
+import { readFile, writeFile } from "fs/promises";
+import { nip19 } from "nostr-tools";
 import { loadConfig, saveConfig } from "./config.ts";
 import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.ts";
 import { renderTable, renderTaskCard, renderJson } from "./render.ts";
@@ -1424,6 +1426,605 @@ Return ONLY a valid JSON array (no markdown):
         await runtime.updateTask(s.id, boardId, { priority: s.priority });
       }
       console.log(chalk.green(`✓ Applied ${changes.length} priority update(s)`));
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- CSV helpers ----
+
+function csvEscape(val: string): string {
+  if (!val) return "";
+  if (val.includes(",") || val.includes('"') || val.includes("\n")) {
+    return '"' + val.replace(/"/g, '""') + '"';
+  }
+  return val;
+}
+
+function parseCSVLine(line: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+  while (i <= line.length) {
+    if (i === line.length) { fields.push(""); break; }
+    if (line[i] === '"') {
+      let field = "";
+      i++;
+      while (i < line.length) {
+        if (line[i] === '"' && line[i + 1] === '"') { field += '"'; i += 2; }
+        else if (line[i] === '"') { i++; break; }
+        else { field += line[i++]; }
+      }
+      fields.push(field);
+      if (line[i] === ",") i++;
+    } else {
+      const end = line.indexOf(",", i);
+      if (end === -1) { fields.push(line.slice(i)); break; }
+      else { fields.push(line.slice(i, end)); i = end + 1; }
+    }
+  }
+  return fields;
+}
+
+function parseCSV(text: string): Record<string, string>[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim() !== "");
+  if (lines.length < 2) return [];
+  const headers = parseCSVLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const values = parseCSVLine(line);
+    const row: Record<string, string> = {};
+    headers.forEach((h, idx) => { row[h.trim()] = (values[idx] ?? "").trim(); });
+    return row;
+  });
+}
+
+function npubOrHexToHex(val: string): string {
+  if (val.startsWith("npub1")) {
+    try {
+      const decoded = nip19.decode(val);
+      if (decoded.type === "npub") return decoded.data as string;
+    } catch { /* fall through */ }
+  }
+  return val;
+}
+
+// ---- export ----
+program
+  .command("export")
+  .description("Export tasks to JSON, CSV, or Markdown")
+  .option("--board <id|name>", "Board to export from")
+  .option("--format <json|csv|md>", "Output format (default: json)", "json")
+  .option("--status <open|done|any>", "Status filter (default: open)", "open")
+  .option("--output <file>", "Write to file instead of stdout")
+  .action(async (opts) => {
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const tasks = await runtime.listTasks({
+        boardId,
+        status: opts.status as "open" | "done" | "any",
+        refresh: false,
+      });
+      const boardEntry = config.boards.find((b) => b.id === boardId);
+
+      let output = "";
+
+      if (opts.format === "json") {
+        output = JSON.stringify(tasks, null, 2);
+      } else if (opts.format === "csv") {
+        const CSV_HEADER = "id,title,status,priority,dueISO,column,boardName,note,subtasks,createdAt";
+        const rows = tasks.map((t) => {
+          const subtaskStr = (t.subtasks ?? []).map((s) => s.title).join("|");
+          return [
+            csvEscape(t.id),
+            csvEscape(t.title),
+            csvEscape(t.completed ? "done" : "open"),
+            csvEscape(t.priority ? String(t.priority) : ""),
+            csvEscape(t.dueISO ? t.dueISO.slice(0, 10) : ""),
+            csvEscape(t.column ?? ""),
+            csvEscape(t.boardName ?? ""),
+            csvEscape(t.note ?? ""),
+            csvEscape(subtaskStr),
+            csvEscape(t.createdAt ? String(t.createdAt) : ""),
+          ].join(",");
+        });
+        output = [CSV_HEADER, ...rows].join("\n") + "\n";
+      } else if (opts.format === "md") {
+        const boardName = boardEntry?.name ?? boardId.slice(0, 8);
+        const statusLabel = opts.status === "done" ? "Done Tasks" : opts.status === "any" ? "All Tasks" : "Open Tasks";
+        const lines: string[] = [`## ${statusLabel} — ${boardName}`, ""];
+        // Group by column
+        const byColumn = new Map<string, typeof tasks>();
+        for (const t of tasks) {
+          const colId = t.column ?? "";
+          const group = byColumn.get(colId) ?? [];
+          group.push(t);
+          byColumn.set(colId, group);
+        }
+        for (const [colId, colTasks] of byColumn) {
+          let colName = colId;
+          if (boardEntry?.columns) {
+            const col = boardEntry.columns.find((c) => c.id === colId);
+            if (col) colName = col.name;
+          }
+          if (!colId) colName = "No Column";
+          lines.push(`### ${colName}`, "");
+          for (const t of colTasks) {
+            const check = t.completed ? "x" : " ";
+            const meta: string[] = [];
+            if (t.priority) meta.push(`priority: ${t.priority === 3 ? "high" : t.priority === 2 ? "medium" : "low"}`);
+            if (t.dueISO) meta.push(`due: ${t.dueISO.slice(0, 10)}`);
+            const metaStr = meta.length > 0 ? ` *(${meta.join(", ")})*` : "";
+            lines.push(`- [${check}] ${t.title}${metaStr}`);
+            for (const s of t.subtasks ?? []) {
+              const sc = s.completed ? "x" : " ";
+              lines.push(`    - [${sc}] ${s.title}`);
+            }
+          }
+          lines.push("");
+        }
+        output = lines.join("\n");
+      } else {
+        console.error(chalk.red(`Unknown format: "${opts.format}". Use: json, csv, md`));
+        exitCode = 1;
+      }
+
+      if (exitCode === 0) {
+        if (opts.output) {
+          await writeFile(opts.output, output, "utf-8");
+          process.stderr.write(`✓ Exported ${tasks.length} tasks → ${opts.output}\n`);
+        } else {
+          process.stdout.write(output);
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- import ----
+program
+  .command("import <file>")
+  .description("Import tasks from a JSON or CSV file")
+  .option("--board <id|name>", "Board to import into")
+  .option("--dry-run", "Print preview but do not create tasks")
+  .option("--yes", "Skip confirmation prompt")
+  .action(async (file: string, opts) => {
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+
+    let raw: string;
+    try {
+      raw = await readFile(file, "utf-8");
+    } catch {
+      console.error(chalk.red(`Cannot read file: ${file}`));
+      process.exit(1);
+    }
+
+    type ImportRow = {
+      title: string;
+      note?: string;
+      priority?: 1 | 2 | 3;
+      dueISO?: string;
+      column?: string;
+      subtasks?: string[];
+    };
+
+    let rows: ImportRow[] = [];
+    const ext = file.split(".").pop()?.toLowerCase();
+
+    if (ext === "json") {
+      let parsed: unknown;
+      try { parsed = JSON.parse(raw); } catch {
+        console.error(chalk.red("Invalid JSON file")); process.exit(1);
+      }
+      if (!Array.isArray(parsed)) {
+        console.error(chalk.red("JSON file must be an array of objects")); process.exit(1);
+      }
+      rows = (parsed as Record<string, unknown>[]).map((obj) => ({
+        title: String(obj.title ?? ""),
+        note: obj.note ? String(obj.note) : undefined,
+        priority: [1, 2, 3].includes(Number(obj.priority)) ? Number(obj.priority) as 1 | 2 | 3 : undefined,
+        dueISO: obj.dueISO ? String(obj.dueISO) : undefined,
+        column: obj.column ? String(obj.column) : undefined,
+        subtasks: Array.isArray(obj.subtasks)
+          ? (obj.subtasks as unknown[]).map((s) => typeof s === "string" ? s : (s as Record<string, unknown>).title ? String((s as Record<string, unknown>).title) : "").filter(Boolean)
+          : undefined,
+      }));
+    } else if (ext === "csv") {
+      const csvRows = parseCSV(raw);
+      rows = csvRows.map((r) => ({
+        title: r.title ?? "",
+        note: r.note || undefined,
+        priority: [1, 2, 3].includes(Number(r.priority)) ? Number(r.priority) as 1 | 2 | 3 : undefined,
+        dueISO: r.dueISO || undefined,
+        column: r.column || undefined,
+        subtasks: r.subtasks ? r.subtasks.split("|").map((s) => s.trim()).filter(Boolean) : undefined,
+      }));
+    } else {
+      console.error(chalk.red(`Unsupported file extension: .${ext}. Use .json or .csv`));
+      process.exit(1);
+    }
+
+    // Validate: check for missing titles
+    const invalid = rows.map((r, i) => ({ i, r })).filter(({ r }) => !r.title.trim());
+    if (invalid.length > 0) {
+      console.error(chalk.red(`Invalid rows (missing title): ${invalid.map(({ i }) => i + 1).join(", ")}`));
+      process.exit(1);
+    }
+
+    if (rows.length === 0) {
+      console.log(chalk.dim("No rows to import."));
+      process.exit(0);
+    }
+
+    // Print preview table
+    console.log(chalk.bold(`\nImport preview (${rows.length} tasks):`));
+    console.log(chalk.dim(`  ${"TITLE".padEnd(36)}  ${"PRI".padEnd(4)}  ${"DUE".padEnd(12)}  COLUMN`));
+    for (const r of rows) {
+      const t = (r.title.length > 36 ? r.title.slice(0, 35) + "…" : r.title).padEnd(36);
+      const p = (r.priority ? String(r.priority) : "-").padEnd(4);
+      const d = (r.dueISO ? r.dueISO.slice(0, 10) : "").padEnd(12);
+      const c = r.column ?? "";
+      console.log(`  ${t}  ${p}  ${d}  ${c}`);
+    }
+
+    if (opts.dryRun) {
+      console.log(chalk.dim("\n[dry-run] No tasks created."));
+      process.exit(0);
+    }
+
+    if (!opts.yes) {
+      const { createInterface } = await import("readline");
+      const confirmed = await new Promise<boolean>((resolve) => {
+        const rl = createInterface({ input: process.stdin, output: process.stdout });
+        rl.question("\nProceed? [Y/n] ", (ans: string) => {
+          rl.close();
+          resolve(ans === "" || ans.toLowerCase() === "y");
+        });
+      });
+      if (!confirmed) {
+        console.log("Aborted.");
+        process.exit(0);
+      }
+    }
+
+    const runtime = initRuntime(config);
+    const boardEntry = config.boards.find((b) => b.id === boardId)!;
+    let exitCode = 0;
+    try {
+      // Check existing tasks to detect duplicates
+      const existing = await runtime.listTasks({ boardId, status: "any" });
+      const existingTitles = new Set(existing.map((t) => t.title.toLowerCase()));
+
+      let created = 0;
+      for (let i = 0; i < rows.length; i++) {
+        const r = rows[i];
+        if (existingTitles.has(r.title.toLowerCase())) {
+          console.log(chalk.yellow(`⚠ Skipping duplicate: ${r.title}`));
+          continue;
+        }
+        // Resolve column
+        let colId: string | undefined;
+        if (r.column) {
+          const col = resolveColumn(boardEntry, r.column);
+          if (col) colId = col.id;
+        }
+        const subtasks = (r.subtasks ?? []).map((text) => ({
+          id: crypto.randomUUID(),
+          title: text,
+          completed: false,
+        }));
+        await runtime.createTaskFull({
+          title: r.title,
+          note: r.note ?? "",
+          boardId,
+          dueISO: r.dueISO,
+          priority: r.priority,
+          columnId: colId,
+          subtasks: subtasks.length > 0 ? subtasks : undefined,
+        });
+        created++;
+        console.log(chalk.green(`  [${created}/${rows.length}] ✓ ${r.title}`));
+      }
+      console.log(chalk.green(`✓ Imported ${created}/${rows.length} tasks`));
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- inbox ----
+const inboxCmd = program
+  .command("inbox")
+  .description("Manage inbox tasks (quick capture and triage)");
+
+inboxCmd
+  .command("list")
+  .description("List inbox tasks (inboxItem: true)")
+  .option("--board <id|name>", "Board to list from")
+  .action(async (opts) => {
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const tasks = await runtime.listTasks({ boardId, status: "open" });
+      const inboxTasks = tasks.filter((t) => t.inboxItem === true);
+      if (inboxTasks.length === 0) {
+        console.log(chalk.dim("No inbox tasks."));
+      } else {
+        renderTable(inboxTasks, config.trustedNpubs);
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+inboxCmd
+  .command("add <title>")
+  .description("Capture a task to inbox (inboxItem: true)")
+  .option("--board <id|name>", "Board to add to")
+  .action(async (title: string, opts) => {
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const boardEntry = config.boards.find((b) => b.id === boardId)!;
+    if (boardEntry.kind === "compound") {
+      console.error(chalk.red("Cannot add tasks to a compound board."));
+      process.exit(1);
+    }
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      await runtime.createTaskFull({
+        title,
+        note: "",
+        boardId,
+        inboxItem: true,
+      });
+      console.log(chalk.green(`✓ Inbox: ${title}`));
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+inboxCmd
+  .command("triage <taskId>")
+  .description("Triage an inbox task: assign column, priority, due date")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--column <id|name>", "Column to assign")
+  .option("--priority <1|2|3>", "Priority")
+  .option("--due <YYYY-MM-DD>", "Due date")
+  .option("--yes", "Apply flags directly without prompting")
+  .action(async (taskId: string, opts) => {
+    validateDue(opts.due);
+    validatePriority(opts.priority);
+    warnShortTaskId(taskId);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const boardEntry = config.boards.find((b) => b.id === boardId)!;
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else {
+        // Show task details
+        console.log(chalk.bold(`\nTask: ${task.title}`));
+        if (task.note) console.log(`  Note:     ${task.note}`);
+        if (task.priority) console.log(`  Priority: ${task.priority}`);
+        if (task.dueISO) console.log(`  Due:      ${task.dueISO.slice(0, 10)}`);
+        console.log();
+
+        let colId: string | null = null;
+        let colName: string | null = null;
+        let priority: 1 | 2 | 3 | null = null;
+        let dueISO: string | null = null;
+
+        if (opts.yes) {
+          // Apply flags directly
+          if (opts.column) {
+            const col = resolveColumn(boardEntry, opts.column);
+            if (col) { colId = col.id; colName = col.name; }
+          }
+          if (opts.priority) priority = parseInt(opts.priority, 10) as 1 | 2 | 3;
+          if (opts.due) dueISO = opts.due;
+        } else {
+          const { createInterface } = await import("readline");
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          const ask = (q: string): Promise<string> =>
+            new Promise((resolve) => rl.question(q, (ans: string) => resolve(ans.trim())));
+
+          const currentCol = task.column
+            ? (boardEntry.columns?.find((c) => c.id === task.column)?.name ?? task.column)
+            : "none";
+          const colAns = await ask(`Column [${currentCol}]: `);
+          if (colAns) {
+            const col = resolveColumn(boardEntry, colAns);
+            if (col) { colId = col.id; colName = col.name; }
+            else process.stderr.write(`⚠ Column not found — skipping column change\n`);
+          }
+
+          const priAns = await ask(`Priority [${task.priority ?? "none"}]: `);
+          if (priAns && ["1", "2", "3"].includes(priAns)) {
+            priority = parseInt(priAns, 10) as 1 | 2 | 3;
+          }
+
+          const dueAns = await ask(`Due date [${task.dueISO ? task.dueISO.slice(0, 10) : "none"}]: `);
+          if (dueAns && /^\d{4}-\d{2}-\d{2}$/.test(dueAns)) {
+            dueISO = dueAns;
+          } else if (dueAns) {
+            process.stderr.write(`⚠ Invalid due date format — skipping\n`);
+          }
+
+          rl.close();
+        }
+
+        const patch: Record<string, unknown> = { inboxItem: false };
+        if (colId !== null) patch.columnId = colId;
+        if (priority !== null) patch.priority = priority;
+        if (dueISO !== null) patch.dueISO = dueISO;
+
+        const updated = await runtime.updateTask(taskId, boardId, patch);
+        if (!updated) {
+          console.error(chalk.red("Failed to update task"));
+          exitCode = 1;
+        } else {
+          const parts: string[] = [];
+          if (colName) parts.push(`column: ${colName}`);
+          if (priority) parts.push(`priority: ${priority}`);
+          if (dueISO) parts.push(`due: ${dueISO}`);
+          const detail = parts.length > 0 ? `  → ${parts.join(", ")}` : "";
+          console.log(chalk.green(`✓ Triaged: ${updated.title}${detail}`));
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- board create ----
+boardCmd
+  .command("create <name>")
+  .description("Create and publish a new board")
+  .option("--kind <lists|week>", "Board kind (default: lists)", "lists")
+  .option("--relay <url>", "Relay URL hint (informational)")
+  .action(async (name: string, opts) => {
+    if (!["lists", "week"].includes(opts.kind)) {
+      console.error(chalk.red(`Invalid --kind: "${opts.kind}". Use: lists or week`));
+      process.exit(1);
+    }
+    const kind = opts.kind as "lists" | "week";
+    const config = await loadConfig();
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      let columns: { id: string; name: string }[] = [];
+      if (kind === "lists") {
+        const { createInterface } = await import("readline");
+        const answer = await new Promise<string>((resolve) => {
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          rl.question("Column names (comma-separated, or blank for none): ", (ans: string) => {
+            rl.close();
+            resolve(ans.trim());
+          });
+        });
+        if (answer) {
+          columns = answer.split(",").map((n) => n.trim()).filter(Boolean).map((n) => ({
+            id: crypto.randomUUID(),
+            name: n,
+          }));
+        }
+      }
+      const { boardId } = await runtime.createBoard({ name, kind, columns });
+      console.log(chalk.green(`✓ Created board: ${name}  [id: ${boardId}]  [kind: ${kind}]`));
+      console.log(chalk.dim("  Joined automatically. Run: taskify board sync to confirm."));
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- assign ----
+program
+  .command("assign <taskId> <npubOrHex>")
+  .description("Assign a task to a user (npub or hex pubkey)")
+  .option("--board <id|name>", "Board the task belongs to")
+  .action(async (taskId: string, npubOrHex: string, opts) => {
+    warnShortTaskId(taskId);
+    const hex = npubOrHexToHex(npubOrHex);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else {
+        const existing = task.assignees ?? [];
+        if (existing.includes(hex)) {
+          console.log(chalk.dim(`Already assigned: ${npubOrHex}`));
+        } else {
+          const updated = await runtime.updateTask(taskId, boardId, {
+            assignees: [...existing, hex],
+          });
+          if (!updated) {
+            console.error(chalk.red("Failed to update task"));
+            exitCode = 1;
+          } else {
+            console.log(chalk.green(`✓ Assigned to: ${updated.title}`));
+          }
+        }
+      }
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      exitCode = 1;
+    } finally {
+      await runtime.disconnect();
+      process.exit(exitCode);
+    }
+  });
+
+// ---- unassign ----
+program
+  .command("unassign <taskId> <npubOrHex>")
+  .description("Remove an assignee from a task")
+  .option("--board <id|name>", "Board the task belongs to")
+  .action(async (taskId: string, npubOrHex: string, opts) => {
+    warnShortTaskId(taskId);
+    const hex = npubOrHexToHex(npubOrHex);
+    const config = await loadConfig();
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    let exitCode = 0;
+    try {
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) {
+        console.error(chalk.red(`Task not found: ${taskId}`));
+        exitCode = 1;
+      } else {
+        const filtered = (task.assignees ?? []).filter((a) => a !== hex);
+        const updated = await runtime.updateTask(taskId, boardId, {
+          assignees: filtered,
+        });
+        if (!updated) {
+          console.error(chalk.red("Failed to update task"));
+          exitCode = 1;
+        } else {
+          console.log(chalk.green(`✓ Unassigned from: ${updated.title}`));
+        }
+      }
     } catch (err) {
       console.error(chalk.red(String(err)));
       exitCode = 1;

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -127,6 +127,8 @@ function recordToCache(r: FullTaskRecord): CachedTask {
     recurrence: r.recurrence,
     bounty: r.bounty,
     reminders: r.reminders as string[] | undefined,
+    inboxItem: r.inboxItem,
+    assignees: r.assignees,
   };
 }
 
@@ -154,6 +156,8 @@ function cacheToRecord(t: CachedTask, boardName?: string): FullTaskRecord {
     recurrence: t.recurrence as Recurrence | undefined,
     bounty: t.bounty,
     reminders: t.reminders as ReminderPreset[] | undefined,
+    inboxItem: t.inboxItem,
+    assignees: t.assignees,
   };
 }
 
@@ -181,10 +185,14 @@ export type FullTaskRecord = {
   reminders?: ReminderPreset[];
   column?: string;         // col tag value (column ID)
   sourceBoardId?: string;
+  inboxItem?: boolean;
+  assignees?: string[];    // hex pubkeys
 };
 
 export type ExtendedCreateInput = AgentTaskCreateInput & {
   subtasks?: Subtask[];
+  inboxItem?: boolean;
+  assignees?: string[];
 };
 
 export type NostrRuntime = {
@@ -200,6 +208,7 @@ export type NostrRuntime = {
   syncBoard(boardId: string): Promise<{ kind?: string; columns?: { id: string; name: string }[]; children?: string[] }>;
   createTask(input: AgentTaskCreateInput): Promise<FullTaskRecord>;
   createTaskFull(input: ExtendedCreateInput): Promise<FullTaskRecord>;
+  createBoard(input: { name: string; kind: "lists" | "week"; columns?: { id: string; name: string }[] }): Promise<{ boardId: string }>;
   updateTask(taskId: string, boardId: string, patch: AgentTaskPatchInput): Promise<FullTaskRecord | null>;
   setTaskStatus(taskId: string, status: AgentTaskStatus, boardId: string): Promise<FullTaskRecord | null>;
   deleteTask(taskId: string, boardId: string): Promise<FullTaskRecord | null>;
@@ -256,6 +265,12 @@ async function parseDecryptedEvent(
       subtasks: payload.subtasks ?? undefined,
       bounty: payload.bounty ?? undefined,
       column,
+      inboxItem: payload.inboxItem === true ? true : undefined,
+      assignees: Array.isArray(payload.assignees) && payload.assignees.length > 0
+        ? (payload.assignees as Array<unknown>).map((a) =>
+            typeof a === "string" ? a : (a as Record<string, string>).pubkey ?? "")
+          .filter(Boolean)
+        : undefined,
     };
   } catch {
     return null;
@@ -387,7 +402,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
 
     async disconnect(): Promise<void> {
       try {
-        ndk.pool?.destroy();
+        (ndk.pool as unknown as { destroy?(): void })?.destroy?.();
       } catch {
         // ignore teardown errors
       }
@@ -511,7 +526,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       await ensureConnected();
       const bTag = boardTagHash(boardId);
       const fetchPromise = ndk.fetchEvents(
-        { kinds: [30300], "#b": [bTag], limit: 1 } as Parameters<typeof ndk.fetchEvents>[0],
+        { kinds: [30300], "#b": [bTag], limit: 1 } as unknown as Parameters<typeof ndk.fetchEvents>[0],
         { closeOnEose: true },
       );
       const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) =>
@@ -638,8 +653,8 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         documents: null,
         bounty: null,
         subtasks: input.subtasks ?? null,
-        assignees: null,
-        inboxItem: null,
+        assignees: input.assignees ? input.assignees.map((pk) => ({ pubkey: pk })) : null,
+        inboxItem: input.inboxItem === true ? true : null,
       };
       // Resolve column: explicit > week-board today > ""
       let colId = "";
@@ -664,6 +679,8 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         lastEditedBy: userPubkey,
         subtasks: input.subtasks,
         column: colId || undefined,
+        inboxItem: input.inboxItem === true ? true : undefined,
+        assignees: input.assignees,
       };
       // Update cache with the new task
       const cache = readCache();
@@ -700,6 +717,9 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         ...(patch.note !== undefined ? { note: patch.note ?? "" } : {}),
         ...(patch.dueISO !== undefined ? { dueISO: patch.dueISO ?? "" } : {}),
         ...(patch.priority !== undefined ? { priority: patch.priority ?? null } : {}),
+        ...(patch.inboxItem !== undefined ? { inboxItem: patch.inboxItem } : {}),
+        // Store assignees as {pubkey} objects in Nostr payload for PWA compat
+        ...(patch.assignees !== undefined ? { assignees: patch.assignees.map((pk) => ({ pubkey: pk })) } : {}),
         lastEditedBy: userPubkey,
       };
       const statusTag = event.tags.find((t) => t[0] === "status");
@@ -708,8 +728,21 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       const existingColId = colTag?.[1] ?? "";
       const colId = patch.columnId !== undefined ? (patch.columnId ?? "") : existingColId;
       await publishTaskEvent(entry.id, taskId, merged, status, colId);
-      const updated = { ...existing, ...merged };
-      if (patch.columnId !== undefined) (updated as FullTaskRecord).column = colId || undefined;
+      // Build updated FullTaskRecord — keep assignees as string[] (extract pubkeys)
+      const updatedAssignees: string[] | undefined = patch.assignees !== undefined
+        ? patch.assignees
+        : existing.assignees;
+      const updated: FullTaskRecord = {
+        ...existing,
+        title: merged.title ?? existing.title,
+        note: merged.note || undefined,
+        dueISO: merged.dueISO ?? existing.dueISO,
+        priority: merged.priority ?? undefined,
+        inboxItem: merged.inboxItem === true ? true : undefined,
+        assignees: updatedAssignees,
+        lastEditedBy: merged.lastEditedBy,
+      };
+      if (patch.columnId !== undefined) updated.column = colId || undefined;
       // Invalidate cache entry
       const cache = readCache();
       const bc = cache.boards[entry.id];
@@ -932,6 +965,54 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         }
       }
       return results;
+    },
+
+    async createBoard(input: {
+      name: string;
+      kind: "lists" | "week";
+      columns?: { id: string; name: string }[];
+    }): Promise<{ boardId: string }> {
+      await ensureConnected();
+      const boardId = crypto.randomUUID();
+      const { signer } = deriveBoardKeys(boardId);
+      const bTag = boardTagHash(boardId);
+
+      const contentPayload = {
+        name: input.name,
+        kind: input.kind,
+        columns: input.columns ?? [],
+        version: 1,
+      };
+      const encrypted = await encryptContent(boardId, JSON.stringify(contentPayload));
+
+      const event = new NDKEvent(ndk);
+      event.kind = 30300;
+      event.content = encrypted;
+      event.tags = [
+        ["d", boardId],
+        ["b", bTag],
+        ["k", input.kind],
+        ...(input.columns ?? []).map((c): string[] => ["col", c.id, c.name]),
+      ];
+      await event.sign(signer);
+      try {
+        await event.publish();
+      } catch (err) {
+        throw new Error(`Board publish failed: ${String(err)}`);
+      }
+
+      // Auto-join: save to config
+      const cfg = await loadConfig();
+      const newEntry: BoardEntry = {
+        id: boardId,
+        name: input.name,
+        kind: input.kind,
+        columns: input.columns ?? [],
+      };
+      cfg.boards.push(newEntry);
+      await saveConfig(cfg);
+
+      return { boardId };
     },
   };
 }

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -1,0 +1,937 @@
+import NDK, { NDKEvent, NDKPrivateKeySigner, NDKRelayStatus } from "@nostr-dev-kit/ndk";
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+import { getPublicKey, nip19 } from "nostr-tools";
+import type { ReminderPreset, Recurrence, Subtask } from "./shared/taskTypes.ts";
+import type { AgentTaskCreateInput, AgentTaskPatchInput, AgentTaskStatus } from "./shared/agentRuntime.ts";
+import type { AgentSecurityConfig } from "./shared/agentSecurity.ts";
+import type { TaskifyConfig, BoardEntry } from "./config.ts";
+import { saveConfig, loadConfig } from "./config.ts";
+import { readCache, writeCache, isCacheFresh, type CachedTask } from "./taskCache.ts";
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+// ---- Internal helpers (not exported) ----
+
+function boardTagHash(boardId: string): string {
+  return bytesToHex(sha256(new TextEncoder().encode(boardId)));
+}
+
+function deriveBoardKeys(boardId: string): {
+  sk: Uint8Array;
+  skHex: string;
+  pk: string;
+  signer: NDKPrivateKeySigner;
+} {
+  const label = new TextEncoder().encode("taskify-board-nostr-key-v1");
+  const id = new TextEncoder().encode(boardId);
+  const material = new Uint8Array(label.length + id.length);
+  material.set(label, 0);
+  material.set(id, label.length);
+  const sk = sha256(material);
+  const skHex = bytesToHex(sk);
+  const pk = getPublicKey(sk);
+  return { sk, skHex, pk, signer: new NDKPrivateKeySigner(skHex) };
+}
+
+async function deriveAESKey(boardId: string): Promise<CryptoKey> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(boardId),
+  );
+  return crypto.subtle.importKey(
+    "raw",
+    digest,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+async function encryptContent(boardId: string, plaintext: string): Promise<string> {
+  const key = await deriveAESKey(boardId);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const pt = new TextEncoder().encode(plaintext);
+  const ct = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, pt);
+  const result = new Uint8Array(12 + ct.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(ct), 12);
+  return Buffer.from(result).toString("base64");
+}
+
+async function decryptContent(boardId: string, data: string): Promise<string> {
+  const key = await deriveAESKey(boardId);
+  const bytes = Buffer.from(data, "base64");
+  const iv = bytes.subarray(0, 12);
+  const ct = bytes.subarray(12);
+  const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+  return new TextDecoder().decode(pt);
+}
+
+function getUserPubkeyHex(config: TaskifyConfig): string | undefined {
+  if (!config.nsec) return undefined;
+  try {
+    const decoded = nip19.decode(config.nsec);
+    if (decoded.type === "nsec") {
+      return getPublicKey(decoded.data as Uint8Array);
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+function validateEventCompat(event: NDKEvent): boolean {
+  if (event.kind !== 30301) return false;
+  const hasD = event.tags.some((t) => t[0] === "d");
+  const hasB = event.tags.some((t) => t[0] === "b");
+  if (!hasD || !hasB) return false;
+  if (!event.content) return false;
+  return true;
+}
+
+function resolveBoardEntry(config: TaskifyConfig, boardIdOrName: string): BoardEntry | null {
+  // Exact UUID match first
+  let entry = config.boards.find((b) => b.id === boardIdOrName);
+  if (entry) return entry;
+  // Case-insensitive name match
+  const lower = boardIdOrName.toLowerCase();
+  entry = config.boards.find((b) => b.name.toLowerCase() === lower);
+  return entry ?? null;
+}
+
+// ---- Cache conversion helpers ----
+
+function recordToCache(r: FullTaskRecord): CachedTask {
+  return {
+    id: r.id,
+    title: r.title,
+    boardId: r.boardId,
+    boardName: r.boardName,
+    status: r.completed ? "done" : "open",
+    updatedAt: r.createdAt,
+    note: r.note,
+    dueISO: r.dueISO,
+    dueDateEnabled: r.dueDateEnabled,
+    dueTimeEnabled: r.dueTimeEnabled,
+    priority: r.priority,
+    completed: r.completed,
+    completedAt: r.completedAt,
+    createdAt: r.createdAt,
+    createdBy: r.createdBy,
+    lastEditedBy: r.lastEditedBy,
+    column: r.column,
+    subtasks: r.subtasks as Array<{ id: string; title: string; completed: boolean }> | undefined,
+    recurrence: r.recurrence,
+    bounty: r.bounty,
+    reminders: r.reminders as string[] | undefined,
+  };
+}
+
+function cacheToRecord(t: CachedTask, boardName?: string): FullTaskRecord {
+  return {
+    id: t.id,
+    boardId: t.boardId,
+    boardName: t.boardName ?? boardName,
+    title: t.title,
+    note: t.note,
+    dueISO: t.dueISO ?? "",
+    dueDateEnabled: t.dueDateEnabled,
+    dueTimeEnabled: t.dueTimeEnabled,
+    priority: t.priority,
+    completed: t.status === "done",
+    completedAt: t.completedAt,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt
+      ? new Date(t.updatedAt * 1000).toISOString()
+      : undefined,
+    createdBy: t.createdBy,
+    lastEditedBy: t.lastEditedBy,
+    column: t.column,
+    subtasks: t.subtasks,
+    recurrence: t.recurrence as Recurrence | undefined,
+    bounty: t.bounty,
+    reminders: t.reminders as ReminderPreset[] | undefined,
+  };
+}
+
+// ---- Public types ----
+
+export type FullTaskRecord = {
+  id: string;              // UUID from the "d" tag
+  boardId: string;         // raw board UUID
+  boardName?: string;
+  title: string;
+  note?: string;
+  dueISO: string;
+  dueDateEnabled?: boolean;
+  dueTimeEnabled?: boolean;
+  priority?: 1 | 2 | 3;
+  completed: boolean;
+  completedAt?: string;
+  createdAt?: number;      // Unix seconds (for render compat)
+  updatedAt?: string;
+  createdBy?: string;      // hex pubkey
+  lastEditedBy?: string;   // hex pubkey
+  recurrence?: Recurrence;
+  subtasks?: Subtask[];
+  bounty?: object;
+  reminders?: ReminderPreset[];
+  column?: string;         // col tag value (column ID)
+  sourceBoardId?: string;
+};
+
+export type ExtendedCreateInput = AgentTaskCreateInput & {
+  subtasks?: Subtask[];
+};
+
+export type NostrRuntime = {
+  getDefaultBoardId(): string | null;
+  disconnect(): Promise<void>;
+  listTasks(options: {
+    boardId?: string;
+    status: "open" | "done" | "any";
+    columnId?: string;
+    refresh?: boolean;
+    noCache?: boolean;
+  }): Promise<FullTaskRecord[]>;
+  syncBoard(boardId: string): Promise<{ kind?: string; columns?: { id: string; name: string }[]; children?: string[] }>;
+  createTask(input: AgentTaskCreateInput): Promise<FullTaskRecord>;
+  createTaskFull(input: ExtendedCreateInput): Promise<FullTaskRecord>;
+  updateTask(taskId: string, boardId: string, patch: AgentTaskPatchInput): Promise<FullTaskRecord | null>;
+  setTaskStatus(taskId: string, status: AgentTaskStatus, boardId: string): Promise<FullTaskRecord | null>;
+  deleteTask(taskId: string, boardId: string): Promise<FullTaskRecord | null>;
+  toggleSubtask(taskId: string, boardId: string, subtaskRef: string, completed: boolean): Promise<FullTaskRecord | null>;
+  getTask(taskId: string, boardId?: string): Promise<FullTaskRecord | null>;
+  remindTask(taskId: string, presets: ReminderPreset[]): Promise<void>;
+  getLocalReminders(taskId: string): ReminderPreset[];
+  getAgentSecurityConfig(): Promise<AgentSecurityConfig>;
+  setAgentSecurityConfig(cfg: AgentSecurityConfig): Promise<AgentSecurityConfig>;
+  getRelayStatus(): Promise<{ url: string; connected: boolean }[]>;
+};
+
+// ---- Event parsing ----
+
+async function parseDecryptedEvent(
+  event: NDKEvent,
+  boardId: string,
+  boardName?: string,
+): Promise<FullTaskRecord | null> {
+  if (!validateEventCompat(event)) return null;
+  try {
+    const plaintext = await decryptContent(boardId, event.content);
+    const payload = JSON.parse(plaintext);
+    const dTag = event.tags.find((t) => t[0] === "d");
+    const taskId = dTag?.[1] ?? "";
+    if (!taskId) return null;
+    const statusTag = event.tags.find((t) => t[0] === "status");
+    const statusVal = statusTag?.[1] ?? "open";
+    const completed = statusVal === "done";
+    const colTag = event.tags.find((t) => t[0] === "col");
+    const column = colTag?.[1] || undefined;
+    return {
+      id: taskId,
+      boardId,
+      boardName,
+      title: payload.title ?? "",
+      note: payload.note || undefined,
+      dueISO: payload.dueISO ?? "",
+      dueDateEnabled: payload.dueDateEnabled ?? undefined,
+      dueTimeEnabled: payload.dueTimeEnabled ?? undefined,
+      priority: payload.priority ?? undefined,
+      completed,
+      completedAt: payload.completedAt ?? undefined,
+      // payload.createdAt is ms; convert to seconds for render compat
+      createdAt: payload.createdAt
+        ? Math.floor(payload.createdAt / 1000)
+        : event.created_at,
+      updatedAt: event.created_at
+        ? new Date(event.created_at * 1000).toISOString()
+        : undefined,
+      createdBy: payload.createdBy,
+      lastEditedBy: payload.lastEditedBy,
+      recurrence: payload.recurrence ?? undefined,
+      subtasks: payload.subtasks ?? undefined,
+      bounty: payload.bounty ?? undefined,
+      column,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---- Runtime factory ----
+
+export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
+  const ndk = new NDK({
+    explicitRelayUrls: config.relays,
+  });
+
+  let connected = false;
+
+  async function ensureConnected(): Promise<void> {
+    if (!connected) {
+      await Promise.race([
+        ndk.connect(),
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            process.stderr.write(
+              "⚠ Relay connection slow — continuing with available relays\n",
+            );
+            resolve();
+          }, 8000),
+        ),
+      ]);
+      connected = true;
+    }
+  }
+
+  async function fetchBoardEvents(boardId: string, taskId?: string): Promise<Set<NDKEvent>> {
+    const bTag = boardTagHash(boardId);
+    const filter: Record<string, unknown> = {
+      kinds: [30301],
+      "#b": [bTag],
+      limit: taskId ? undefined : 500,
+    };
+    if (taskId) filter["#d"] = [taskId];
+
+    let hardTimer: ReturnType<typeof setTimeout>;
+
+    return new Promise<Set<NDKEvent>>((resolve) => {
+      const collected = new Set<NDKEvent>();
+      let graceTimer: ReturnType<typeof setTimeout> | null = null;
+      let settled = false;
+      const HARD_TIMEOUT_MS = taskId ? 10_000 : 15_000;
+      const EOSE_GRACE_MS = 200;
+
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        if (graceTimer) clearTimeout(graceTimer);
+        if (hardTimer) clearTimeout(hardTimer);
+        try { sub.stop(); } catch { /* ignore */ }
+        resolve(collected);
+      };
+
+      hardTimer = setTimeout(settle, HARD_TIMEOUT_MS);
+
+      const sub = ndk.subscribe(
+        filter as Parameters<typeof ndk.subscribe>[0],
+        { closeOnEose: false },
+      );
+
+      sub.on("event", (evt: NDKEvent) => {
+        if (!settled) collected.add(evt);
+      });
+
+      sub.on("eose", () => {
+        // First EOSE received — start grace window if not already started
+        if (!graceTimer && !settled) {
+          graceTimer = setTimeout(settle, EOSE_GRACE_MS);
+        }
+      });
+    });
+  }
+
+  // Resolves a full UUID from a short prefix — fetches all board events and scans "d" tags.
+  async function resolveTaskId(boardId: string, taskIdOrPrefix: string): Promise<string | null> {
+    // Full UUID — use directly
+    if (taskIdOrPrefix.length === 36) return taskIdOrPrefix;
+    // Short prefix — scan board events
+    const allEvents = await fetchBoardEvents(boardId);
+    const prefix = taskIdOrPrefix.toLowerCase().slice(0, 8);
+    for (const event of allEvents) {
+      const dTag = event.tags.find((t) => t[0] === "d");
+      const dVal = (dTag?.[1] ?? "").toLowerCase();
+      if (dVal.startsWith(prefix)) return dTag![1];
+    }
+    return null;
+  }
+
+  async function publishTaskEvent(
+    boardId: string,
+    taskId: string,
+    payload: Record<string, unknown>,
+    status: "open" | "done" | "deleted",
+    colId: string = "",
+  ): Promise<NDKEvent> {
+    const { signer } = deriveBoardKeys(boardId);
+    const bTag = boardTagHash(boardId);
+    const encrypted = await encryptContent(boardId, JSON.stringify(payload));
+    const event = new NDKEvent(ndk);
+    event.kind = 30301;
+    event.content = encrypted;
+    event.tags = [
+      ["d", taskId],
+      ["b", bTag],
+      ["col", colId],
+      ["status", status],
+    ];
+    await event.sign(signer);
+    try {
+      await event.publish();
+    } catch (err) {
+      throw new Error(
+        `Publish failed — check relay connectivity (taskify relay status): ${String(err)}`,
+      );
+    }
+    return event;
+  }
+
+  return {
+    getDefaultBoardId(): string | null {
+      return config.boards[0]?.id ?? null;
+    },
+
+    async disconnect(): Promise<void> {
+      try {
+        ndk.pool?.destroy();
+      } catch {
+        // ignore teardown errors
+      }
+    },
+
+    async listTasks({ boardId, status, columnId, refresh, noCache }): Promise<FullTaskRecord[]> {
+      const boards: BoardEntry[] = [];
+      if (boardId) {
+        const entry = resolveBoardEntry(config, boardId);
+        if (!entry) {
+          throw new Error(
+            `Board not found in config: "${boardId}". Use: taskify board join <id> --name <name>`,
+          );
+        }
+        boards.push(entry);
+      } else {
+        boards.push(...config.boards);
+      }
+      if (boards.length === 0) return [];
+
+      const cache = readCache();
+      const records: FullTaskRecord[] = [];
+
+      for (const board of boards) {
+        // Compound board: aggregate tasks from children
+        if (board.kind === "compound") {
+          await ensureConnected();
+          const childIds = board.children ?? [];
+          const seen = new Set<string>();
+          for (const childId of childIds) {
+            const childEntry = resolveBoardEntry(config, childId) ?? { id: childId, name: childId };
+            const childEvents = await fetchBoardEvents(childId);
+            for (const event of childEvents) {
+              const record = await parseDecryptedEvent(event, childId, (childEntry as BoardEntry).name ?? childId);
+              if (!record) continue;
+              if (seen.has(record.id)) continue;
+              seen.add(record.id);
+              record.sourceBoardId = childId;
+              if (status === "open" && record.completed) continue;
+              if (status === "done" && !record.completed) continue;
+              if (columnId !== undefined && record.column !== columnId) continue;
+              records.push(record);
+            }
+          }
+          continue;
+        }
+
+        const boardCache = cache.boards[board.id];
+
+        // Use cache if fresh and not forcing a refresh
+        if (!refresh && boardCache && isCacheFresh(boardCache)) {
+          for (const t of boardCache.tasks) {
+            const rec = cacheToRecord(t, board.name);
+            if (status === "open" && rec.completed) continue;
+            if (status === "done" && !rec.completed) continue;
+            if (columnId !== undefined && rec.column !== columnId) continue;
+            records.push(rec);
+          }
+          continue;
+        }
+
+        // Fetch live from relay
+        await ensureConnected();
+        const events = await fetchBoardEvents(board.id);
+        const liveRecords: FullTaskRecord[] = [];
+        for (const event of events) {
+          const record = await parseDecryptedEvent(event, board.id, board.name);
+          if (!record) continue;
+          liveRecords.push(record);
+        }
+
+        // A3/A2: guard against caching an empty result when previous data exists
+        if (liveRecords.length === 0 && boardCache && !noCache) {
+          const cacheAgeMs = Date.now() - boardCache.fetchedAt;
+          const TEN_MIN_MS = 10 * 60 * 1000;
+          if (cacheAgeMs <= TEN_MIN_MS) {
+            // A3: cache ≤ 10 min old — silently fall back, skip relay result
+            for (const t of boardCache.tasks) {
+              const rec = cacheToRecord(t, board.name);
+              if (status === "open" && rec.completed) continue;
+              if (status === "done" && !rec.completed) continue;
+              if (columnId !== undefined && rec.column !== columnId) continue;
+              records.push(rec);
+            }
+            continue;
+          } else if (boardCache.tasks.length > 0) {
+            // A2: stale cache has tasks — warn and keep, don't overwrite with empty
+            process.stderr.write("⚠ Relay returned 0 tasks — keeping cached results\n");
+            for (const t of boardCache.tasks) {
+              const rec = cacheToRecord(t, board.name);
+              if (status === "open" && rec.completed) continue;
+              if (status === "done" && !rec.completed) continue;
+              if (columnId !== undefined && rec.column !== columnId) continue;
+              records.push(rec);
+            }
+            continue;
+          }
+        }
+
+        // Write all records (any status) to cache
+        cache.boards[board.id] = {
+          tasks: liveRecords.map(recordToCache),
+          fetchedAt: Date.now(),
+        };
+
+        // Filter for the caller
+        for (const record of liveRecords) {
+          if (columnId !== undefined && record.column !== columnId) continue;
+          if (status === "open" && record.completed) continue;
+          if (status === "done" && !record.completed) continue;
+          records.push(record);
+        }
+      }
+
+      writeCache(cache);
+      records.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+      return records;
+    },
+
+    async syncBoard(boardId: string): Promise<{ kind?: string; columns?: { id: string; name: string }[]; children?: string[] }> {
+      await ensureConnected();
+      const bTag = boardTagHash(boardId);
+      const fetchPromise = ndk.fetchEvents(
+        { kinds: [30300], "#b": [bTag], limit: 1 } as Parameters<typeof ndk.fetchEvents>[0],
+        { closeOnEose: true },
+      );
+      const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) =>
+        setTimeout(() => resolve(new Set<NDKEvent>()), 10000),
+      );
+      const events = await Promise.race([fetchPromise, timeoutPromise]);
+
+      // Load fresh config to ensure we have the latest board entry
+      const cfg = await loadConfig();
+      const entry = cfg.boards.find((b) => b.id === boardId);
+      if (!entry) return {};
+
+      let kind: string | undefined;
+      let columns: { id: string; name: string }[] | undefined;
+      let children: string[] | undefined;
+
+      if (events.size > 0) {
+        const [event] = events;
+        const kTag = event.tags.find((t) => t[0] === "k");
+        if (kTag?.[1]) kind = kTag[1];
+
+        const colTags = event.tags.filter((t) => t[0] === "col" && t[1] && t[2]);
+        if (colTags.length > 0) {
+          columns = colTags.map((t) => ({ id: t[1], name: t[2] }));
+        }
+
+        // Check for "ch" tags
+        const chTags = event.tags.filter((t) => t[0] === "ch" && t[1]);
+        if (chTags.length > 0) {
+          children = chTags.map((t) => t[1]);
+        }
+
+        // Try to decrypt content for additional columns and kind (fallback)
+        try {
+          if (event.content) {
+            const plaintext = await decryptContent(boardId, event.content);
+            const parsed = JSON.parse(plaintext);
+
+            // Extract kind from content if not found in tags
+            if (!kind && parsed.kind) {
+              kind = String(parsed.kind);
+            }
+
+            // Extract columns from content
+            if (Array.isArray(parsed.columns)) {
+              const contentCols: { id: string; name: string }[] = parsed.columns
+                .filter(
+                  (c: unknown) =>
+                    c && typeof c === "object" && "id" in (c as object) && "name" in (c as object),
+                )
+                .map((c: { id: string; name: string }) => ({ id: String(c.id), name: String(c.name) }));
+
+              // Merge with tag-discovered columns (deduplicate by id)
+              const merged = [...(columns ?? [])];
+              for (const cc of contentCols) {
+                if (!merged.find((m) => m.id === cc.id)) {
+                  merged.push(cc);
+                }
+              }
+              if (merged.length > 0) columns = merged;
+            }
+
+            // Extract children from content
+            if (Array.isArray(parsed.children)) {
+              const contentChildren = (parsed.children as unknown[]).filter((c): c is string => typeof c === "string");
+              const mergedChildren = [...(children ?? [])];
+              for (const cc of contentChildren) {
+                if (!mergedChildren.includes(cc)) mergedChildren.push(cc);
+              }
+              if (mergedChildren.length > 0) children = mergedChildren;
+            }
+          }
+        } catch { /* non-fatal — content may not be in expected format */ }
+
+        if (kind) entry.kind = kind as BoardEntry["kind"];
+        if (columns && columns.length > 0) entry.columns = columns;
+        if (children && children.length > 0) entry.children = children;
+        await saveConfig(cfg);
+      }
+
+      return { kind, columns, children };
+    },
+
+    async createTask(input: AgentTaskCreateInput): Promise<FullTaskRecord> {
+      return (this as NostrRuntime).createTaskFull(input);
+    },
+
+    async createTaskFull(input: ExtendedCreateInput): Promise<FullTaskRecord> {
+      await ensureConnected();
+      const entry = resolveBoardEntry(config, input.boardId);
+      if (!entry) {
+        throw new Error(
+          `Board not found in config: "${input.boardId}". Use: taskify board join <id> --name <name>`,
+        );
+      }
+      const boardId = entry.id;
+      const taskId = crypto.randomUUID();
+      const userPubkey = getUserPubkeyHex(config);
+      if (!userPubkey) {
+        process.stderr.write(
+          "\x1b[33m(warning: no nsec configured — createdBy/lastEditedBy will be empty)\x1b[0m\n",
+        );
+      }
+      const now = Date.now();
+      const payload: Record<string, unknown> = {
+        title: input.title,
+        priority: input.priority ?? null,
+        note: input.note ?? "",
+        dueISO: input.dueISO ?? "",
+        completedAt: null,
+        completedBy: null,
+        recurrence: null,
+        hiddenUntilISO: null,
+        createdBy: userPubkey,
+        lastEditedBy: userPubkey,
+        createdAt: now,
+        streak: null,
+        longestStreak: null,
+        seriesId: null,
+        dueDateEnabled: input.dueISO ? true : null,
+        dueTimeEnabled: null,
+        dueTimeZone: null,
+        images: null,
+        documents: null,
+        bounty: null,
+        subtasks: input.subtasks ?? null,
+        assignees: null,
+        inboxItem: null,
+      };
+      // Resolve column: explicit > week-board today > ""
+      let colId = "";
+      if (input.columnId !== undefined) {
+        colId = input.columnId;
+      } else if (entry.kind === "week") {
+        colId = new Date().toISOString().slice(0, 10);
+      }
+      await publishTaskEvent(boardId, taskId, payload, "open", colId);
+      const result: FullTaskRecord = {
+        id: taskId,
+        boardId,
+        boardName: entry.name,
+        title: input.title,
+        note: input.note || undefined,
+        dueISO: input.dueISO ?? "",
+        dueDateEnabled: input.dueISO ? true : undefined,
+        priority: input.priority,
+        completed: false,
+        createdAt: Math.floor(now / 1000),
+        createdBy: userPubkey,
+        lastEditedBy: userPubkey,
+        subtasks: input.subtasks,
+        column: colId || undefined,
+      };
+      // Update cache with the new task
+      const cache = readCache();
+      const boardCache = cache.boards[boardId] ?? { tasks: [], fetchedAt: Date.now() };
+      boardCache.tasks = boardCache.tasks.filter((t) => t.id !== taskId);
+      boardCache.tasks.push(recordToCache(result));
+      cache.boards[boardId] = boardCache;
+      writeCache(cache);
+      return result;
+    },
+
+    async updateTask(
+      taskId: string,
+      boardId: string,
+      patch: AgentTaskPatchInput,
+    ): Promise<FullTaskRecord | null> {
+      await ensureConnected();
+      const entry = resolveBoardEntry(config, boardId);
+      if (!entry) return null;
+      const resolvedId = await resolveTaskId(entry.id, taskId);
+      if (!resolvedId) return null;
+      taskId = resolvedId;
+      const events = await fetchBoardEvents(entry.id, taskId);
+      if (events.size === 0) return null;
+      const [event] = events;
+      const existing = await parseDecryptedEvent(event, entry.id, entry.name);
+      if (!existing) return null;
+      const plaintext = await decryptContent(entry.id, event.content);
+      const rawPayload = JSON.parse(plaintext);
+      const userPubkey = getUserPubkeyHex(config);
+      const merged = {
+        ...rawPayload,
+        ...(patch.title !== undefined ? { title: patch.title } : {}),
+        ...(patch.note !== undefined ? { note: patch.note ?? "" } : {}),
+        ...(patch.dueISO !== undefined ? { dueISO: patch.dueISO ?? "" } : {}),
+        ...(patch.priority !== undefined ? { priority: patch.priority ?? null } : {}),
+        lastEditedBy: userPubkey,
+      };
+      const statusTag = event.tags.find((t) => t[0] === "status");
+      const status = (statusTag?.[1] ?? "open") as "open" | "done" | "deleted";
+      const colTag = event.tags.find((t) => t[0] === "col");
+      const existingColId = colTag?.[1] ?? "";
+      const colId = patch.columnId !== undefined ? (patch.columnId ?? "") : existingColId;
+      await publishTaskEvent(entry.id, taskId, merged, status, colId);
+      const updated = { ...existing, ...merged };
+      if (patch.columnId !== undefined) (updated as FullTaskRecord).column = colId || undefined;
+      // Invalidate cache entry
+      const cache = readCache();
+      const bc = cache.boards[entry.id];
+      if (bc) {
+        bc.tasks = bc.tasks.filter((t) => t.id !== taskId);
+        bc.tasks.push(recordToCache(updated));
+        writeCache(cache);
+      }
+      return updated;
+    },
+
+    async setTaskStatus(
+      taskId: string,
+      status: AgentTaskStatus,
+      boardId: string,
+    ): Promise<FullTaskRecord | null> {
+      await ensureConnected();
+      const entry = resolveBoardEntry(config, boardId);
+      if (!entry) return null;
+      const resolvedId = await resolveTaskId(entry.id, taskId);
+      if (!resolvedId) return null;
+      taskId = resolvedId;
+      const events = await fetchBoardEvents(entry.id, taskId);
+      if (events.size === 0) return null;
+      const [event] = events;
+      const existing = await parseDecryptedEvent(event, entry.id, entry.name);
+      if (!existing) return null;
+      const plaintext = await decryptContent(entry.id, event.content);
+      const rawPayload = JSON.parse(plaintext);
+      const userPubkey = getUserPubkeyHex(config);
+      const completed = status === "done";
+      const merged = {
+        ...rawPayload,
+        completedAt: completed ? nowISO() : null,
+        lastEditedBy: userPubkey,
+      };
+      const nostrStatus: "open" | "done" | "deleted" = completed ? "done" : "open";
+      const colTag = event.tags.find((t) => t[0] === "col");
+      const colId = colTag?.[1] ?? "";
+      await publishTaskEvent(entry.id, taskId, merged, nostrStatus, colId);
+      const updated = { ...existing, completed, completedAt: merged.completedAt ?? undefined };
+      // Update cache
+      const cache = readCache();
+      const bc = cache.boards[entry.id];
+      if (bc) {
+        bc.tasks = bc.tasks.filter((t) => t.id !== taskId);
+        bc.tasks.push(recordToCache(updated));
+        writeCache(cache);
+      }
+      return updated;
+    },
+
+    async deleteTask(taskId: string, boardId: string): Promise<FullTaskRecord | null> {
+      await ensureConnected();
+      const entry = resolveBoardEntry(config, boardId);
+      if (!entry) return null;
+      const resolvedId = await resolveTaskId(entry.id, taskId);
+      if (!resolvedId) return null;
+      taskId = resolvedId;
+      const events = await fetchBoardEvents(entry.id, taskId);
+      if (events.size === 0) return null;
+      const [event] = events;
+      const existing = await parseDecryptedEvent(event, entry.id, entry.name);
+      if (!existing) return null;
+      const plaintext = await decryptContent(entry.id, event.content);
+      const rawPayload = JSON.parse(plaintext);
+      const colTag = event.tags.find((t) => t[0] === "col");
+      const colId = colTag?.[1] ?? "";
+
+      // Step 1: publish kind 30301 status=deleted (app-level soft delete)
+      await publishTaskEvent(entry.id, taskId, rawPayload, "deleted", colId);
+
+      // Step 2: publish NIP-09 kind 5 deletion request (matches PWA's publishTaskDeletionRequest)
+      const boardKeys = deriveBoardKeys(entry.id);
+      const aTag = `30301:${boardKeys.pk}:${taskId}`;
+      try {
+        const nip09Event = new NDKEvent(ndk);
+        nip09Event.kind = 5;
+        nip09Event.content = "Task deleted";
+        nip09Event.tags = [["a", aTag]];
+        nip09Event.created_at = Math.floor(Date.now() / 1000);
+        ndk.signer = boardKeys.signer;
+        await nip09Event.publish();
+      } catch {
+        // Non-fatal: NIP-09 relay support varies; soft delete already published
+      }
+
+      // Remove from cache
+      const cache = readCache();
+      const bc = cache.boards[entry.id];
+      if (bc) {
+        bc.tasks = bc.tasks.filter((t) => t.id !== taskId);
+        writeCache(cache);
+      }
+
+      return existing;
+    },
+
+    async toggleSubtask(
+      taskId: string,
+      boardId: string,
+      subtaskRef: string,
+      completed: boolean,
+    ): Promise<FullTaskRecord | null> {
+      await ensureConnected();
+      const entry = resolveBoardEntry(config, boardId);
+      if (!entry) return null;
+      const resolvedId = await resolveTaskId(entry.id, taskId);
+      if (!resolvedId) return null;
+      taskId = resolvedId;
+      const events = await fetchBoardEvents(entry.id, taskId);
+      if (events.size === 0) return null;
+      const [event] = events;
+      const existing = await parseDecryptedEvent(event, entry.id, entry.name);
+      if (!existing) return null;
+      const plaintext = await decryptContent(entry.id, event.content);
+      const rawPayload = JSON.parse(plaintext);
+      const subtasks: Array<{ id: string; title: string; completed: boolean }> =
+        rawPayload.subtasks ?? [];
+      // Resolve by 1-based index or title substring
+      const indexNum = parseInt(subtaskRef, 10);
+      let targetIdx = -1;
+      if (!isNaN(indexNum) && indexNum >= 1 && indexNum <= subtasks.length) {
+        targetIdx = indexNum - 1;
+      } else {
+        const lower = subtaskRef.toLowerCase();
+        targetIdx = subtasks.findIndex((s) => s.title.toLowerCase().includes(lower));
+      }
+      if (targetIdx === -1) {
+        throw new Error(`Subtask not found: ${subtaskRef}`);
+      }
+      subtasks[targetIdx] = { ...subtasks[targetIdx], completed };
+      rawPayload.subtasks = subtasks;
+      const statusTag = event.tags.find((t) => t[0] === "status");
+      const status = (statusTag?.[1] ?? "open") as "open" | "done" | "deleted";
+      const colTag = event.tags.find((t) => t[0] === "col");
+      const colId = colTag?.[1] ?? "";
+      await publishTaskEvent(entry.id, taskId, rawPayload, status, colId);
+      return { ...existing, subtasks };
+    },
+
+    async getTask(taskId: string, boardId?: string): Promise<FullTaskRecord | null> {
+      await ensureConnected();
+      const boards: BoardEntry[] = [];
+      if (boardId) {
+        const entry = resolveBoardEntry(config, boardId);
+        if (entry) boards.push(entry);
+      } else {
+        boards.push(...config.boards);
+      }
+      for (const board of boards) {
+        // Try exact UUID match via #d filter
+        const events = await fetchBoardEvents(board.id, taskId);
+        for (const event of events) {
+          const record = await parseDecryptedEvent(event, board.id, board.name);
+          if (record) return record;
+        }
+        // UUID prefix match: fetch all and scan
+        if (taskId.length < 36) {
+          const allEvents = await fetchBoardEvents(board.id);
+          const prefix = taskId.toLowerCase().slice(0, 8);
+          for (const event of allEvents) {
+            const dTag = event.tags.find((t) => t[0] === "d");
+            const dVal = (dTag?.[1] ?? "").toLowerCase();
+            if (dVal.startsWith(prefix)) {
+              const record = await parseDecryptedEvent(event, board.id, board.name);
+              if (record) return record;
+            }
+          }
+        }
+      }
+      return null;
+    },
+
+    async remindTask(taskId: string, presets: ReminderPreset[]): Promise<void> {
+      // Device-local only — NEVER publish to Nostr
+      const cfg = await loadConfig();
+      if (!cfg.taskReminders) cfg.taskReminders = {};
+      cfg.taskReminders[taskId] = presets;
+      await saveConfig(cfg);
+      process.stderr.write(
+        "\x1b[2m  Note: Reminders are device-local and will not sync to other devices\x1b[0m\n",
+      );
+    },
+
+    getLocalReminders(taskId: string): ReminderPreset[] {
+      return config.taskReminders?.[taskId] ?? [];
+    },
+
+    async getAgentSecurityConfig(): Promise<AgentSecurityConfig> {
+      const cfg = await loadConfig();
+      return {
+        enabled: cfg.securityEnabled,
+        mode: cfg.securityMode,
+        trustedNpubs: cfg.trustedNpubs,
+        updatedISO: nowISO(),
+      };
+    },
+
+    async setAgentSecurityConfig(secCfg: AgentSecurityConfig): Promise<AgentSecurityConfig> {
+      const cfg = await loadConfig();
+      cfg.securityEnabled = secCfg.enabled;
+      cfg.securityMode = secCfg.mode;
+      cfg.trustedNpubs = secCfg.trustedNpubs;
+      await saveConfig(cfg);
+      return secCfg;
+    },
+
+    async getRelayStatus(): Promise<{ url: string; connected: boolean }[]> {
+      await ensureConnected();
+      const results: { url: string; connected: boolean }[] = [];
+      for (const [url, relay] of ndk.pool.relays) {
+        const connected = relay.status === NDKRelayStatus.CONNECTED;
+        results.push({ url, connected });
+      }
+      // If pool is empty (no relays in map), fall back to config list as disconnected
+      if (results.length === 0) {
+        for (const url of config.relays) {
+          results.push({ url, connected: false });
+        }
+      }
+      return results;
+    },
+  };
+}

--- a/taskify-cli/src/render.ts
+++ b/taskify-cli/src/render.ts
@@ -74,7 +74,7 @@ function formatRec(task: FullTaskRecord): string {
 }
 
 function formatBounty(task: FullTaskRecord): string {
-  const b = task.bounty;
+  const b = task.bounty as Record<string, unknown> | undefined;
   if (!b || b.amount === undefined) return "";
   const amt = String(b.amount);
   switch (b.state) {
@@ -100,7 +100,16 @@ function formatRecurrenceFull(task: FullTaskRecord): string {
   }
 }
 
-const COL_HEADER = `${"ID".padEnd(8)}  ${"TITLE".padEnd(40)}  ${"DUE".padEnd(12)}  ${"PRI".padEnd(4)}  ${"REC".padEnd(5)}  ${"BOUNTY".padEnd(8)}  TRUST`;
+function formatAssignee(task: FullTaskRecord): string {
+  const assignees = task.assignees;
+  if (!Array.isArray(assignees) || assignees.length === 0) return "".padEnd(12);
+  const first = assignees[0];
+  const npub = toNpubSafe(first) ?? first;
+  const truncated = npub.length > 12 ? npub.slice(0, 9) + "..." : npub;
+  return truncated.padEnd(12);
+}
+
+const COL_HEADER = `${"ID".padEnd(8)}  ${"TITLE".padEnd(40)}  ${"DUE".padEnd(12)}  ${"PRI".padEnd(4)}  ${"REC".padEnd(5)}  ${"BOUNTY".padEnd(8)}  ${"ASSIGN".padEnd(12)}  TRUST`;
 
 export function renderTable(tasks: FullTaskRecord[], trustedNpubs: string[], columnName?: string): void {
   const byBoard = new Map<string, FullTaskRecord[]>();
@@ -127,8 +136,9 @@ export function renderTable(tasks: FullTaskRecord[], trustedNpubs: string[], col
       const pri = formatPri(task.priority);
       const rec = formatRec(task);
       const bounty = formatBounty(task).padEnd(8);
+      const assign = formatAssignee(task);
       const trust = trustLabel(task.lastEditedBy, trustedNpubs);
-      console.log(`${id}  ${title}  ${due}  ${pri}  ${rec}  ${bounty}  ${trust}`);
+      console.log(`${id}  ${title}  ${due}  ${pri}  ${rec}  ${bounty}  ${assign}  ${trust}`);
     }
   }
 }
@@ -173,13 +183,14 @@ export function renderTaskCard(task: FullTaskRecord, trustedNpubs: string[], loc
   }
 
   if (task.bounty) {
-    const b = task.bounty;
+    const b = task.bounty as Record<string, unknown>;
     console.log(`${lbl("Bounty:")}`);
     if (b.amount !== undefined) console.log(`  ${lbl("Amount:")}${b.amount}`);
     console.log(`  ${lbl("State:")}${b.state}`);
     if (b.lock) console.log(`  ${lbl("Lock:")}${b.lock}`);
     if (b.mint) {
-      const mintDisplay = b.mint.length > 40 ? b.mint.slice(0, 37) + "..." : b.mint;
+      const mint = String(b.mint);
+      const mintDisplay = mint.length > 40 ? mint.slice(0, 37) + "..." : mint;
       console.log(`  ${lbl("Mint:")}${mintDisplay}`);
     }
   }

--- a/taskify-cli/src/render.ts
+++ b/taskify-cli/src/render.ts
@@ -1,0 +1,204 @@
+import chalk from "chalk";
+import type { FullTaskRecord } from "./nostrRuntime.ts";
+import { nip19 } from "nostr-tools";
+import { TASK_PRIORITY_MARKS } from "./shared/taskTypes.ts";
+import type { ReminderPreset } from "./shared/taskTypes.ts";
+
+const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function toNpubSafe(hex: string): string | null {
+  // hex must be raw 32-byte (64-char) — encode directly, no prefix stripping
+  try { return nip19.npubEncode(hex); } catch { return null; }
+}
+
+function truncateNpub(raw: string | undefined): string {
+  if (!raw) return "unknown";
+  const npub = toNpubSafe(raw) ?? raw;
+  if (npub.length <= 16) return npub;
+  return npub.slice(0, 12) + "...";
+}
+
+function npubToHex(npubOrHex: string): string {
+  if (npubOrHex.startsWith("npub1")) {
+    try {
+      const decoded = nip19.decode(npubOrHex);
+      if (decoded.type === "npub") return decoded.data as string;
+    } catch { /* fall through */ }
+  }
+  return npubOrHex;
+}
+
+export function trustLabel(lastEditedBy: string | undefined, trustedNpubs: string[]): string {
+  if (!lastEditedBy) return chalk.yellow("? unknown");
+  // Normalize all trusted entries to raw hex for comparison
+  const trustedHexSet = new Set(trustedNpubs.map(npubToHex));
+  if (trustedHexSet.has(lastEditedBy)) return chalk.green("✓ trusted");
+  return chalk.red("✗ untrusted");
+}
+
+function truncateWithSubtasks(task: FullTaskRecord, titleLen: number): string {
+  const subtasks = task.subtasks;
+  let suffix = "";
+  if (Array.isArray(subtasks) && subtasks.length > 0) {
+    const done = subtasks.filter((s) => s.completed).length;
+    suffix = ` (${done}/${subtasks.length})`;
+  }
+  const available = titleLen - suffix.length;
+  let base = task.title;
+  if (base.length > available) {
+    base = base.slice(0, available - 1) + "…";
+  }
+  return (base + suffix).padEnd(titleLen);
+}
+
+function formatDue(dueISO: string): string {
+  if (!dueISO) return "".padEnd(12);
+  return dueISO.slice(0, 10).padEnd(12);
+}
+
+function formatPri(priority: number | undefined): string {
+  if (!priority) return "-".padEnd(4);
+  return String(priority).padEnd(4);
+}
+
+function formatRec(task: FullTaskRecord): string {
+  const rec = task.recurrence;
+  if (!rec || rec.type === "none") return "".padEnd(5);
+  switch (rec.type) {
+    case "daily": return "DAY  ";
+    case "weekly": return "WKL  ";
+    case "every": return "EVR  ";
+    case "monthlyDay": return "MON  ";
+    default: return "".padEnd(5);
+  }
+}
+
+function formatBounty(task: FullTaskRecord): string {
+  const b = task.bounty;
+  if (!b || b.amount === undefined) return "";
+  const amt = String(b.amount);
+  switch (b.state) {
+    case "claimed": return amt + "✓";
+    case "locked": return amt + "⏳";
+    case "revoked": return amt + "✗";
+    default: return amt;
+  }
+}
+
+function formatRecurrenceFull(task: FullTaskRecord): string {
+  const rec = task.recurrence;
+  if (!rec || rec.type === "none") return "";
+  switch (rec.type) {
+    case "daily": return "daily";
+    case "weekly": {
+      const days = (rec.days ?? []).map((d) => WEEKDAY_NAMES[d] ?? d).join(" ");
+      return `weekly ${days}`.trim();
+    }
+    case "every": return `every ${rec.n} ${rec.unit}`;
+    case "monthlyDay": return `monthlyDay ${rec.day}${rec.interval ? ` (every ${rec.interval})` : ""}`;
+    default: return "";
+  }
+}
+
+const COL_HEADER = `${"ID".padEnd(8)}  ${"TITLE".padEnd(40)}  ${"DUE".padEnd(12)}  ${"PRI".padEnd(4)}  ${"REC".padEnd(5)}  ${"BOUNTY".padEnd(8)}  TRUST`;
+
+export function renderTable(tasks: FullTaskRecord[], trustedNpubs: string[], columnName?: string): void {
+  const byBoard = new Map<string, FullTaskRecord[]>();
+  for (const task of tasks) {
+    const group = byBoard.get(task.boardId) ?? [];
+    group.push(task);
+    byBoard.set(task.boardId, group);
+  }
+
+  for (const [boardId, boardTasks] of byBoard) {
+    const boardName = boardTasks[0]?.boardName;
+    let boardHeader = boardName
+      ? `Board: ${boardName}  (${boardId.slice(0, 8)}...)`
+      : `Board: ${boardId}`;
+    if (columnName) {
+      boardHeader += `  •  Column: ${columnName}`;
+    }
+    console.log("\n" + chalk.bold(boardHeader));
+    console.log(chalk.dim(COL_HEADER));
+    for (const task of boardTasks) {
+      const id = task.id.slice(0, 8).padEnd(8);
+      const title = truncateWithSubtasks(task, 40);
+      const due = formatDue(task.dueISO);
+      const pri = formatPri(task.priority);
+      const rec = formatRec(task);
+      const bounty = formatBounty(task).padEnd(8);
+      const trust = trustLabel(task.lastEditedBy, trustedNpubs);
+      console.log(`${id}  ${title}  ${due}  ${pri}  ${rec}  ${bounty}  ${trust}`);
+    }
+  }
+}
+
+export function renderTaskCard(task: FullTaskRecord, trustedNpubs: string[], localReminders?: ReminderPreset[]): void {
+  const lbl = (s: string) => chalk.dim(s.padEnd(14));
+
+  console.log();
+  console.log(`${lbl("ID:")}${task.id.slice(0, 8)}`);
+  console.log(`${lbl("Board:")}${task.boardId}`);
+  console.log(`${lbl("Title:")}${task.title}`);
+  if (task.note) {
+    console.log(`${lbl("Note:")}${task.note}`);
+  }
+  if (task.dueISO) {
+    console.log(`${lbl("Due:")}${task.dueISO.slice(0, 10)}`);
+  }
+  if (task.priority) {
+    const mark = TASK_PRIORITY_MARKS[task.priority] ?? String(task.priority);
+    console.log(`${lbl("Priority:")}${mark} (${task.priority})`);
+  }
+  const statusStr = task.completed
+    ? `done  (completed ${task.completedAt ? task.completedAt.slice(0, 10) : "?"})`
+    : "open";
+  console.log(`${lbl("Status:")}${task.completed ? chalk.green(statusStr) : statusStr}`);
+
+  const recStr = formatRecurrenceFull(task);
+  if (recStr) {
+    console.log(`${lbl("Recurrence:")}${recStr}`);
+  }
+
+  if (localReminders && localReminders.length > 0) {
+    console.log(`${lbl("Reminders:")}(device-local) ${localReminders.join(", ")}`);
+  }
+
+  if (task.subtasks && task.subtasks.length > 0) {
+    console.log(`${lbl("Subtasks:")}`);
+    task.subtasks.forEach((s, i) => {
+      const check = s.completed ? "x" : " ";
+      console.log(`  [${i + 1}] [${check}] ${s.title}`);
+    });
+  }
+
+  if (task.bounty) {
+    const b = task.bounty;
+    console.log(`${lbl("Bounty:")}`);
+    if (b.amount !== undefined) console.log(`  ${lbl("Amount:")}${b.amount}`);
+    console.log(`  ${lbl("State:")}${b.state}`);
+    if (b.lock) console.log(`  ${lbl("Lock:")}${b.lock}`);
+    if (b.mint) {
+      const mintDisplay = b.mint.length > 40 ? b.mint.slice(0, 37) + "..." : b.mint;
+      console.log(`  ${lbl("Mint:")}${mintDisplay}`);
+    }
+  }
+
+  const createdByDisplay = truncateNpub(task.createdBy);
+  console.log(`${lbl("Created by:")}${createdByDisplay}`);
+
+  const editedByDisplay = truncateNpub(task.lastEditedBy);
+  const trust = trustLabel(task.lastEditedBy, trustedNpubs);
+  console.log(`${lbl("Edited by:")}${editedByDisplay}  ${trust}`);
+
+  if (task.createdAt) {
+    const d = new Date(task.createdAt * 1000);
+    const dateStr = d.toISOString().slice(0, 16).replace("T", " ");
+    console.log(`${lbl("Created at:")}${dateStr}`);
+  }
+  console.log();
+}
+
+export function renderJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}

--- a/taskify-cli/src/shared/agentDispatcher.ts
+++ b/taskify-cli/src/shared/agentDispatcher.ts
@@ -1,0 +1,837 @@
+import { toNpub } from "./nostr.ts";
+import { getAgentIdempotencyStore } from "./agentIdempotency.ts";
+import {
+  addTrustedNpub,
+  annotateTrust,
+  clearTrustedNpubs,
+  getEffectiveAgentSecurityMode,
+  isLooselyValidTrustedNpub,
+  removeTrustedNpub,
+  summarizeTrustCounts,
+  type AgentSecurityConfig,
+} from "./agentSecurity.ts";
+import {
+  getAgentRuntime,
+  type AgentTaskRecord,
+  type AgentTaskCreateInput,
+  type AgentTaskPatchInput,
+  type AgentTaskStatus,
+} from "./agentRuntime.ts";
+
+type AgentErrorCode =
+  | "PARSE_JSON"
+  | "VALIDATION"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "FORBIDDEN"
+  | "INTERNAL";
+
+type AgentProtocolVersion = number;
+
+type MetaHelpCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "meta.help";
+  params: Record<string, never>;
+};
+
+type TaskCreateCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "task.create";
+  params: {
+    title: string;
+    note?: string;
+    boardId?: string;
+    dueISO?: string;
+    priority?: 1 | 2 | 3;
+    idempotencyKey?: string;
+  };
+};
+
+type TaskUpdateCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "task.update";
+  params: {
+    taskId: string;
+    patch: {
+      title?: string;
+      note?: string;
+      dueISO?: string | null;
+      priority?: 1 | 2 | 3 | null;
+    };
+  };
+};
+
+type TaskSetStatusCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "task.setStatus";
+  params: {
+    taskId: string;
+    status: AgentTaskStatus;
+  };
+};
+
+type TaskListCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "task.list";
+  params: {
+    boardId?: string;
+    status?: "open" | "done" | "any";
+    query?: string;
+    limit?: number;
+    cursor?: string;
+  };
+};
+
+type TaskGetCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "task.get";
+  params: {
+    taskId: string;
+  };
+};
+
+type AgentSecurityGetCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.security.get";
+  params: Record<string, never>;
+};
+
+type AgentSecuritySetCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.security.set";
+  params: {
+    enabled?: boolean;
+    mode?: "off" | "moderate" | "strict";
+  };
+};
+
+type AgentTrustAddCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.trust.add";
+  params: {
+    npub: string;
+  };
+};
+
+type AgentTrustRemoveCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.trust.remove";
+  params: {
+    npub: string;
+  };
+};
+
+type AgentTrustListCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.trust.list";
+  params: Record<string, never>;
+};
+
+type AgentTrustClearCommand = {
+  v: AgentProtocolVersion;
+  id: string;
+  op: "agent.trust.clear";
+  params: Record<string, never>;
+};
+
+export type AgentCommandV1 =
+  | MetaHelpCommand
+  | TaskCreateCommand
+  | TaskUpdateCommand
+  | TaskSetStatusCommand
+  | TaskListCommand
+  | TaskGetCommand
+  | AgentSecurityGetCommand
+  | AgentSecuritySetCommand
+  | AgentTrustAddCommand
+  | AgentTrustRemoveCommand
+  | AgentTrustListCommand
+  | AgentTrustClearCommand;
+
+export type AgentResponseV1 = {
+  v: AgentProtocolVersion;
+  id: string | null;
+  ok: boolean;
+  result: Record<string, unknown> | null;
+  error: {
+    code: AgentErrorCode;
+    message: string;
+    details?: Record<string, string>;
+  } | null;
+};
+
+type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; details: Record<string, string>; id: string | null; version: AgentProtocolVersion };
+
+type AgentTaskSummary = {
+  id: string;
+  title: string;
+  note: string;
+  boardId: string;
+  status: "open" | "done";
+  dueISO: string | null;
+  priority: number | null;
+  updatedISO: string;
+  createdByNpub: string | null;
+  lastEditedByNpub: string | null;
+  provenance: "trusted" | "untrusted" | "unknown";
+  trusted: boolean;
+  agentSafe: boolean;
+};
+
+function success(
+  id: string | null,
+  result: Record<string, unknown>,
+  version: AgentProtocolVersion = 1,
+): AgentResponseV1 {
+  return { v: version, id, ok: true, result, error: null };
+}
+
+function failure(
+  id: string | null,
+  code: AgentErrorCode,
+  message: string,
+  details?: Record<string, string>,
+  version: AgentProtocolVersion = 1,
+): AgentResponseV1 {
+  return {
+    v: version,
+    id,
+    ok: false,
+    result: null,
+    error: {
+      code,
+      message,
+      ...(details && Object.keys(details).length ? { details } : {}),
+    },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseIsoString(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const time = Date.parse(value);
+  if (Number.isNaN(time)) return undefined;
+  return new Date(time).toISOString();
+}
+
+function toUpdatedISO(task: AgentTaskRecord): string {
+  const rawUpdatedAt = (task as any).updatedAt;
+  if (typeof rawUpdatedAt === "string" && !Number.isNaN(Date.parse(rawUpdatedAt))) {
+    return new Date(rawUpdatedAt).toISOString();
+  }
+  if (typeof task.completedAt === "string" && !Number.isNaN(Date.parse(task.completedAt))) {
+    return new Date(task.completedAt).toISOString();
+  }
+  if (typeof task.createdAt === "number" && Number.isFinite(task.createdAt)) {
+    return new Date(task.createdAt).toISOString();
+  }
+  if (typeof task.dueISO === "string" && !Number.isNaN(Date.parse(task.dueISO))) {
+    return new Date(task.dueISO).toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+function toNullableDueISO(task: AgentTaskRecord): string | null {
+  if (task.dueDateEnabled === false) return null;
+  if (typeof task.dueISO === "string" && !Number.isNaN(Date.parse(task.dueISO))) {
+    return new Date(task.dueISO).toISOString();
+  }
+  return null;
+}
+
+function buildTaskBaseSummary(task: AgentTaskRecord) {
+  return {
+    id: task.id,
+    title: task.title,
+    note: task.note ?? "",
+    boardId: task.boardId,
+    status: task.completed ? "done" : "open",
+    dueISO: toNullableDueISO(task),
+    priority: task.priority ?? null,
+    updatedISO: toUpdatedISO(task),
+    createdByNpub: toNpub(task.createdBy ?? null),
+    lastEditedByNpub: toNpub(task.lastEditedBy ?? null),
+  };
+}
+
+function encodeCursor(offset: number): string {
+  const payload = JSON.stringify({ offset });
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(payload, "utf8").toString("base64");
+  }
+  return btoa(payload);
+}
+
+function decodeCursor(cursor: string): number | null {
+  try {
+    const decoded =
+      typeof Buffer !== "undefined"
+        ? Buffer.from(cursor, "base64").toString("utf8")
+        : atob(cursor);
+    const parsed = JSON.parse(decoded);
+    if (!isPlainObject(parsed)) return null;
+    const offset = parsed.offset;
+    return typeof offset === "number" && Number.isInteger(offset) && offset >= 0 ? offset : null;
+  } catch {
+    return null;
+  }
+}
+
+function requireString(
+  source: Record<string, unknown>,
+  field: string,
+  details: Record<string, string>,
+  options?: { allowEmpty?: boolean },
+): string | undefined {
+  const value = source[field];
+  if (typeof value !== "string") {
+    details[`params.${field}`] = "Expected string";
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!options?.allowEmpty && !trimmed) {
+    details[`params.${field}`] = "Required";
+    return undefined;
+  }
+  return trimmed;
+}
+
+function parseProtocolVersion(value: unknown): AgentProtocolVersion | null {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    const parsed = Number(value.trim());
+    if (Number.isInteger(parsed) && parsed >= 1) return parsed;
+  }
+  return null;
+}
+
+function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
+  if (!isPlainObject(raw)) {
+    return { ok: false, details: { root: "Expected a JSON object" }, id: null, version: 1 };
+  }
+
+  const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : null;
+  const version = parseProtocolVersion(raw.v ?? (raw as any).version);
+  const details: Record<string, string> = {};
+
+  if (version === null) details.v = "Expected positive integer version";
+  if (!id) details.id = "Required string";
+  if (typeof raw.op !== "string" || !raw.op.trim()) details.op = "Required string";
+  if (!isPlainObject(raw.params)) details.params = "Expected object";
+
+  if (Object.keys(details).length > 0) {
+    return { ok: false, details, id, version: version ?? 1 };
+  }
+
+  const op = String(raw.op).trim();
+  const params = raw.params as Record<string, unknown>;
+
+  switch (op) {
+    case "meta.help":
+    case "agent.security.get":
+    case "agent.trust.list":
+    case "agent.trust.clear":
+      return {
+        ok: true,
+        value: { v: version!, id: id!, op, params: {} } as AgentCommandV1,
+      };
+
+    case "task.create": {
+      const nextDetails: Record<string, string> = {};
+      const title = requireString(params, "title", nextDetails);
+      const note =
+        params.note === undefined
+          ? ""
+          : typeof params.note === "string"
+            ? params.note
+            : (nextDetails["params.note"] = "Expected string", "");
+      const boardId =
+        params.boardId === undefined
+          ? undefined
+          : typeof params.boardId === "string" && params.boardId.trim()
+            ? params.boardId.trim()
+            : (nextDetails["params.boardId"] = "Expected string", undefined);
+      const dueISO =
+        params.dueISO === undefined
+          ? undefined
+          : parseIsoString(params.dueISO) ?? (nextDetails["params.dueISO"] = "Expected ISO 8601 string", undefined);
+      const priority =
+        params.priority === undefined
+          ? undefined
+          : params.priority === 1 || params.priority === 2 || params.priority === 3
+            ? params.priority
+            : (nextDetails["params.priority"] = "Expected number 1-3", undefined);
+      const idempotencyKey =
+        params.idempotencyKey === undefined
+          ? undefined
+          : typeof params.idempotencyKey === "string" && params.idempotencyKey.trim()
+            ? params.idempotencyKey.trim()
+            : (nextDetails["params.idempotencyKey"] = "Expected string", undefined);
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: {
+          v: version!,
+          id: id!,
+          op,
+          params: { title: title!, note, ...(boardId ? { boardId } : {}), ...(dueISO ? { dueISO } : {}), ...(priority ? { priority } : {}), ...(idempotencyKey ? { idempotencyKey } : {}) },
+        } as AgentCommandV1,
+      };
+    }
+
+    case "task.update": {
+      const nextDetails: Record<string, string> = {};
+      const taskId = requireString(params, "taskId", nextDetails);
+      if (!isPlainObject(params.patch)) {
+        nextDetails["params.patch"] = "Expected object";
+        return { ok: false, details: nextDetails, id };
+      }
+      const rawPatch = params.patch as Record<string, unknown>;
+      const patch: AgentTaskPatchInput = {};
+      if (rawPatch.title !== undefined) {
+        if (typeof rawPatch.title === "string" && rawPatch.title.trim()) patch.title = rawPatch.title.trim();
+        else nextDetails["params.patch.title"] = "Expected non-empty string";
+      }
+      if (rawPatch.note !== undefined) {
+        if (typeof rawPatch.note === "string") patch.note = rawPatch.note;
+        else nextDetails["params.patch.note"] = "Expected string";
+      }
+      if (rawPatch.dueISO !== undefined) {
+        if (rawPatch.dueISO === null) patch.dueISO = null;
+        else {
+          const dueISO = parseIsoString(rawPatch.dueISO);
+          if (dueISO) patch.dueISO = dueISO;
+          else nextDetails["params.patch.dueISO"] = "Expected ISO 8601 string or null";
+        }
+      }
+      if (rawPatch.priority !== undefined) {
+        if (rawPatch.priority === null) patch.priority = null;
+        else if (rawPatch.priority === 1 || rawPatch.priority === 2 || rawPatch.priority === 3) patch.priority = rawPatch.priority;
+        else nextDetails["params.patch.priority"] = "Expected number 1-3 or null";
+      }
+      if (Object.keys(patch).length === 0) {
+        nextDetails["params.patch"] = "At least one patch field is required";
+      }
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: {
+          v: version!,
+          id: id!,
+          op,
+          params: { taskId: taskId!, patch },
+        } as AgentCommandV1,
+      };
+    }
+
+    case "task.setStatus": {
+      const nextDetails: Record<string, string> = {};
+      const taskId = requireString(params, "taskId", nextDetails);
+      const status =
+        params.status === "open" || params.status === "done"
+          ? params.status
+          : (nextDetails["params.status"] = 'Expected "open" or "done"', undefined);
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: {
+          v: version!,
+          id: id!,
+          op,
+          params: { taskId: taskId!, status: status as AgentTaskStatus },
+        } as AgentCommandV1,
+      };
+    }
+
+    case "task.list": {
+      const nextDetails: Record<string, string> = {};
+      const boardId =
+        params.boardId === undefined
+          ? undefined
+          : typeof params.boardId === "string" && params.boardId.trim()
+            ? params.boardId.trim()
+            : (nextDetails["params.boardId"] = "Expected string", undefined);
+      const status =
+        params.status === undefined
+          ? "open"
+          : params.status === "open" || params.status === "done" || params.status === "any"
+            ? params.status
+            : (nextDetails["params.status"] = 'Expected "open", "done", or "any"', "open");
+      const query =
+        params.query === undefined
+          ? undefined
+          : typeof params.query === "string" && params.query.trim()
+            ? params.query.trim()
+            : (nextDetails["params.query"] = "Expected non-empty string", undefined);
+      const limit =
+        params.limit === undefined
+          ? 50
+          : typeof params.limit === "number" && Number.isInteger(params.limit) && params.limit >= 1
+            ? Math.min(200, params.limit)
+            : (nextDetails["params.limit"] = "Expected integer 1-200", 50);
+      const cursor =
+        params.cursor === undefined
+          ? undefined
+          : typeof params.cursor === "string" && params.cursor.trim()
+            ? params.cursor.trim()
+            : (nextDetails["params.cursor"] = "Expected string", undefined);
+      if (cursor && decodeCursor(cursor) === null) {
+        nextDetails["params.cursor"] = "Invalid cursor";
+      }
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: {
+          v: version!,
+          id: id!,
+          op,
+          params: {
+            ...(boardId ? { boardId } : {}),
+            status,
+            ...(query ? { query } : {}),
+            limit,
+            ...(cursor ? { cursor } : {}),
+          },
+        } as AgentCommandV1,
+      };
+    }
+
+    case "task.get": {
+      const nextDetails: Record<string, string> = {};
+      const taskId = requireString(params, "taskId", nextDetails);
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: { v: version!, id: id!, op, params: { taskId: taskId! } } as AgentCommandV1,
+      };
+    }
+
+    case "agent.security.set": {
+      const nextDetails: Record<string, string> = {};
+      const nextParams: Record<string, unknown> = {};
+      if (params.enabled !== undefined) {
+        if (typeof params.enabled === "boolean") nextParams.enabled = params.enabled;
+        else nextDetails["params.enabled"] = "Expected boolean";
+      }
+      if (params.mode !== undefined) {
+        if (params.mode === "off" || params.mode === "moderate" || params.mode === "strict") nextParams.mode = params.mode;
+        else nextDetails["params.mode"] = 'Expected "off", "moderate", or "strict"';
+      }
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: { v: version!, id: id!, op, params: nextParams } as AgentCommandV1,
+      };
+    }
+
+    case "agent.trust.add":
+    case "agent.trust.remove": {
+      const nextDetails: Record<string, string> = {};
+      const npub = requireString(params, "npub", nextDetails);
+      if (npub && !isLooselyValidTrustedNpub(npub)) {
+        nextDetails["params.npub"] = 'Expected string starting with "npub1"';
+      }
+      if (Object.keys(nextDetails).length > 0) {
+        return { ok: false, details: nextDetails, id };
+      }
+      return {
+        ok: true,
+        value: { v: version!, id: id!, op, params: { npub: npub!.toLowerCase() } } as AgentCommandV1,
+      };
+    }
+
+    default:
+      return {
+        ok: false,
+        details: { op: "Unsupported operation" },
+        id,
+        version: version ?? 1,
+      };
+  }
+}
+
+function buildHelpResult(): Record<string, unknown> {
+  return {
+    ops: [
+      { op: "meta.help", paramsSchema: {} },
+      { op: "task.create", paramsSchema: { title: "string (required)", note: "string (optional)", boardId: "string (optional)", dueISO: "ISO 8601 string (optional)", priority: "number 1-3 (optional)", idempotencyKey: "string (optional)" } },
+      { op: "task.update", paramsSchema: { taskId: "string (required)", patch: { title: "string (optional)", note: "string (optional)", dueISO: "ISO 8601 string|null (optional)", priority: "1|2|3|null (optional)" } } },
+      { op: "task.setStatus", paramsSchema: { taskId: "string (required)", status: '"open"|"done" (required)' } },
+      { op: "task.list", paramsSchema: { boardId: "string (optional)", status: '"open"|"done"|"any" (optional, default "open")', query: "string (optional)", limit: "number 1-200 (optional, default 50)", cursor: "string (optional)" } },
+      { op: "task.get", paramsSchema: { taskId: "string (required)" } },
+      { op: "agent.security.get", paramsSchema: {} },
+      { op: "agent.security.set", paramsSchema: { enabled: "boolean (optional)", mode: '"off"|"moderate"|"strict" (optional)' } },
+      { op: "agent.trust.add", paramsSchema: { npub: 'string starting with "npub1" (required)' } },
+      { op: "agent.trust.remove", paramsSchema: { npub: 'string starting with "npub1" (required)' } },
+      { op: "agent.trust.list", paramsSchema: {} },
+      { op: "agent.trust.clear", paramsSchema: {} },
+    ],
+  };
+}
+
+async function getSecurityConfig(runtime: NonNullable<ReturnType<typeof getAgentRuntime>>): Promise<AgentSecurityConfig> {
+  return await runtime.getAgentSecurityConfig();
+}
+
+function summarizeTaskWithTrust(task: AgentTaskRecord, securityConfig: AgentSecurityConfig): AgentTaskSummary {
+  return annotateTrust(buildTaskBaseSummary(task), securityConfig);
+}
+
+function maybeForbidStrictSingleItem<T extends AgentTaskSummary>(
+  item: T,
+  securityConfig: AgentSecurityConfig,
+  id: string,
+  version: AgentProtocolVersion,
+): AgentResponseV1 | null {
+  if (getEffectiveAgentSecurityMode(securityConfig) === "strict" && !item.trusted) {
+    return failure(id, "FORBIDDEN", "Item is not trusted in strict mode", undefined, version);
+  }
+  return null;
+}
+
+export async function dispatchAgentCommand(raw: string): Promise<AgentResponseV1> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return failure(null, "PARSE_JSON", "Invalid JSON");
+  }
+
+  if (Array.isArray(parsed)) {
+    return failure(null, "VALIDATION", "Expected a single JSON object", { root: "Arrays are not supported" });
+  }
+
+  const validated = validateCommand(parsed);
+  if (!validated.ok) {
+    return failure(validated.id, "VALIDATION", "Command validation failed", validated.details, validated.version);
+  }
+
+  const command = validated.value;
+  const runtime = getAgentRuntime();
+  if (!runtime) {
+    return failure(command.id, "INTERNAL", "Agent runtime is not available", undefined, command.v);
+  }
+
+  try {
+    switch (command.op) {
+      case "meta.help":
+        return success(command.id, buildHelpResult(), command.v);
+
+      case "task.create": {
+        const { title, note = "", dueISO, priority, idempotencyKey } = command.params;
+        const boardId = command.params.boardId ?? runtime.getDefaultBoardId() ?? "inbox";
+        const idempotencyStore = getAgentIdempotencyStore();
+
+        if (idempotencyKey) {
+          const existingTaskId = await idempotencyStore.get(idempotencyKey);
+          if (existingTaskId) {
+            const existingTask = await runtime.getTask(existingTaskId);
+            if (existingTask) {
+              const securityConfig = await getSecurityConfig(runtime);
+              return success(command.id, {
+                taskId: existingTask.id,
+                task: summarizeTaskWithTrust(existingTask, securityConfig),
+              }, command.v);
+            }
+          }
+        }
+
+        const createdTask = await runtime.createTask({
+          title,
+          note,
+          boardId,
+          ...(dueISO ? { dueISO } : {}),
+          ...(priority ? { priority } : {}),
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        } satisfies AgentTaskCreateInput);
+        if (idempotencyKey) {
+          await idempotencyStore.set(idempotencyKey, createdTask.id);
+        }
+        const securityConfig = await getSecurityConfig(runtime);
+        return success(command.id, {
+          taskId: createdTask.id,
+          task: summarizeTaskWithTrust(createdTask, securityConfig),
+        }, command.v);
+      }
+
+      case "task.update": {
+        const updatedTask = await runtime.updateTask(command.params.taskId, command.params.patch);
+        if (!updatedTask) {
+          return failure(command.id, "NOT_FOUND", "Task not found", undefined, command.v);
+        }
+        const securityConfig = await getSecurityConfig(runtime);
+        return success(command.id, { task: summarizeTaskWithTrust(updatedTask, securityConfig) }, command.v);
+      }
+
+      case "task.setStatus": {
+        const updatedTask = await runtime.setTaskStatus(command.params.taskId, command.params.status);
+        if (!updatedTask) {
+          return failure(command.id, "NOT_FOUND", "Task not found", undefined, command.v);
+        }
+        const securityConfig = await getSecurityConfig(runtime);
+        return success(command.id, { task: summarizeTaskWithTrust(updatedTask, securityConfig) }, command.v);
+      }
+
+      case "task.list": {
+        const securityConfig = await getSecurityConfig(runtime);
+        const tasks = await runtime.listTasks({
+          ...(command.params.boardId ? { boardId: command.params.boardId } : {}),
+          status: command.params.status ?? "open",
+        });
+
+        const sorted = [...tasks].sort((left, right) => {
+          const leftUpdated = toUpdatedISO(left);
+          const rightUpdated = toUpdatedISO(right);
+          if (leftUpdated !== rightUpdated) return rightUpdated.localeCompare(leftUpdated);
+          return left.id.localeCompare(right.id);
+        });
+
+        const annotatedAll = sorted.map((task) => summarizeTaskWithTrust(task, securityConfig));
+        const query = command.params.query?.toLowerCase();
+        const queryFiltered = query
+          ? annotatedAll.filter((item) => {
+            const haystack = `${item.title}\n${item.note}`.toLowerCase();
+            return haystack.includes(query);
+          })
+          : annotatedAll;
+        const filtered = getEffectiveAgentSecurityMode(securityConfig) === "strict"
+          ? queryFiltered.filter((item) => item.trusted)
+          : queryFiltered;
+        const offset = command.params.cursor ? decodeCursor(command.params.cursor) ?? 0 : 0;
+        const limit = command.params.limit ?? 50;
+        const items = filtered.slice(offset, offset + limit);
+        const nextOffset = offset + items.length;
+        const nextCursor = nextOffset < filtered.length ? encodeCursor(nextOffset) : null;
+        return success(command.id, {
+          items,
+          nextCursor,
+          counts: summarizeTrustCounts(filtered, items.length),
+        }, command.v);
+      }
+
+      case "task.get": {
+        const task = await runtime.getTask(command.params.taskId);
+        if (!task) {
+          return failure(command.id, "NOT_FOUND", "Task not found", undefined, command.v);
+        }
+        const securityConfig = await getSecurityConfig(runtime);
+        const summary = summarizeTaskWithTrust(task, securityConfig);
+        const strictError = maybeForbidStrictSingleItem(summary, securityConfig, command.id, command.v);
+        if (strictError) return strictError;
+        return success(command.id, { task: summary }, command.v);
+      }
+
+      case "agent.security.get": {
+        const config = await getSecurityConfig(runtime);
+        return success(command.id, {
+          enabled: config.enabled,
+          mode: config.mode,
+          trustedNpubs: config.trustedNpubs,
+          updatedISO: config.updatedISO,
+        }, command.v);
+      }
+
+      case "agent.security.set": {
+        const current = await getSecurityConfig(runtime);
+        const next = {
+          enabled: command.params.enabled ?? current.enabled,
+          mode: command.params.mode ?? current.mode,
+          trustedNpubs: current.trustedNpubs,
+          updatedISO: new Date().toISOString(),
+        } satisfies AgentSecurityConfig;
+        const saved = await runtime.setAgentSecurityConfig(next);
+        return success(command.id, {
+          enabled: saved.enabled,
+          mode: saved.mode,
+          trustedNpubs: saved.trustedNpubs,
+          updatedISO: saved.updatedISO,
+        }, command.v);
+      }
+
+      case "agent.trust.add": {
+        const current = await getSecurityConfig(runtime);
+        const saved = await runtime.setAgentSecurityConfig(addTrustedNpub(current, command.params.npub));
+        return success(command.id, {
+          enabled: saved.enabled,
+          mode: saved.mode,
+          trustedNpubs: saved.trustedNpubs,
+          updatedISO: saved.updatedISO,
+        }, command.v);
+      }
+
+      case "agent.trust.remove": {
+        const current = await getSecurityConfig(runtime);
+        const saved = await runtime.setAgentSecurityConfig(removeTrustedNpub(current, command.params.npub));
+        return success(command.id, {
+          enabled: saved.enabled,
+          mode: saved.mode,
+          trustedNpubs: saved.trustedNpubs,
+          updatedISO: saved.updatedISO,
+        }, command.v);
+      }
+
+      case "agent.trust.list": {
+        const config = await getSecurityConfig(runtime);
+        return success(command.id, { trustedNpubs: config.trustedNpubs }, command.v);
+      }
+
+      case "agent.trust.clear": {
+        const current = await getSecurityConfig(runtime);
+        const saved = await runtime.setAgentSecurityConfig(clearTrustedNpubs(current));
+        return success(command.id, {
+          enabled: saved.enabled,
+          mode: saved.mode,
+          trustedNpubs: saved.trustedNpubs,
+          updatedISO: saved.updatedISO,
+        }, command.v);
+      }
+
+      default:
+        return failure(command.id, "VALIDATION", "Unsupported operation", { op: "Unsupported operation" }, command.v);
+    }
+  } catch (error: any) {
+    const code = error?.code;
+    const message = typeof error?.message === "string" && error.message ? error.message : "Internal error";
+    if (
+      code === "PARSE_JSON"
+      || code === "VALIDATION"
+      || code === "NOT_FOUND"
+      || code === "CONFLICT"
+      || code === "FORBIDDEN"
+      || code === "INTERNAL"
+    ) {
+      return failure(command.id, code, message, undefined, command.v);
+    }
+    return failure(command.id, "INTERNAL", message, undefined, command.v);
+  }
+}

--- a/taskify-cli/src/shared/agentDispatcher.ts
+++ b/taskify-cli/src/shared/agentDispatcher.ts
@@ -261,7 +261,7 @@ function buildTaskBaseSummary(task: AgentTaskRecord) {
     title: task.title,
     note: task.note ?? "",
     boardId: task.boardId,
-    status: task.completed ? "done" : "open",
+    status: (task.completed ? "done" : "open") as "open" | "done",
     dueISO: toNullableDueISO(task),
     priority: task.priority ?? null,
     updatedISO: toUpdatedISO(task),
@@ -386,7 +386,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
             ? params.idempotencyKey.trim()
             : (nextDetails["params.idempotencyKey"] = "Expected string", undefined);
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -404,7 +404,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
       const taskId = requireString(params, "taskId", nextDetails);
       if (!isPlainObject(params.patch)) {
         nextDetails["params.patch"] = "Expected object";
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       const rawPatch = params.patch as Record<string, unknown>;
       const patch: AgentTaskPatchInput = {};
@@ -433,7 +433,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
         nextDetails["params.patch"] = "At least one patch field is required";
       }
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -454,7 +454,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
           ? params.status
           : (nextDetails["params.status"] = 'Expected "open" or "done"', undefined);
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -503,7 +503,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
         nextDetails["params.cursor"] = "Invalid cursor";
       }
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -526,7 +526,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
       const nextDetails: Record<string, string> = {};
       const taskId = requireString(params, "taskId", nextDetails);
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -546,7 +546,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
         else nextDetails["params.mode"] = 'Expected "off", "moderate", or "strict"';
       }
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -562,7 +562,7 @@ function validateCommand(raw: unknown): ValidationResult<AgentCommandV1> {
         nextDetails["params.npub"] = 'Expected string starting with "npub1"';
       }
       if (Object.keys(nextDetails).length > 0) {
-        return { ok: false, details: nextDetails, id };
+        return { ok: false, details: nextDetails, id, version: version ?? 1 };
       }
       return {
         ok: true,
@@ -816,8 +816,10 @@ export async function dispatchAgentCommand(raw: string): Promise<AgentResponseV1
         }, command.v);
       }
 
-      default:
-        return failure(command.id, "VALIDATION", "Unsupported operation", { op: "Unsupported operation" }, command.v);
+      default: {
+        const _cmd = command as unknown as { id: string; v: number };
+        return failure(_cmd.id, "VALIDATION", "Unsupported operation", { op: "Unsupported operation" }, _cmd.v);
+      }
     }
   } catch (error: any) {
     const code = error?.code;

--- a/taskify-cli/src/shared/agentIdempotency.ts
+++ b/taskify-cli/src/shared/agentIdempotency.ts
@@ -1,0 +1,68 @@
+// CLI-adapted version of agentIdempotency.ts (in-memory + file-based persistence)
+
+export const AGENT_IDEMPOTENCY_STORAGE_KEY = "taskify.agent.idempotency.v1";
+const MAX_AGENT_IDEMPOTENCY_ENTRIES = 100;
+const AGENT_IDEMPOTENCY_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type AgentIdempotencyEntry = {
+  key: string;
+  taskId: string;
+  createdAt: number;
+};
+
+export type AgentIdempotencyStore = {
+  get(key: string): Promise<string | null>;
+  set(key: string, taskId: string): Promise<void>;
+};
+
+function normalizeIdempotencyKey(value: string): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+// In-memory store for CLI use
+const inMemoryEntries: Map<string, AgentIdempotencyEntry> = new Map();
+
+const inMemoryIdempotencyStore: AgentIdempotencyStore = {
+  async get(key: string) {
+    const normalizedKey = normalizeIdempotencyKey(key);
+    if (!normalizedKey) return null;
+    const entry = inMemoryEntries.get(normalizedKey);
+    if (!entry) return null;
+    if (Date.now() - entry.createdAt >= AGENT_IDEMPOTENCY_TTL_MS) {
+      inMemoryEntries.delete(normalizedKey);
+      return null;
+    }
+    return entry.taskId;
+  },
+
+  async set(key: string, taskId: string) {
+    const normalizedKey = normalizeIdempotencyKey(key);
+    const normalizedTaskId = typeof taskId === "string" ? taskId.trim() : "";
+    if (!normalizedKey || !normalizedTaskId) return;
+
+    inMemoryEntries.set(normalizedKey, {
+      key: normalizedKey,
+      taskId: normalizedTaskId,
+      createdAt: Date.now(),
+    });
+
+    // Trim to max entries (keep newest)
+    if (inMemoryEntries.size > MAX_AGENT_IDEMPOTENCY_ENTRIES) {
+      const sorted = Array.from(inMemoryEntries.values()).sort((a, b) => a.createdAt - b.createdAt);
+      const toRemove = sorted.slice(0, inMemoryEntries.size - MAX_AGENT_IDEMPOTENCY_ENTRIES);
+      for (const entry of toRemove) {
+        inMemoryEntries.delete(entry.key);
+      }
+    }
+  },
+};
+
+let currentAgentIdempotencyStore: AgentIdempotencyStore = inMemoryIdempotencyStore;
+
+export function getAgentIdempotencyStore(): AgentIdempotencyStore {
+  return currentAgentIdempotencyStore;
+}
+
+export function setAgentIdempotencyStore(store: AgentIdempotencyStore | null | undefined): void {
+  currentAgentIdempotencyStore = store ?? inMemoryIdempotencyStore;
+}

--- a/taskify-cli/src/shared/agentRuntime.ts
+++ b/taskify-cli/src/shared/agentRuntime.ts
@@ -27,6 +27,7 @@ export type AgentTaskCreateInput = {
   priority?: 1 | 2 | 3;
   columnId?: string;
   idempotencyKey?: string;
+  assignees?: string[];
 };
 
 export type AgentTaskPatchInput = {
@@ -35,6 +36,8 @@ export type AgentTaskPatchInput = {
   dueISO?: string | null;
   priority?: 1 | 2 | 3 | null;
   columnId?: string | null;
+  inboxItem?: boolean;
+  assignees?: string[];
 };
 
 export type AgentRuntime = {

--- a/taskify-cli/src/shared/agentRuntime.ts
+++ b/taskify-cli/src/shared/agentRuntime.ts
@@ -1,0 +1,61 @@
+import type { AgentSecurityConfig } from "./agentSecurity.ts";
+
+export type AgentTaskRecord = {
+  id: string;
+  boardId: string;
+  title: string;
+  note?: string;
+  dueISO: string;
+  dueDateEnabled?: boolean;
+  dueTimeEnabled?: boolean;
+  completed?: boolean;
+  completedAt?: string;
+  createdAt?: number;
+  updatedAt?: string;
+  priority?: 1 | 2 | 3;
+  createdBy?: string;
+  lastEditedBy?: string;
+};
+
+export type AgentTaskStatus = "open" | "done";
+
+export type AgentTaskCreateInput = {
+  title: string;
+  note: string;
+  boardId: string;
+  dueISO?: string;
+  priority?: 1 | 2 | 3;
+  columnId?: string;
+  idempotencyKey?: string;
+};
+
+export type AgentTaskPatchInput = {
+  title?: string;
+  note?: string;
+  dueISO?: string | null;
+  priority?: 1 | 2 | 3 | null;
+  columnId?: string | null;
+};
+
+export type AgentRuntime = {
+  getDefaultBoardId(): string | null;
+  getTask(taskId: string): Promise<AgentTaskRecord | null> | AgentTaskRecord | null;
+  listTasks(
+    options: { boardId?: string; status: "open" | "done" | "any" },
+  ): Promise<AgentTaskRecord[]> | AgentTaskRecord[];
+  createTask(input: AgentTaskCreateInput): Promise<AgentTaskRecord>;
+  updateTask(taskId: string, patch: AgentTaskPatchInput): Promise<AgentTaskRecord | null>;
+  setTaskStatus(taskId: string, status: AgentTaskStatus): Promise<AgentTaskRecord | null>;
+  getAgentSecurityConfig(): Promise<AgentSecurityConfig> | AgentSecurityConfig;
+  setAgentSecurityConfig(config: AgentSecurityConfig): Promise<AgentSecurityConfig> | AgentSecurityConfig;
+};
+
+let currentAgentRuntime: AgentRuntime | null = null;
+
+export function setAgentRuntime(runtime: AgentRuntime | null): void {
+  currentAgentRuntime = runtime;
+}
+
+export function getAgentRuntime(): AgentRuntime | null {
+  return currentAgentRuntime;
+}

--- a/taskify-cli/src/shared/agentSecurity.ts
+++ b/taskify-cli/src/shared/agentSecurity.ts
@@ -1,0 +1,226 @@
+// CLI-adapted version of agentSecurity.ts (browser storage removed)
+
+export type AgentSecurityMode = "off" | "moderate" | "strict";
+export type AgentProvenance = "trusted" | "untrusted" | "unknown";
+
+export type AgentSecurityConfig = {
+  enabled: boolean;
+  mode: AgentSecurityMode;
+  trustedNpubs: string[];
+  updatedISO: string;
+};
+
+export type AgentTrustAnnotated = {
+  createdByNpub: string | null;
+  lastEditedByNpub: string | null;
+  provenance: AgentProvenance;
+  trusted: boolean;
+  agentSafe: boolean;
+};
+
+export type AgentTrustCounts = {
+  trusted: number;
+  untrusted: number;
+  unknown: number;
+  returned: number;
+};
+
+export type AgentSecurityStore = {
+  get(): AgentSecurityConfig;
+  set(config: AgentSecurityConfig): AgentSecurityConfig;
+};
+
+export const AGENT_SECURITY_STORAGE_KEY = "taskify.agent.security.v1";
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+export function defaultAgentSecurityConfig(): AgentSecurityConfig {
+  return {
+    enabled: true,
+    mode: "moderate",
+    trustedNpubs: [],
+    updatedISO: nowISO(),
+  };
+}
+
+function normalizeMode(value: unknown): AgentSecurityMode {
+  return value === "strict" || value === "off" ? value : "moderate";
+}
+
+function normalizeTrustedNpub(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export function isLooselyValidTrustedNpub(value: unknown): boolean {
+  return typeof value === "string" && value.trim().toLowerCase().startsWith("npub1") && value.trim().length > 10;
+}
+
+function normalizeTrustedNpubList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const deduped = new Map<string, string>();
+  for (const entry of value) {
+    const normalized = normalizeTrustedNpub(entry);
+    if (!normalized) continue;
+    deduped.set(normalized, normalized);
+  }
+  return Array.from(deduped.values()).sort();
+}
+
+export function normalizeAgentSecurityConfig(raw: unknown): AgentSecurityConfig {
+  const fallback = defaultAgentSecurityConfig();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return fallback;
+  const candidate = raw as Partial<AgentSecurityConfig>;
+  const updatedISO =
+    typeof candidate.updatedISO === "string" && !Number.isNaN(Date.parse(candidate.updatedISO))
+      ? new Date(candidate.updatedISO).toISOString()
+      : fallback.updatedISO;
+  return {
+    enabled: candidate.enabled === true,
+    mode: normalizeMode(candidate.mode),
+    trustedNpubs: normalizeTrustedNpubList(candidate.trustedNpubs),
+    updatedISO,
+  };
+}
+
+// In-memory store for CLI use (config.ts provides persistence)
+const inMemoryStore: { config: AgentSecurityConfig | null } = { config: null };
+
+const defaultStore: AgentSecurityStore = {
+  get() {
+    return inMemoryStore.config ?? defaultAgentSecurityConfig();
+  },
+  set(config: AgentSecurityConfig) {
+    const normalized = normalizeAgentSecurityConfig(config);
+    inMemoryStore.config = normalized;
+    return normalized;
+  },
+};
+
+let currentAgentSecurityStore: AgentSecurityStore = defaultStore;
+
+export function getAgentSecurityStore(): AgentSecurityStore {
+  return currentAgentSecurityStore;
+}
+
+export function setAgentSecurityStore(store: AgentSecurityStore | null | undefined): void {
+  currentAgentSecurityStore = store ?? defaultStore;
+}
+
+export function loadAgentSecurityConfig(): AgentSecurityConfig {
+  return currentAgentSecurityStore.get();
+}
+
+export function saveAgentSecurityConfig(config: AgentSecurityConfig): AgentSecurityConfig {
+  return currentAgentSecurityStore.set(config);
+}
+
+export function updateAgentSecurityConfig(
+  updates: Partial<Pick<AgentSecurityConfig, "enabled" | "mode" | "trustedNpubs">>,
+): AgentSecurityConfig {
+  const current = loadAgentSecurityConfig();
+  return saveAgentSecurityConfig({
+    enabled: typeof updates.enabled === "boolean" ? updates.enabled : current.enabled,
+    mode: updates.mode ? normalizeMode(updates.mode) : current.mode,
+    trustedNpubs:
+      updates.trustedNpubs !== undefined
+        ? normalizeTrustedNpubList(updates.trustedNpubs)
+        : current.trustedNpubs,
+    updatedISO: nowISO(),
+  });
+}
+
+export function addTrustedNpub(config: AgentSecurityConfig, npub: string): AgentSecurityConfig {
+  const normalized = normalizeTrustedNpub(npub);
+  if (!normalized) return normalizeAgentSecurityConfig(config);
+  return normalizeAgentSecurityConfig({
+    ...config,
+    trustedNpubs: Array.from(new Set([...config.trustedNpubs.map((entry) => entry.toLowerCase()), normalized])),
+    updatedISO: nowISO(),
+  });
+}
+
+export function removeTrustedNpub(config: AgentSecurityConfig, npub: string): AgentSecurityConfig {
+  const normalized = normalizeTrustedNpub(npub);
+  return normalizeAgentSecurityConfig({
+    ...config,
+    trustedNpubs: config.trustedNpubs.filter((entry) => entry.toLowerCase() !== normalized),
+    updatedISO: nowISO(),
+  });
+}
+
+export function clearTrustedNpubs(config: AgentSecurityConfig): AgentSecurityConfig {
+  return normalizeAgentSecurityConfig({
+    ...config,
+    trustedNpubs: [],
+    updatedISO: nowISO(),
+  });
+}
+
+export function getEffectiveAgentSecurityMode(config: AgentSecurityConfig): AgentSecurityMode {
+  if (!config.enabled) return "off";
+  return normalizeMode(config.mode);
+}
+
+function classifyProvenance(
+  createdByNpub: string | null,
+  lastEditedByNpub: string | null,
+  config: AgentSecurityConfig,
+): AgentProvenance {
+  const trustedNpubs = new Set(config.trustedNpubs.map((entry) => entry.toLowerCase()));
+  const normalizedLastEditedBy = normalizeTrustedNpub(lastEditedByNpub);
+  const normalizedCreatedBy = normalizeTrustedNpub(createdByNpub);
+
+  if (normalizedLastEditedBy && trustedNpubs.has(normalizedLastEditedBy)) {
+    return "trusted";
+  }
+  if (!normalizedLastEditedBy && !normalizedCreatedBy) {
+    return "unknown";
+  }
+  return "untrusted";
+}
+
+export function annotateTrust<T extends { createdByNpub?: string | null; lastEditedByNpub?: string | null }>(
+  item: T,
+  config: AgentSecurityConfig,
+): T & AgentTrustAnnotated {
+  const createdByNpub = normalizeTrustedNpub(item.createdByNpub) ?? null;
+  const lastEditedByNpub = normalizeTrustedNpub(item.lastEditedByNpub) ?? null;
+  const provenance = classifyProvenance(createdByNpub, lastEditedByNpub, config);
+  const trusted = provenance === "trusted";
+  return {
+    ...item,
+    createdByNpub,
+    lastEditedByNpub,
+    provenance,
+    trusted,
+    agentSafe: trusted,
+  };
+}
+
+export function applyTrustFilter<T extends { createdByNpub?: string | null; lastEditedByNpub?: string | null }>(
+  items: T[],
+  config: AgentSecurityConfig,
+): (T & AgentTrustAnnotated)[] {
+  const annotated = items.map((item) => annotateTrust(item, config));
+  if (getEffectiveAgentSecurityMode(config) === "strict") {
+    return annotated.filter((item) => item.trusted);
+  }
+  return annotated;
+}
+
+export function summarizeTrustCounts<T extends { provenance: AgentProvenance }>(
+  allItems: T[],
+  returnedCount: number,
+): AgentTrustCounts {
+  return {
+    trusted: allItems.filter((item) => item.provenance === "trusted").length,
+    untrusted: allItems.filter((item) => item.provenance === "untrusted").length,
+    unknown: allItems.filter((item) => item.provenance === "unknown").length,
+    returned: returnedCount,
+  };
+}

--- a/taskify-cli/src/shared/boardUtils.ts
+++ b/taskify-cli/src/shared/boardUtils.ts
@@ -1,0 +1,472 @@
+import type { Task, Board, CalendarEvent, Recurrence, Weekday } from "./taskTypes.ts";
+import {
+  isoDatePart,
+  parseDateKey,
+  startOfDay,
+  isoTimePart,
+  formatDateKeyFromParts,
+  isoFromDateTime,
+  normalizeTimeZone,
+} from "./dateUtils.ts";
+import type { Settings } from "./settingsTypes.ts";
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// ---- Compound child helpers ----
+
+export type CompoundChildId = string;
+
+export function parseCompoundChildInput(raw: string): { boardId: string; relays: string[] } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { boardId: "", relays: [] };
+  let boardId = trimmed;
+  let relaySegment = "";
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex >= 0) {
+    boardId = trimmed.slice(0, atIndex).trim();
+    relaySegment = trimmed.slice(atIndex + 1).trim();
+  } else {
+    const spaceIndex = trimmed.search(/\s/);
+    if (spaceIndex >= 0) {
+      boardId = trimmed.slice(0, spaceIndex).trim();
+      relaySegment = trimmed.slice(spaceIndex + 1).trim();
+    }
+  }
+  const relays = relaySegment
+    ? relaySegment.split(/[\s,]+/).map((relay) => relay.trim()).filter(Boolean)
+    : [];
+  return { boardId, relays };
+}
+
+export function boardScopeIds(board: Board, boards: Board[]): string[] {
+  const ids = new Set<string>();
+  const addId = (value?: string | null) => {
+    if (typeof value === "string" && value) ids.add(value);
+  };
+  const addBoard = (target: Board | undefined) => {
+    if (!target) return;
+    addId(target.id);
+    addId(target.nostr?.boardId);
+  };
+
+  addBoard(board);
+
+  if (board.kind === "compound") {
+    board.children.forEach((childId) => {
+      addId(childId);
+      addBoard(findBoardByCompoundChildId(boards, childId));
+    });
+  }
+
+  return Array.from(ids);
+}
+
+export function findBoardByCompoundChildId(boards: Board[], childId: string): Board | undefined {
+  return boards.find((board) => {
+    if (board.id === childId) return true;
+    return !!board.nostr?.boardId && board.nostr.boardId === childId;
+  });
+}
+
+export function compoundChildMatchesBoard(childId: string, board: Board): boolean {
+  return childId === board.id || (!!board.nostr?.boardId && childId === board.nostr.boardId);
+}
+
+export function normalizeCompoundChildId(boards: Board[], childId: string): string {
+  const match = findBoardByCompoundChildId(boards, childId);
+  return match ? match.id : childId;
+}
+
+// ---- Board migration ----
+
+export function migrateBoards(stored: any): Board[] | null {
+  try {
+    const arr = stored as any[];
+    if (!Array.isArray(arr)) return null;
+    return arr.map((b) => {
+      const archived =
+        typeof b?.archived === "boolean"
+          ? b.archived
+          : typeof b?.hidden === "boolean"
+            ? b.hidden
+            : false;
+      const hidden =
+        typeof b?.hidden === "boolean" && typeof b?.archived === "boolean"
+          ? b.hidden
+          : false;
+      const clearCompletedDisabled =
+        typeof b?.clearCompletedDisabled === "boolean" ? b.clearCompletedDisabled : false;
+      const indexCardEnabled =
+        typeof (b as any)?.indexCardEnabled === "boolean" ? Boolean((b as any).indexCardEnabled) : false;
+      const hideChildBoardNames =
+        typeof (b as any)?.hideChildBoardNames === "boolean"
+          ? Boolean((b as any).hideChildBoardNames)
+          : false;
+      if (b?.kind === "week") {
+        return {
+          id: b.id,
+          name: b.name,
+          kind: "week",
+          nostr: b.nostr,
+          archived,
+          hidden,
+          clearCompletedDisabled,
+        } as Board;
+      }
+      if (b?.kind === "lists" && Array.isArray(b.columns)) {
+        return {
+          id: b.id,
+          name: b.name,
+          kind: "lists",
+          columns: b.columns,
+          nostr: b.nostr,
+          archived,
+          hidden,
+          clearCompletedDisabled,
+          indexCardEnabled,
+        } as Board;
+      }
+      if (b?.kind === "compound") {
+        const rawChildren = Array.isArray((b as any)?.children) ? (b as any).children : [];
+        const children = rawChildren
+          .filter((child: unknown) => typeof child === "string" && child && child !== b.id) as string[];
+        return {
+          id: b.id,
+          name: b.name,
+          kind: "compound",
+          children,
+          nostr: b.nostr,
+          archived,
+          hidden,
+          clearCompletedDisabled,
+          indexCardEnabled,
+          hideChildBoardNames,
+        } as Board;
+      }
+      if (b?.kind === "bible") {
+        const name = typeof b?.name === "string" && b.name.trim() ? b.name : "Bible";
+        return {
+          id: b.id,
+          name,
+          kind: "bible",
+          archived,
+          hidden,
+          clearCompletedDisabled,
+        } as Board;
+      }
+      if (b?.kind === "list") {
+        const colId = crypto.randomUUID();
+        return {
+          id: b.id,
+          name: b.name,
+          kind: "lists",
+          columns: [{ id: colId, name: "Items" }],
+          nostr: b?.nostr,
+          archived,
+          hidden,
+          clearCompletedDisabled,
+          indexCardEnabled,
+        } as Board;
+      }
+      const colId = crypto.randomUUID();
+      return {
+        id: b?.id || crypto.randomUUID(),
+        name: b?.name || "Board",
+        kind: "lists",
+        columns: [{ id: colId, name: "Items" }],
+        nostr: b?.nostr,
+        archived,
+        hidden,
+        clearCompletedDisabled,
+        indexCardEnabled,
+      } as Board;
+    });
+  } catch { return null; }
+}
+
+// ---- Startup board selection ----
+
+export function pickStartupBoard(boards: Board[], overrides?: Partial<Record<Weekday, string>>): string {
+  const visible = boards.filter(b => !b.archived && !b.hidden);
+  const today = (new Date().getDay() as Weekday);
+  const overrideId = overrides?.[today];
+  if (overrideId) {
+    const match = visible.find(b => b.id === overrideId) || boards.find(b => !b.archived && b.id === overrideId);
+    if (match) return match.id;
+  }
+  if (visible.length) return visible[0].id;
+  const firstUnarchived = boards.find(b => !b.archived);
+  if (firstUnarchived) return firstUnarchived.id;
+  return boards[0]?.id || "";
+}
+
+// ---- Week helpers ----
+
+export function startOfWeek(d: Date, weekStart: Weekday): Date {
+  const sd = startOfDay(d);
+  const current = sd.getDay() as Weekday;
+  const ws = (weekStart === 1 || weekStart === 6) ? weekStart : 0;
+  let diff = current - ws;
+  if (diff < 0) diff += 7;
+  return new Date(sd.getTime() - diff * 86400000);
+}
+
+// ---- Recurrence helpers ----
+
+export function nextOccurrence(
+  currentISO: string,
+  rule: Recurrence,
+  keepTime = false,
+  timeZone?: string,
+): string | null {
+  const safeZone = normalizeTimeZone(timeZone);
+  if (safeZone) {
+    const dateKey = isoDatePart(currentISO, safeZone);
+    const dateParts = parseDateKey(dateKey);
+    if (dateParts) {
+      const baseTime = keepTime ? isoTimePart(currentISO, safeZone) : "";
+      const applyDate = (parts: { year: number; month: number; day: number }): string => {
+        const nextDateKey = formatDateKeyFromParts(parts.year, parts.month, parts.day);
+        return isoFromDateTime(nextDateKey, baseTime || undefined, safeZone);
+      };
+      const addDays = (d: number) => {
+        const base = new Date(Date.UTC(dateParts.year, dateParts.month - 1, dateParts.day));
+        base.setUTCDate(base.getUTCDate() + d);
+        return {
+          year: base.getUTCFullYear(),
+          month: base.getUTCMonth() + 1,
+          day: base.getUTCDate(),
+        };
+      };
+      const weekdayForParts = (parts: { year: number; month: number; day: number }) =>
+        new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay() as Weekday;
+      let next: string | null = null;
+      switch (rule.type) {
+        case "none":
+          next = null; break;
+        case "daily":
+          next = applyDate(addDays(1)); break;
+        case "weekly": {
+          if (!rule.days.length) return null;
+          for (let i = 1; i <= 28; i++) {
+            const cand = addDays(i);
+            const wd = weekdayForParts(cand);
+            if (rule.days.includes(wd)) { next = applyDate(cand); break; }
+          }
+          break;
+        }
+        case "every": {
+          if (rule.unit === "hour") {
+            const current = new Date(currentISO);
+            const n = new Date(current.getTime() + rule.n * 3600000);
+            next = n.toISOString();
+          } else {
+            const daysToAdd = rule.unit === "day" ? rule.n : rule.n * 7;
+            next = applyDate(addDays(daysToAdd));
+          }
+          break;
+        }
+        case "monthlyDay": {
+          const interval = Math.max(1, rule.interval ?? 1);
+          const base = new Date(Date.UTC(dateParts.year, dateParts.month - 1 + interval, 1));
+          const n = {
+            year: base.getUTCFullYear(),
+            month: base.getUTCMonth() + 1,
+            day: Math.min(rule.day, 28),
+          };
+          next = applyDate(n);
+          break;
+        }
+      }
+      if (next && rule.untilISO) {
+        const limitKey = isoDatePart(rule.untilISO, safeZone);
+        const nextKey = isoDatePart(next, safeZone);
+        if (nextKey > limitKey) return null;
+      }
+      return next;
+    }
+  }
+  const currentDate = new Date(currentISO);
+  const curDay = startOfDay(currentDate);
+  const timeOffset = currentDate.getTime() - curDay.getTime();
+  const baseTime = keepTime ? isoTimePart(currentISO) : "";
+  const applyTime = (day: Date): string => {
+    if (keepTime && baseTime) {
+      const datePart = isoDatePart(day.toISOString());
+      return isoFromDateTime(datePart, baseTime);
+    }
+    return new Date(day.getTime() + timeOffset).toISOString();
+  };
+  const addDays = (d: number) => {
+    const nextDay = startOfDay(new Date(curDay.getTime() + d * 86400000));
+    return applyTime(nextDay);
+  };
+  let next: string | null = null;
+  switch (rule.type) {
+    case "none":
+      next = null; break;
+    case "daily":
+      next = addDays(1); break;
+    case "weekly": {
+      if (!rule.days.length) return null;
+      for (let i = 1; i <= 28; i++) {
+        const cand = addDays(i);
+        const wd = new Date(cand).getDay() as Weekday;
+        if (rule.days.includes(wd)) { next = cand; break; }
+      }
+      break;
+    }
+    case "every": {
+      if (rule.unit === "hour") {
+        const current = new Date(currentISO);
+        const n = new Date(current.getTime() + rule.n * 3600000);
+        next = n.toISOString();
+      } else {
+        const daysToAdd = rule.unit === "day" ? rule.n : rule.n * 7;
+        next = addDays(daysToAdd);
+      }
+      break;
+    }
+    case "monthlyDay": {
+      const y = curDay.getFullYear(), m = curDay.getMonth();
+      const interval = Math.max(1, rule.interval ?? 1);
+      const n = startOfDay(new Date(y, m + interval, Math.min(rule.day, 28)));
+      next = applyTime(n);
+      break;
+    }
+  }
+  if (next && rule.untilISO) {
+    const limit = startOfDay(new Date(rule.untilISO)).getTime();
+    const n = startOfDay(new Date(next)).getTime();
+    if (n > limit) return null;
+  }
+  return next;
+}
+
+// ---- Visibility helpers ----
+
+export function revealsOnDueDate(rule: Recurrence): boolean {
+  if (isFrequentRecurrence(rule)) return true;
+  return false;
+}
+
+export function isFrequentRecurrence(rule?: Recurrence | null): boolean {
+  if (!rule) return false;
+  if (rule.type === "daily" || rule.type === "weekly") return true;
+  if (rule.type === "every") {
+    return rule.unit === "day" || rule.unit === "week";
+  }
+  return false;
+}
+
+export function isVisibleNow(t: Task, now = new Date()): boolean {
+  if (!t.hiddenUntilISO) return true;
+  const today = startOfDay(now).getTime();
+  if (t.recurrence && revealsOnDueDate(t.recurrence)) {
+    const dueReveal = startOfDay(new Date(t.dueISO)).getTime();
+    if (!Number.isNaN(dueReveal)) return today >= dueReveal;
+  }
+  const reveal = startOfDay(new Date(t.hiddenUntilISO)).getTime();
+  return today >= reveal;
+}
+
+export function hiddenUntilForNext(
+  nextISO: string,
+  rule: Recurrence,
+  weekStart: Weekday
+): string | undefined {
+  const nextMidnight = startOfDay(new Date(nextISO));
+  if (revealsOnDueDate(rule)) {
+    return nextMidnight.toISOString();
+  }
+  const sow = startOfWeek(nextMidnight, weekStart);
+  return sow.toISOString();
+}
+
+export function hiddenUntilForBoard(dueISO: string, boardKind: Board["kind"], weekStart: Weekday): string | undefined {
+  const dueDate = startOfDay(new Date(dueISO));
+  if (Number.isNaN(dueDate.getTime())) return undefined;
+  const today = startOfDay(new Date());
+  if (boardKind === "lists" || boardKind === "compound") {
+    return dueDate.getTime() > today.getTime() ? dueDate.toISOString() : undefined;
+  }
+  const nowSow = startOfWeek(new Date(), weekStart);
+  const dueSow = startOfWeek(dueDate, weekStart);
+  return dueSow.getTime() > nowSow.getTime() ? dueSow.toISOString() : undefined;
+}
+
+export function applyHiddenForFuture(task: Task, weekStart: Weekday, boardKind: Board["kind"]): void {
+  if (task.dueDateEnabled === false) {
+    task.hiddenUntilISO = undefined;
+    return;
+  }
+  task.hiddenUntilISO = hiddenUntilForBoard(task.dueISO, boardKind, weekStart);
+}
+
+// ---- Calendar event visibility helpers ----
+
+function calendarEventDateKey(event: CalendarEvent): string | null {
+  if (event.kind === "date") {
+    return ISO_DATE_PATTERN.test(event.startDate) ? event.startDate : null;
+  }
+  const key = isoDatePart(event.startISO, event.startTzid);
+  return ISO_DATE_PATTERN.test(key) ? key : null;
+}
+
+function hiddenUntilForCalendarEvent(
+  event: CalendarEvent,
+  boardKind: Board["kind"],
+  weekStart: Weekday,
+): string | undefined {
+  if (boardKind !== "lists" && boardKind !== "compound") return undefined;
+  const dateKey = calendarEventDateKey(event);
+  if (!dateKey) return undefined;
+  const parsed = parseDateKey(dateKey);
+  if (!parsed) return undefined;
+  const eventDate = new Date(parsed.year, parsed.month - 1, parsed.day);
+  if (Number.isNaN(eventDate.getTime())) return undefined;
+  const eventWeekStart = startOfWeek(eventDate, weekStart);
+  const currentWeekStart = startOfWeek(new Date(), weekStart);
+  if (eventWeekStart.getTime() > currentWeekStart.getTime()) {
+    return eventWeekStart.toISOString();
+  }
+  return undefined;
+}
+
+export function applyHiddenForCalendarEvent(event: CalendarEvent, weekStart: Weekday, boardKind: Board["kind"]): CalendarEvent {
+  const hiddenUntilISO = hiddenUntilForCalendarEvent(event, boardKind, weekStart);
+  if (hiddenUntilISO) {
+    if (event.hiddenUntilISO === hiddenUntilISO) return event;
+    return { ...event, hiddenUntilISO };
+  }
+  if (!event.hiddenUntilISO) return event;
+  return { ...event, hiddenUntilISO: undefined };
+}
+
+// ---- Order helpers ----
+
+export function nextOrderForBoard(
+  boardId: string,
+  tasks: Task[],
+  newTaskPosition: Settings["newTaskPosition"]
+): number {
+  const boardTasks = tasks.filter(task => task.boardId === boardId);
+  if (newTaskPosition === "top") {
+    const minOrder = boardTasks.reduce((min, task) => Math.min(min, task.order ?? 0), 0);
+    return minOrder - 1;
+  }
+  return boardTasks.reduce((max, task) => Math.max(max, task.order ?? -1), -1) + 1;
+}
+
+export function nextOrderForCalendarBoard(
+  boardId: string,
+  events: CalendarEvent[],
+  newItemPosition: Settings["newTaskPosition"],
+): number {
+  const boardEvents = events.filter((event) => event.boardId === boardId && !event.external);
+  if (newItemPosition === "top") {
+    const minOrder = boardEvents.reduce((min, event) => Math.min(min, event.order ?? 0), 0);
+    return minOrder - 1;
+  }
+  return boardEvents.reduce((max, event) => Math.max(max, event.order ?? -1), -1) + 1;
+}

--- a/taskify-cli/src/shared/dateUtils.ts
+++ b/taskify-cli/src/shared/dateUtils.ts
@@ -1,0 +1,119 @@
+// Minimal date utilities for taskify-cli (no browser dependencies)
+
+export function startOfDay(d: Date): Date {
+  const result = new Date(d);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+export function isoDatePart(iso: string, tz?: string | null): string {
+  if (!iso) return "";
+  try {
+    if (tz) {
+      const date = new Date(iso);
+      if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+      const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone: tz,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).formatToParts(date);
+      const year = parts.find((p) => p.type === "year")?.value ?? "";
+      const month = parts.find((p) => p.type === "month")?.value ?? "";
+      const day = parts.find((p) => p.type === "day")?.value ?? "";
+      return `${year}-${month}-${day}`;
+    }
+  } catch {
+    // fall through
+  }
+  return iso.slice(0, 10);
+}
+
+export function isoTimePart(iso: string, tz?: string | null): string {
+  if (!iso) return "";
+  try {
+    if (tz) {
+      const date = new Date(iso);
+      if (Number.isNaN(date.getTime())) return "";
+      const parts = new Intl.DateTimeFormat("en-GB", {
+        timeZone: tz,
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }).formatToParts(date);
+      const hour = parts.find((p) => p.type === "hour")?.value ?? "";
+      const minute = parts.find((p) => p.type === "minute")?.value ?? "";
+      return `${hour}:${minute}`;
+    }
+  } catch {
+    // fall through
+  }
+  // UTC fallback
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const h = String(d.getUTCHours()).padStart(2, "0");
+  const m = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function isoTimePartUtc(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const h = String(d.getUTCHours()).padStart(2, "0");
+  const m = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function parseDateKey(key: string): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key);
+  if (!match) return null;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+export function formatDateKeyFromParts(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function isoFromDateTime(dateKey: string, time?: string, tz?: string): string {
+  if (!time) {
+    return new Date(`${dateKey}T00:00:00Z`).toISOString();
+  }
+  if (tz) {
+    try {
+      // Build a date string and convert from the given timezone
+      const localStr = `${dateKey}T${time}:00`;
+      const date = new Date(
+        new Intl.DateTimeFormat("en-CA", {
+          timeZone: tz,
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+          hour12: false,
+        }).format(new Date(localStr))
+      );
+      if (!Number.isNaN(date.getTime())) return date.toISOString();
+    } catch {
+      // fall through
+    }
+  }
+  return new Date(`${dateKey}T${time}:00Z`).toISOString();
+}
+
+export function normalizeTimeZone(tz?: string | null): string | null {
+  if (!tz || typeof tz !== "string") return null;
+  const trimmed = tz.trim();
+  if (!trimmed) return null;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return null;
+  }
+}

--- a/taskify-cli/src/shared/nostr.ts
+++ b/taskify-cli/src/shared/nostr.ts
@@ -1,0 +1,71 @@
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { getPublicKey, nip19 } from "nostr-tools";
+
+function arrayLikeToHex(data: ArrayLike<number>): string {
+  return Array.from(data).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Normalize Nostr public key input into a compressed 33-byte hex string (66 chars).
+ */
+export function normalizeNostrPubkey(input: string | null | undefined): string | null {
+  let value = input?.trim();
+  if (!value) return null;
+
+  if (/^nostr:/i.test(value)) {
+    value = value.replace(/^nostr:/i, "");
+  }
+
+  const lowerValue = value.toLowerCase();
+
+  const maybeHex = lowerValue.startsWith("0x") ? lowerValue.slice(2) : lowerValue;
+  if (/^(02|03)[0-9a-f]{64}$/.test(maybeHex)) {
+    return maybeHex;
+  }
+  if (/^[0-9a-f]{64}$/.test(maybeHex)) {
+    return `02${maybeHex}`;
+  }
+
+  try {
+    const decoded = nip19.decode(lowerValue);
+    if (decoded.type !== "npub" || !decoded.data) return null;
+    const decodedData: unknown = decoded.data;
+    if (typeof decodedData === "string") {
+      if (/^[0-9a-f]{64}$/.test(decodedData)) return `02${decodedData.toLowerCase()}`;
+      return null;
+    }
+    if (decodedData instanceof Uint8Array) {
+      return `02${bytesToHex(decodedData).toLowerCase()}`;
+    }
+    if (Array.isArray(decodedData)) {
+      return `02${arrayLikeToHex(decodedData).toLowerCase()}`;
+    }
+  } catch {
+    // fall through to null
+  }
+  return null;
+}
+
+export function toNpub(input: string | null | undefined): string | null {
+  const normalized = normalizeNostrPubkey(input);
+  if (!normalized) return null;
+  try {
+    return nip19.npubEncode(normalized.slice(-64));
+  } catch {
+    return null;
+  }
+}
+
+export function isValidNostrPubkeyHex(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^(02|03)[0-9a-fA-F]{64}$/.test(value);
+}
+
+export function deriveCompressedPubkeyFromSecret(secretHex: string): string | null {
+  if (!/^[0-9a-fA-F]{64}$/.test(secretHex?.trim() || "")) return null;
+  try {
+    const pubkey = getPublicKey(hexToBytes(secretHex.trim()));
+    return `02${pubkey.toLowerCase()}`;
+  } catch {
+    return null;
+  }
+}

--- a/taskify-cli/src/shared/settingsTypes.ts
+++ b/taskify-cli/src/shared/settingsTypes.ts
@@ -1,0 +1,106 @@
+// CLI-adapted version of settingsTypes.ts (browser imports removed)
+
+import type { Weekday } from "./taskTypes.ts";
+
+// ---- Stubs for types not needed in CLI ----
+export type AccentPalette = string;
+export type ScriptureMemoryFrequency = string;
+export type ScriptureMemorySort = string;
+
+// ---- Push notifications ----
+
+export type PushPlatform = "ios" | "android";
+
+export type PushPreferences = {
+  enabled: boolean;
+  platform: PushPlatform;
+  deviceId?: string;
+  subscriptionId?: string;
+  permission?: NotificationPermission;
+};
+
+// ---- Fasting reminders ----
+
+export type FastingRemindersMode = "weekday" | "random";
+
+// ---- Settings ----
+
+export type Settings = {
+  weekStart: Weekday;
+  newTaskPosition: "top" | "bottom";
+  streaksEnabled: boolean;
+  completedTab: boolean;
+  bibleTrackerEnabled: boolean;
+  scriptureMemoryEnabled: boolean;
+  scriptureMemoryBoardId?: string | null;
+  scriptureMemoryFrequency: ScriptureMemoryFrequency;
+  scriptureMemorySort: ScriptureMemorySort;
+  fastingRemindersEnabled: boolean;
+  fastingRemindersMode: FastingRemindersMode;
+  fastingRemindersPerMonth: number;
+  fastingRemindersWeekday: Weekday;
+  fastingRemindersRandomSeed: string;
+  showFullWeekRecurring: boolean;
+  baseFontSize: number | null;
+  startBoardByDay: Partial<Record<Weekday, string>>;
+  accent: "green" | "blue" | "background";
+  backgroundImage?: string | null;
+  backgroundAccent?: AccentPalette | null;
+  backgroundAccents?: AccentPalette[] | null;
+  backgroundAccentIndex?: number | null;
+  backgroundBlur: "blurred" | "sharp";
+  hideCompletedSubtasks: boolean;
+  startupView: "main" | "wallet";
+  walletConversionEnabled: boolean;
+  walletPrimaryCurrency: "sat" | "usd";
+  walletSentStateChecksEnabled: boolean;
+  walletPaymentRequestsEnabled: boolean;
+  walletPaymentRequestsBackgroundChecksEnabled: boolean;
+  walletMintBackupEnabled: boolean;
+  walletContactsSyncEnabled: boolean;
+  fileStorageServer: string;
+  npubCashLightningAddressEnabled: boolean;
+  npubCashAutoClaim: boolean;
+  cloudBackupsEnabled: boolean;
+  nostrBackupEnabled: boolean;
+  nostrBackupMetadataEnabled: boolean;
+  pushNotifications: PushPreferences;
+  agentModeEnabled: boolean;
+  allowAgentCommands: boolean;
+};
+
+// ---- Accent choices ----
+
+export type AccentChoice = {
+  id: "blue" | "green";
+  label: string;
+  fill: string;
+  ring: string;
+  border: string;
+  borderActive: string;
+  shadow: string;
+  shadowActive: string;
+};
+
+export const ACCENT_CHOICES: AccentChoice[] = [
+  {
+    id: "blue",
+    label: "iMessage blue",
+    fill: "#0a84ff",
+    ring: "rgba(64, 156, 255, 0.32)",
+    border: "rgba(64, 156, 255, 0.38)",
+    borderActive: "rgba(64, 156, 255, 0.88)",
+    shadow: "0 12px 26px rgba(10, 132, 255, 0.32)",
+    shadowActive: "0 18px 34px rgba(10, 132, 255, 0.42)",
+  },
+  {
+    id: "green",
+    label: "Mint green",
+    fill: "#34c759",
+    ring: "rgba(52, 199, 89, 0.28)",
+    border: "rgba(52, 199, 89, 0.36)",
+    borderActive: "rgba(52, 199, 89, 0.86)",
+    shadow: "0 12px 24px rgba(52, 199, 89, 0.28)",
+    shadowActive: "0 18px 32px rgba(52, 199, 89, 0.38)",
+  },
+];

--- a/taskify-cli/src/shared/taskTypes.ts
+++ b/taskify-cli/src/shared/taskTypes.ts
@@ -1,0 +1,306 @@
+// CLI-adapted version of taskTypes.ts (browser imports removed)
+
+// ---- Stubs for types not needed in CLI ----
+export type TaskDocument = unknown;
+export type CalendarRsvpFb = string;
+export type CalendarRsvpStatus = string;
+export type SharedContactPayload = unknown;
+export type SharedTaskPayload = unknown;
+
+// ---- Priority ----
+
+export type TaskPriority = 1 | 2 | 3;
+
+export const TASK_PRIORITY_MARKS: Record<TaskPriority, string> = {
+  1: "!",
+  2: "!!",
+  3: "!!!",
+};
+
+// ---- Recurrence ----
+
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0=Sun
+
+export type Recurrence =
+  | { type: "none"; untilISO?: string }
+  | { type: "daily"; untilISO?: string }
+  | { type: "weekly"; days: Weekday[]; untilISO?: string }
+  | { type: "every"; n: number; unit: "hour" | "day" | "week"; untilISO?: string }
+  | { type: "monthlyDay"; day: number; interval?: number; untilISO?: string };
+
+// ---- Subtask ----
+
+export type Subtask = {
+  id: string;
+  title: string;
+  completed?: boolean;
+};
+
+// ---- Reminders ----
+
+export type BuiltinReminderPreset = "0h" | "5m" | "15m" | "30m" | "1h" | "1d" | "1w" | "0d";
+export type CustomReminderPreset = `custom-${number}`;
+export type ReminderPreset = BuiltinReminderPreset | CustomReminderPreset;
+
+// ---- Inbox ----
+
+export type InboxSender = {
+  pubkey: string;
+  name?: string;
+  npub?: string;
+};
+
+export type InboxItemStatus =
+  | "pending"
+  | "accepted"
+  | "declined"
+  | "tentative"
+  | "deleted"
+  | "read";
+
+export type InboxItem =
+  | {
+      type: "board";
+      boardId: string;
+      boardName?: string;
+      relays?: string[];
+      sender: InboxSender;
+      receivedAt: string;
+      status?: InboxItemStatus;
+      dmEventId?: string;
+    }
+  | {
+      type: "contact";
+      contact: SharedContactPayload;
+      sender: InboxSender;
+      receivedAt: string;
+      status?: InboxItemStatus;
+      dmEventId?: string;
+    }
+  | {
+      type: "task";
+      task: SharedTaskPayload;
+      sender: InboxSender;
+      receivedAt: string;
+      status?: InboxItemStatus;
+      dmEventId?: string;
+    };
+
+export type TaskAssigneeStatus = "pending" | "accepted" | "declined" | "tentative";
+
+export type TaskAssignee = {
+  pubkey: string;
+  relay?: string;
+  status?: TaskAssigneeStatus;
+  respondedAt?: number;
+};
+
+// ---- Task ----
+
+export type Task = {
+  id: string;
+  boardId: string;
+  createdBy?: string;
+  lastEditedBy?: string;
+  createdAt?: number;
+  updatedAt?: string;
+  title: string;
+  priority?: TaskPriority;
+  note?: string;
+  images?: string[];
+  documents?: TaskDocument[];
+  dueISO: string;
+  dueDateEnabled?: boolean;
+  completed?: boolean;
+  completedAt?: string;
+  completedBy?: string;
+  recurrence?: Recurrence;
+  column?: "day";
+  columnId?: string;
+  hiddenUntilISO?: string;
+  order?: number;
+  streak?: number;
+  longestStreak?: number;
+  seriesId?: string;
+  subtasks?: Subtask[];
+  assignees?: TaskAssignee[];
+  bounty?: {
+    id: string;
+    token: string;
+    amount?: number;
+    mint?: string;
+    lock?: "p2pk" | "htlc" | "none" | "unknown";
+    owner?: string;
+    sender?: string;
+    receiver?: string;
+    state: "locked" | "unlocked" | "revoked" | "claimed";
+    updatedAt: string;
+    enc?:
+      | { alg: "aes-gcm-256"; iv: string; ct: string }
+      | { alg: "nip04"; data: string }
+      | null;
+  };
+  dueTimeEnabled?: boolean;
+  dueTimeZone?: string;
+  reminders?: ReminderPreset[];
+  reminderTime?: string;
+  scriptureMemoryId?: string;
+  scriptureMemoryStage?: number;
+  scriptureMemoryPrevReviewISO?: string | null;
+  scriptureMemoryScheduledAt?: string;
+  bountyLists?: string[];
+  bountyDeletedAt?: string;
+  inboxItem?: InboxItem;
+};
+
+// ---- Calendar event types ----
+
+export type CalendarEventParticipant = {
+  pubkey: string;
+  relay?: string;
+  role?: string;
+};
+
+export type CalendarEventBase = {
+  id: string;
+  boardId: string;
+  createdBy?: string;
+  lastEditedBy?: string;
+  columnId?: string;
+  order?: number;
+  title: string;
+  summary?: string;
+  description?: string;
+  documents?: TaskDocument[];
+  image?: string;
+  locations?: string[];
+  geohash?: string;
+  participants?: CalendarEventParticipant[];
+  hashtags?: string[];
+  references?: string[];
+  reminders?: ReminderPreset[];
+  reminderTime?: string;
+  hiddenUntilISO?: string;
+  recurrence?: Recurrence;
+  seriesId?: string;
+  readOnly?: boolean;
+  external?: boolean;
+  originBoardId?: string;
+  eventKey?: string;
+  inviteTokens?: Record<string, string>;
+  canonicalAddress?: string;
+  viewAddress?: string;
+  inviteToken?: string;
+  inviteRelays?: string[];
+  boardPubkey?: string;
+  rsvpStatus?: CalendarRsvpStatus;
+  rsvpCreatedAt?: number;
+  rsvpFb?: CalendarRsvpFb;
+};
+
+export type DateCalendarEvent = CalendarEventBase & {
+  kind: "date";
+  startDate: string;
+  endDate?: string;
+};
+
+export type TimeCalendarEvent = CalendarEventBase & {
+  kind: "time";
+  startISO: string;
+  endISO?: string;
+  startTzid?: string;
+  endTzid?: string;
+};
+
+export type CalendarEvent = DateCalendarEvent | TimeCalendarEvent;
+export type ExternalCalendarEvent = CalendarEvent & {
+  external: true;
+  boardPubkey: string;
+};
+
+export function isExternalCalendarEvent(event: CalendarEvent): event is ExternalCalendarEvent {
+  return event.external === true;
+}
+
+// ---- Edit state ----
+
+export type EditItemType = "task" | "event";
+
+export type EditingState =
+  | { type: "task"; originalType: EditItemType; originalId: string; task: Task }
+  | { type: "event"; originalType: EditItemType; originalId: string; event: CalendarEvent };
+
+// ---- Board sort / grouping ----
+
+export type BoardSortMode = "manual" | "due" | "priority" | "created" | "alpha";
+export type BoardSortDirection = "asc" | "desc";
+export type UpcomingBoardGrouping = "mixed" | "grouped";
+
+// ---- Publish / complete function types ----
+
+export type PublishTaskFn = (
+  task: Task,
+  boardOverride?: Board,
+  options?: { skipBoardMetadata?: boolean }
+) => Promise<void>;
+
+export type PublishCalendarEventFn = (
+  event: CalendarEvent,
+  boardOverride?: Board,
+  options?: { skipBoardMetadata?: boolean }
+) => Promise<void>;
+
+export type ScriptureMemoryUpdate = {
+  entryId: string;
+  completedAt: string;
+  stageBefore?: number;
+  nextScheduled?: { entryId: string; scheduledAtISO: string };
+};
+
+export type CompleteTaskResult = {
+  scriptureMemory?: ScriptureMemoryUpdate;
+} | null;
+
+export type CompleteTaskFn = (
+  id: string,
+  options?: { skipScriptureMemoryUpdate?: boolean; inboxAction?: "accept" | "dismiss" | "decline" | "maybe" }
+) => CompleteTaskResult;
+
+// ---- Board types ----
+
+export type ListColumn = { id: string; name: string };
+
+export type CompoundIndexGroup = {
+  key: string;
+  boardId: string;
+  boardName: string;
+  columns: { id: string; name: string }[];
+};
+
+export type BoardBase = {
+  id: string;
+  name: string;
+  nostr?: { boardId: string; relays: string[] };
+  archived?: boolean;
+  hidden?: boolean;
+  clearCompletedDisabled?: boolean;
+};
+
+export type CompoundChildId = string;
+
+export type Board =
+  | (BoardBase & { kind: "week" })
+  | (BoardBase & { kind: "lists"; columns: ListColumn[]; indexCardEnabled?: boolean })
+  | (BoardBase & {
+      kind: "compound";
+      children: CompoundChildId[];
+      indexCardEnabled?: boolean;
+      hideChildBoardNames?: boolean;
+    })
+  | (BoardBase & { kind: "bible" });
+
+export type ListLikeBoard = Extract<Board, { kind: "lists" | "compound" }>;
+
+export function isListLikeBoard(board: Board | null | undefined): board is ListLikeBoard {
+  return !!board && (board.kind === "lists" || board.kind === "compound");
+}

--- a/taskify-cli/src/shared/taskUtils.ts
+++ b/taskify-cli/src/shared/taskUtils.ts
@@ -1,0 +1,273 @@
+import type { Task, Recurrence } from "./taskTypes.ts";
+import type { TaskPriority } from "./taskTypes.ts";
+import { isoDatePart, isoTimePartUtc, startOfDay } from "./dateUtils.ts";
+import { revealsOnDueDate, isFrequentRecurrence } from "./boardUtils.ts";
+
+// ---- Priority normalization ----
+
+export function normalizeTaskPriority(value: unknown): TaskPriority | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const rounded = Math.round(value);
+    if (rounded === 1 || rounded === 2 || rounded === 3) return rounded as TaskPriority;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "!" || trimmed === "!!" || trimmed === "!!!") {
+      return trimmed.length as TaskPriority;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (parsed === 1 || parsed === 2 || parsed === 3) return parsed as TaskPriority;
+  }
+  return undefined;
+}
+
+// ---- Board sort state ----
+
+export type BoardSortMode = "manual" | "due" | "priority" | "created" | "alpha";
+export type BoardSortDirection = "asc" | "desc";
+
+const DEFAULT_BOARD_SORT_DIRECTION: Record<BoardSortMode, BoardSortDirection> = {
+  manual: "asc",
+  due: "asc",
+  priority: "desc",
+  created: "desc",
+  alpha: "asc",
+};
+
+const BOARD_SORT_MODE_IDS = new Set<BoardSortMode>(["manual", "due", "priority", "created", "alpha"]);
+
+export function normalizeBoardSortState(value: unknown): { mode: BoardSortMode; direction: BoardSortDirection } | null {
+  const modeRaw = typeof (value as any)?.mode === "string" ? (value as any).mode : "";
+  if (!BOARD_SORT_MODE_IDS.has(modeRaw as BoardSortMode)) return null;
+  const mode = modeRaw as BoardSortMode;
+  const directionRaw = typeof (value as any)?.direction === "string" ? (value as any).direction : "";
+  const direction: BoardSortDirection =
+    directionRaw === "asc" || directionRaw === "desc" ? (directionRaw as BoardSortDirection) : DEFAULT_BOARD_SORT_DIRECTION[mode];
+  return { mode, direction };
+}
+
+// ---- Bounty list helpers ----
+
+export function taskHasBountyList(task: Task, key: string | null | undefined): boolean {
+  if (!key) return false;
+  if (!Array.isArray(task.bountyLists)) return false;
+  return task.bountyLists.includes(key);
+}
+
+export function withTaskAddedToBountyList(task: Task, key: string | null): Task {
+  if (!key) return task;
+  if (taskHasBountyList(task, key)) return task;
+  const nextLists = Array.isArray(task.bountyLists) ? [...task.bountyLists, key] : [key];
+  return { ...task, bountyLists: nextLists };
+}
+
+export function withTaskRemovedFromBountyList(task: Task, key: string | null): Task {
+  if (!key || !Array.isArray(task.bountyLists)) return task;
+  if (!task.bountyLists.includes(key)) return task;
+  const filtered = task.bountyLists.filter((value) => value !== key);
+  if (filtered.length === 0) {
+    const clone = { ...task };
+    delete clone.bountyLists;
+    return clone;
+  }
+  return { ...task, bountyLists: filtered };
+}
+
+export function isRecoverableBountyTask(task: Task): boolean {
+  return !!task.bounty && typeof task.bountyDeletedAt === "string" && task.bountyDeletedAt.trim().length > 0;
+}
+
+// ---- Nostr pubkey helpers ----
+
+export function toXOnlyHex(value?: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  const hex = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed;
+  if (/^(02|03)[0-9a-f]{64}$/.test(hex)) {
+    return hex.slice(-64);
+  }
+  if (/^[0-9a-f]{64}$/.test(hex)) {
+    return hex;
+  }
+  return null;
+}
+
+export function ensureXOnlyHex(value?: string | null): string | undefined {
+  const normalized = toXOnlyHex(value);
+  return normalized ?? undefined;
+}
+
+export function pubkeysEqual(a?: string | null, b?: string | null): boolean {
+  const ax = toXOnlyHex(a);
+  const bx = toXOnlyHex(b);
+  return !!(ax && bx && ax === bx);
+}
+
+// ---- Bounty normalization ----
+
+export function normalizeBounty(bounty?: Task["bounty"] | null): Task["bounty"] | undefined {
+  if (!bounty) return undefined;
+  const normalized: Task["bounty"] = { ...bounty };
+  const owner = ensureXOnlyHex(normalized!.owner);
+  if (owner) normalized!.owner = owner; else delete normalized!.owner;
+  const sender = ensureXOnlyHex(normalized!.sender);
+  if (sender) normalized!.sender = sender; else delete normalized!.sender;
+  const receiver = ensureXOnlyHex(normalized!.receiver);
+  if (receiver) normalized!.receiver = receiver; else delete normalized!.receiver;
+  const token = typeof normalized!.token === "string" ? normalized!.token : "";
+  const hasToken = token.trim().length > 0;
+  const hasCipher = normalized!.enc !== undefined && normalized!.enc !== null;
+
+  if (normalized!.state === "claimed" || normalized!.state === "revoked") {
+    return normalized;
+  }
+
+  if (hasToken && !hasCipher) {
+    normalized!.state = "unlocked";
+    if (!normalized!.lock || normalized!.lock === "unknown") {
+      normalized!.lock = "none";
+    }
+  } else if (hasCipher && !hasToken) {
+    normalized!.state = "locked";
+  } else if (hasToken && hasCipher) {
+    normalized!.state = "unlocked";
+  } else {
+    normalized!.state = "locked";
+  }
+
+  return normalized;
+}
+
+export function normalizeTaskBounty(task: Task): Task {
+  if (!Object.prototype.hasOwnProperty.call(task, "bounty")) {
+    return task;
+  }
+  const clone: Task = { ...task };
+  const bounty = (clone as any).bounty as Task["bounty"] | undefined;
+  if (!bounty) {
+    delete (clone as any).bounty;
+    return clone;
+  }
+  const normalized = normalizeBounty(bounty);
+  if (!normalized) {
+    delete (clone as any).bounty;
+    return clone;
+  }
+  clone.bounty = normalized;
+  return clone;
+}
+
+// ---- Bounty state label ----
+
+export function bountyStateLabel(bounty: Task["bounty"]): string {
+  return bounty!.state;
+}
+
+// ---- Streak helpers ----
+
+export function mergeLongestStreak(task: Task, streak: number | undefined): number | undefined {
+  const previous =
+    typeof task.longestStreak === "number"
+      ? task.longestStreak
+      : typeof task.streak === "number"
+        ? task.streak
+        : undefined;
+  if (typeof streak === "number") {
+    return previous === undefined ? streak : Math.max(previous, streak);
+  }
+  return previous;
+}
+
+// ---- Recurrence normalization ----
+
+export function normalizeHiddenForRecurring(task: Task): Task {
+  if (!task.hiddenUntilISO || !task.recurrence || !revealsOnDueDate(task.recurrence)) {
+    return task;
+  }
+  const dueMidnight = startOfDay(new Date(task.dueISO));
+  const hiddenMidnight = startOfDay(new Date(task.hiddenUntilISO));
+  if (Number.isNaN(dueMidnight.getTime()) || Number.isNaN(hiddenMidnight.getTime())) return task;
+  const today = startOfDay(new Date());
+  if (dueMidnight.getTime() > today.getTime() && hiddenMidnight.getTime() < dueMidnight.getTime()) {
+    return { ...task, hiddenUntilISO: dueMidnight.toISOString() };
+  }
+  return task;
+}
+
+export function recurrenceSeriesKey(task: Task): string | null {
+  if (!task.recurrence) return null;
+  if (task.seriesId) return `series:${task.boardId}:${task.seriesId}`;
+  const recurrence = JSON.stringify(task.recurrence);
+  return `sig:${task.boardId}::${task.title}::${task.note || ""}::${recurrence}`;
+}
+
+export function recurringInstanceId(seriesId: string, dueISO: string, rule?: Recurrence, timeZone?: string): string {
+  const datePart = isoDatePart(dueISO, timeZone);
+  const timePart =
+    rule && rule.type === "every" && rule.unit === "hour"
+      ? isoTimePartUtc(dueISO)
+      : "";
+  const suffix = timePart ? `${datePart}T${timePart}` : datePart;
+  return `recurrence:${seriesId}:${suffix}`;
+}
+
+export function recurringOccurrenceKey(task: Task): string | null {
+  if (!task.recurrence || !isFrequentRecurrence(task.recurrence)) return null;
+  const seriesKey = recurrenceSeriesKey(task);
+  if (!seriesKey) return null;
+  const datePart = isoDatePart(task.dueISO, task.dueTimeZone);
+  return `${seriesKey}::${datePart}`;
+}
+
+export function pickRecurringDuplicate(a: Task, b: Task): Task {
+  const aCompleted = !!a.completed;
+  const bCompleted = !!b.completed;
+  if (aCompleted !== bCompleted) return aCompleted ? a : b;
+  const aCompletedAt = a.completedAt ? Date.parse(a.completedAt) : 0;
+  const bCompletedAt = b.completedAt ? Date.parse(b.completedAt) : 0;
+  if (aCompletedAt !== bCompletedAt) return aCompletedAt >= bCompletedAt ? a : b;
+  const aIsBase = !!(a.seriesId && a.id === a.seriesId);
+  const bIsBase = !!(b.seriesId && b.id === b.seriesId);
+  if (aIsBase !== bIsBase) return aIsBase ? a : b;
+  const aOrder = typeof a.order === "number" ? a.order : Number.POSITIVE_INFINITY;
+  const bOrder = typeof b.order === "number" ? b.order : Number.POSITIVE_INFINITY;
+  if (aOrder !== bOrder) return aOrder < bOrder ? a : b;
+  return a.id.localeCompare(b.id) <= 0 ? a : b;
+}
+
+export function dedupeRecurringInstances(tasks: Task[]): Task[] {
+  const out: Task[] = [];
+  const indexByKey = new Map<string, number>();
+  let changed = false;
+  for (const task of tasks) {
+    const key = recurringOccurrenceKey(task);
+    if (!key) {
+      out.push(task);
+      continue;
+    }
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex === undefined) {
+      indexByKey.set(key, out.length);
+      out.push(task);
+      continue;
+    }
+    const existing = out[existingIndex];
+    const winner = pickRecurringDuplicate(existing, task);
+    if (winner !== existing) {
+      out[existingIndex] = winner;
+    }
+    changed = true;
+  }
+  return changed ? out : tasks;
+}
+
+// ---- Task created-at normalization ----
+
+export function normalizeTaskCreatedAt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+// ---- Bounty list key ----
+
+export const PINNED_BOUNTY_LIST_KEY = "taskify::pinned";

--- a/taskify-cli/src/taskCache.ts
+++ b/taskify-cli/src/taskCache.ts
@@ -32,6 +32,8 @@ export type CachedTask = {
   recurrence?: unknown;
   bounty?: object;
   reminders?: string[];
+  inboxItem?: boolean;
+  assignees?: string[];
 };
 
 export type BoardCache = {

--- a/taskify-cli/src/taskCache.ts
+++ b/taskify-cli/src/taskCache.ts
@@ -1,0 +1,95 @@
+// Task cache for fast completions and repeated list calls.
+// Cache file: ~/.config/taskify/cache.json
+
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export const CACHE_DIR = join(homedir(), ".config", "taskify");
+export const CACHE_PATH = join(CACHE_DIR, "cache.json");
+export const CACHE_TTL_MS = 300_000; // 5 minutes
+
+export type CachedTask = {
+  id: string;
+  title: string;
+  boardId: string;
+  boardName?: string;
+  status: string; // "open" | "done" | "deleted"
+  updatedAt?: number; // unix seconds
+  // Extended fields (mirrors FullTaskRecord for round-trip fidelity)
+  note?: string;
+  dueISO?: string;
+  dueDateEnabled?: boolean;
+  dueTimeEnabled?: boolean;
+  priority?: 1 | 2 | 3;
+  completed?: boolean;
+  completedAt?: string;
+  createdAt?: number;
+  createdBy?: string;
+  lastEditedBy?: string;
+  column?: string;
+  subtasks?: Array<{ id: string; title: string; completed: boolean }>;
+  recurrence?: unknown;
+  bounty?: object;
+  reminders?: string[];
+};
+
+export type BoardCache = {
+  tasks: CachedTask[];
+  fetchedAt: number;
+};
+
+export type TaskCache = {
+  boards: Record<string, BoardCache>;
+};
+
+export function readCache(): TaskCache {
+  try {
+    const raw = readFileSync(CACHE_PATH, "utf-8");
+    return JSON.parse(raw) as TaskCache;
+  } catch {
+    return { boards: {} };
+  }
+}
+
+export function writeCache(cache: TaskCache): void {
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(CACHE_PATH, JSON.stringify(cache, null, 2), "utf-8");
+  } catch {
+    // Non-fatal: cache writes are best-effort
+  }
+}
+
+export function clearCache(): void {
+  try {
+    unlinkSync(CACHE_PATH);
+  } catch {
+    // Non-fatal if already missing
+  }
+}
+
+export function isCacheFresh(boardCache: BoardCache): boolean {
+  return Date.now() - boardCache.fetchedAt < CACHE_TTL_MS;
+}
+
+/** Read open task IDs from cache synchronously for shell completions. */
+export function readCachedOpenTaskIds(): Array<{ id: string; title: string }> {
+  try {
+    const raw = readFileSync(CACHE_PATH, "utf-8");
+    const cache = JSON.parse(raw) as TaskCache;
+    const now = Date.now();
+    const results: Array<{ id: string; title: string }> = [];
+    for (const boardCache of Object.values(cache.boards ?? {})) {
+      if (now - boardCache.fetchedAt > CACHE_TTL_MS) continue;
+      for (const task of boardCache.tasks ?? []) {
+        if (task.status === "open") {
+          results.push({ id: task.id.slice(0, 8), title: task.title });
+        }
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}

--- a/taskify-cli/tsconfig.json
+++ b/taskify-cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## taskify-cli

Full-featured CLI for managing Taskify boards and tasks over the Nostr protocol.

### What's included

**Core task operations**
- `taskify list / add / show / update / done / reopen / delete`
- `taskify search` — full-text search
- `taskify subtask` — toggle subtasks by index or title
- `taskify remind` — set reminder presets

**Column-aware operations**
- `--column` flag on `add` and `update`
- Week boards auto-assign to today
- `taskify board columns` lists available columns

**Board management**
- `taskify board join / leave / sync / create`
- `taskify board children` for compound boards
- Compound board `listTasks` fans out across children

**Inbox**
- `taskify inbox add / list / triage`
- Quick capture + interactive triage flow

**Export / Import**
- `taskify export --format json|csv|md`
- `taskify import` from JSON or CSV with dry-run + duplicate detection

**AI agent (`taskify agent`)**
- `taskify agent add <description>` — NL → structured task via AI
- `taskify agent triage` — AI priority suggestions across open tasks
- Zero-npm fetch-based AI client (`src/aiClient.ts`)

**Assign / Unassign**
- `taskify assign / unassign` — manage task assignees by npub or hex

**Infrastructure**
- Shell completions: zsh, bash, fish
- Trust model (trusted npubs)
- Relay management
- Local task cache with TTL
- Agent dispatcher / security config
- TypeScript clean (TSC 0 errors)