### PR TITLE
feat(cli): resolve board names from metadata in board sync/list

### DIFF
--- a/.openclaw/skills/taskify-cli/SKILL.md
+++ b/.openclaw/skills/taskify-cli/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: taskify-cli
+description: Use the Taskify CLI to manage tasks, boards, inbox triage, exports/imports, trust, and profiles over Nostr. Trigger when users ask to list/add/update/complete/delete/search tasks, manage board metadata, run inbox triage, or perform Taskify agent commands from terminal workflows (not browser UI automation).
+---
+
+# Taskify CLI
+
+Use deterministic CLI-first workflows for Taskify.
+
+## Command surface
+
+Primary executable: `taskify`
+Repo location: `/Users/openclaw/.openclaw/workspace/Taskify_Release/taskify-cli`
+
+If `taskify` is missing globally, run via local package:
+- `cd /Users/openclaw/.openclaw/workspace/Taskify_Release/taskify-cli`
+- `npm run build` (if needed)
+- `node dist/index.js <args>`
+
+## Safety and reliability rules
+
+1. Prefer read commands first (`list`, `show`, `search`, `boards`, `board columns`) before mutating state.
+2. For destructive commands (`delete`, `board leave`, imports without `--dry-run`), confirm exact target identity first.
+3. Use `--json` whenever machine-verifiable output is needed.
+4. For ambiguous title matches, resolve exact task ID via `taskify search <query> --status any --json`.
+5. Never claim success until exit code is 0 and output confirms expected mutation.
+
+## Fast workflows
+
+### List and filter
+- Open tasks (table): `taskify list`
+- Open tasks (JSON): `taskify list --json`
+- Include done: `taskify list --status any --json`
+- Filter by board/column: `taskify list --board "<board>" --column "<column>" --json`
+
+### Create task
+- Minimal: `taskify add "<title>"`
+- Rich: `taskify add "<title>" --board "<board>" --due "YYYY-MM-DD" --priority 2 --note "..." --subtask "..." --column "..."`
+
+### Update task
+1. Resolve ID:
+   - `taskify search "<query>" --status any --json`
+2. Update fields:
+   - `taskify update <taskId> --title "..." --due "YYYY-MM-DD" --priority 1 --note "..." --column "..."`
+
+### Complete / reopen / delete
+- Complete: `taskify done <taskId> --board "<board>"`
+- Reopen: `taskify reopen <taskId> --board "<board>"`
+- Delete: `taskify delete <taskId> --board "<board>" --force`
+
+### Inbox triage
+- List inbox: `taskify inbox list --board "<board>"`
+- Quick add: `taskify inbox add "<title>" --board "<board>"`
+- Triage: `taskify inbox triage <taskId> --board "<board>" --column "<column>" --priority 2 --due "YYYY-MM-DD" --yes`
+
+### Boards and columns
+- List boards: `taskify boards --json`
+- Joined boards: `taskify board list`
+- Board columns: `taskify board columns "<board>"`
+- Sync board metadata: `taskify board sync`
+
+### Export/import
+- Export JSON: `taskify export --board "<board>" --format json --output /tmp/tasks.json`
+- Export CSV/MD: `taskify export --board "<board>" --format csv --output /tmp/tasks.csv`
+- Import dry run: `taskify import /tmp/tasks.json --board "<board>" --dry-run`
+- Import apply: `taskify import /tmp/tasks.json --board "<board>" --yes`
+
+### Profiles
+- List: `taskify profile list`
+- Use profile: `taskify profile use <name>`
+- One-shot profile: `taskify list --profile <name> --json`
+
+## Task ID resolution pattern (required for edits/deletes)
+
+1. `taskify search "<title fragment>" --status any --json`
+2. Prefer exact title match (and board match if provided).
+3. If multiple matches remain, ask one clarification question.
+4. Execute mutation with resolved `<taskId>`.
+5. Re-read with `taskify show <taskId> --json` or `taskify list --status any --json` to verify.
+
+## Output contract
+
+For agent responses, return concise structure:
+- `status`: `ok` | `failed`
+- `action`: command intent
+- `evidence`: command(s) + key output proof (ID/state)
+- `error`: present only on failure
+
+## References
+
+- CLI commands and examples: `references/command-reference.md`
+- Troubleshooting and fallback execution: `references/troubleshooting.md`

--- a/.openclaw/skills/taskify-cli/references/command-reference.md
+++ b/.openclaw/skills/taskify-cli/references/command-reference.md
@@ -1,0 +1,48 @@
+# Taskify CLI Command Reference
+
+## Core task lifecycle
+
+```bash
+taskify list --status any --json
+taskify add "Ship release notes" --board "Work" --priority 2
+taskify search "release notes" --status any --json
+taskify update <taskId> --due "2026-03-15" --column "In Progress"
+taskify done <taskId>
+taskify reopen <taskId>
+taskify delete <taskId> --force
+```
+
+## Inbox
+
+```bash
+taskify inbox list --board "Work"
+taskify inbox add "Follow up with design" --board "Work"
+taskify inbox triage <taskId> --board "Work" --column "Backlog" --priority 2 --yes
+```
+
+## Boards
+
+```bash
+taskify boards --json
+taskify board list
+taskify board columns "Work"
+taskify board create "Sprint 12" --kind lists
+taskify board sync
+```
+
+## Import/export
+
+```bash
+taskify export --board "Work" --format json --output /tmp/work-tasks.json
+taskify import /tmp/work-tasks.json --board "Work" --dry-run
+taskify import /tmp/work-tasks.json --board "Work" --yes
+```
+
+## Profiles
+
+```bash
+taskify profile list
+taskify profile add cody
+taskify profile use cody
+taskify list --profile cody --json
+```

--- a/.openclaw/skills/taskify-cli/references/troubleshooting.md
+++ b/.openclaw/skills/taskify-cli/references/troubleshooting.md
@@ -1,0 +1,51 @@
+# Taskify CLI Troubleshooting
+
+## `taskify` command not found
+
+Use local entrypoint from repo:
+
+```bash
+cd /Users/openclaw/.openclaw/workspace/Taskify_Release/taskify-cli
+npm install
+npm run build
+node dist/index.js --help
+```
+
+Optional global link:
+
+```bash
+npm link
+taskify --help
+```
+
+## Auth/key issues
+
+Set key:
+
+```bash
+taskify config set nsec nsec1...
+# or
+export TASKIFY_NSEC=nsec1...
+```
+
+Check config:
+
+```bash
+taskify config show
+```
+
+## Relay/connectivity issues
+
+```bash
+taskify relay list
+taskify relay status
+taskify board sync
+```
+
+## Ambiguous task target
+
+Always resolve with search JSON first:
+
+```bash
+taskify search "<query>" --status any --json
+```

--- a/taskify-cli/README.md
+++ b/taskify-cli/README.md
@@ -197,6 +197,50 @@ Adding tasks to a compound board directly is not allowed — use a child board i
 
 ---
 
+## Multiple profiles
+
+Each agent or user can have their own named Nostr identity:
+
+```bash
+# List profiles
+taskify profile list
+
+# Add a new identity
+taskify profile add ink
+
+# Switch active profile
+taskify profile use ink
+
+# Use a profile for one command without switching
+taskify list --profile cody --board "Dev"
+
+# Show profile details
+taskify profile show
+
+# Rename a profile
+taskify profile rename ink writer
+
+# Remove a profile (cannot remove the active one)
+taskify profile remove old-profile --force
+```
+
+Profiles store separate nsec, relays, boards, and trusted npubs.
+The active profile is used by default for all commands.
+Use `--profile <name>` (`-P <name>`) on any command to use a different profile without switching.
+
+### Profile commands
+
+| Command | Options | Description |
+|---|---|---|
+| `profile list` | | List all profiles (► marks active) |
+| `profile add <name>` | | Add a new profile (mini onboarding) |
+| `profile use <name>` | | Switch active profile |
+| `profile show [name]` | | Show profile details (defaults to active) |
+| `profile remove <name>` | `--force` | Remove a profile |
+| `profile rename <old> <new>` | | Rename a profile |
+
+---
+
 ## Example output
 
 ### `taskify list`

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskify-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskify-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@noble/hashes": "^1.4.0",
         "@nostr-dev-kit/ndk": "^2.18.1",

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -18,7 +18,8 @@
         "taskify": "src/index.ts"
       },
       "devDependencies": {
-        "@types/node": "^25.4.0"
+        "@types/node": "^25.4.0",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@codesandbox/nodebox": {
@@ -886,6 +887,20 @@
       "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
       "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/typescript-lru-cache": {
       "version": "2.0.0",

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskify-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskify-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@noble/hashes": "^1.4.0",
         "@nostr-dev-kit/ndk": "^2.18.1",

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -10,7 +10,8 @@
     "build": "tsc && node -e \"const fs=require('fs');const f='dist/index.js';let c=fs.readFileSync(f,'utf8');if(c.startsWith('#!'))c=c.slice(c.indexOf('\\n')+1);fs.writeFileSync(f,'#!/usr/bin/env node\\n'+c)\"",
     "prepare": "npm run build",
     "start": "node dist/index.js",
-    "dev": "node --experimental-strip-types src/index.ts"
+    "dev": "node --experimental-strip-types src/index.ts",
+    "test": "node --test --experimental-strip-types tests/*.test.ts"
   },
   "files": [
     "dist/",

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskify-nostr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -4,7 +4,7 @@
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {
-    "taskify": "./dist/index.js"
+    "taskify": "dist/index.js"
   },
   "scripts": {
     "build": "tsc && node -e \"const fs=require('fs');const f='dist/index.js';let c=fs.readFileSync(f,'utf8');if(c.startsWith('#!'))c=c.slice(c.indexOf('\\n')+1);fs.writeFileSync(f,'#!/usr/bin/env node\\n'+c)\"",
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Solife-me/Taskify_Release"
+    "url": "git+https://github.com/Solife-me/Taskify_Release.git"
   },
   "dependencies": {
     "@noble/hashes": "^1.4.0",

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskify-nostr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,12 +1,34 @@
 {
-  "name": "taskify-cli",
+  "name": "taskify-nostr",
   "version": "0.1.0",
+  "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {
-    "taskify": "./src/index.ts"
+    "taskify": "./dist/index.js"
   },
   "scripts": {
-    "start": "node --experimental-strip-types src/index.ts"
+    "build": "tsc && node -e \"const fs=require('fs');const f='dist/index.js';let c=fs.readFileSync(f,'utf8');if(c.startsWith('#!'))c=c.slice(c.indexOf('\\n')+1);fs.writeFileSync(f,'#!/usr/bin/env node\\n'+c)\"",
+    "prepare": "npm run build",
+    "start": "node dist/index.js",
+    "dev": "node --experimental-strip-types src/index.ts"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "keywords": [
+    "nostr",
+    "tasks",
+    "cli",
+    "productivity"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Solife-me/Taskify_Release"
   },
   "dependencies": {
     "@noble/hashes": "^1.4.0",
@@ -16,6 +38,7 @@
     "nostr-tools": "^2.16.2"
   },
   "devDependencies": {
-    "@types/node": "^25.4.0"
+    "@types/node": "^25.4.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/taskify-cli/src/config.ts
+++ b/taskify-cli/src/config.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from "fs/promises";
 import { mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import type { ReminderPreset } from "./shared/taskTypes.ts";
+import type { ReminderPreset } from "./shared/taskTypes.js";
 
 export const CONFIG_DIR = join(homedir(), ".taskify-cli");
 export const CONFIG_PATH = join(CONFIG_DIR, "config.json");

--- a/taskify-cli/src/config.ts
+++ b/taskify-cli/src/config.ts
@@ -16,7 +16,8 @@ export type BoardEntry = {
   children?: string[];
 };
 
-export type TaskifyConfig = {
+// Per-profile configuration (stored inside profiles.*)
+export type ProfileConfig = {
   nsec?: string;
   relays: string[];
   defaultBoard: string;
@@ -33,13 +34,27 @@ export type TaskifyConfig = {
   };
 };
 
-const DEFAULT_CONFIG: TaskifyConfig = {
-  relays: [
-    "wss://relay.damus.io",
-    "wss://nos.lol",
-    "wss://relay.snort.social",
-    "wss://relay.primal.net",
-  ],
+// What gets stored on disk (new multi-profile format)
+type StoredConfig = {
+  activeProfile: string;
+  profiles: Record<string, ProfileConfig>;
+};
+
+// What loadConfig() returns: flat profile fields + metadata
+export type TaskifyConfig = ProfileConfig & {
+  activeProfile: string;
+  profiles: Record<string, ProfileConfig>;
+};
+
+export const DEFAULT_RELAYS = [
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.snort.social",
+  "wss://relay.primal.net",
+];
+
+const DEFAULT_PROFILE: ProfileConfig = {
+  relays: [...DEFAULT_RELAYS],
   defaultBoard: "Personal",
   trustedNpubs: [],
   securityMode: "moderate",
@@ -48,22 +63,118 @@ const DEFAULT_CONFIG: TaskifyConfig = {
   taskReminders: {},
 };
 
-export async function loadConfig(): Promise<TaskifyConfig> {
-  let cfg: TaskifyConfig;
-  try {
-    const raw = await readFile(CONFIG_PATH, "utf-8");
-    cfg = { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
-  } catch {
-    cfg = { ...DEFAULT_CONFIG };
-  }
-  if (process.env.TASKIFY_NSEC) {
-    cfg.nsec = process.env.TASKIFY_NSEC;
-    process.stderr.write("\x1b[2m(using TASKIFY_NSEC from env)\x1b[0m\n");
-  }
-  return cfg;
+function profileDefaults(partial: Partial<ProfileConfig>): ProfileConfig {
+  return {
+    ...DEFAULT_PROFILE,
+    ...partial,
+    relays: partial.relays && partial.relays.length > 0 ? partial.relays : [...DEFAULT_RELAYS],
+    taskReminders: partial.taskReminders ?? {},
+    trustedNpubs: partial.trustedNpubs ?? [],
+    boards: partial.boards ?? [],
+  };
 }
 
+export async function loadConfig(profileName?: string): Promise<TaskifyConfig> {
+  let stored: StoredConfig;
+
+  try {
+    const raw = await readFile(CONFIG_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    // Migration: detect old flat format (has nsec or relays at top level, no profiles key)
+    if (!parsed.profiles && (parsed.nsec !== undefined || Array.isArray(parsed.relays))) {
+      const profile = profileDefaults(parsed as Partial<ProfileConfig>);
+      stored = {
+        activeProfile: "default",
+        profiles: { default: profile },
+      };
+      // Save migrated config
+      mkdirSync(CONFIG_DIR, { recursive: true });
+      await writeFile(CONFIG_PATH, JSON.stringify(stored, null, 2), "utf-8");
+      process.stderr.write("✓ Config migrated to multi-profile format\n");
+    } else if (parsed.profiles && parsed.activeProfile) {
+      stored = parsed as unknown as StoredConfig;
+    } else {
+      // New empty or unrecognized config
+      stored = {
+        activeProfile: "default",
+        profiles: { default: { ...DEFAULT_PROFILE } },
+      };
+    }
+  } catch {
+    stored = {
+      activeProfile: "default",
+      profiles: { default: { ...DEFAULT_PROFILE } },
+    };
+  }
+
+  // Determine which profile to use
+  const resolvedProfileName = profileName ?? stored.activeProfile;
+  const profile = stored.profiles[resolvedProfileName];
+
+  if (!profile) {
+    throw new Error(
+      `Profile not found: "${resolvedProfileName}". Available: ${Object.keys(stored.profiles).join(", ")}`,
+    );
+  }
+
+  const merged = profileDefaults(profile);
+
+  // TASKIFY_NSEC env var overrides nsec for any profile
+  if (process.env.TASKIFY_NSEC) {
+    merged.nsec = process.env.TASKIFY_NSEC;
+    process.stderr.write("\x1b[2m(using TASKIFY_NSEC from env)\x1b[0m\n");
+  }
+
+  return {
+    ...merged,
+    activeProfile: stored.activeProfile,
+    profiles: stored.profiles,
+  };
+}
+
+// Updates the active profile from flat cfg fields, then saves
 export async function saveConfig(cfg: TaskifyConfig): Promise<void> {
   mkdirSync(CONFIG_DIR, { recursive: true });
-  await writeFile(CONFIG_PATH, JSON.stringify(cfg, null, 2), "utf-8");
+  const profileData: ProfileConfig = {
+    nsec: cfg.nsec,
+    relays: cfg.relays,
+    defaultBoard: cfg.defaultBoard,
+    trustedNpubs: cfg.trustedNpubs,
+    securityMode: cfg.securityMode,
+    securityEnabled: cfg.securityEnabled,
+    boards: cfg.boards,
+    taskReminders: cfg.taskReminders,
+    agent: cfg.agent,
+  };
+  const stored: StoredConfig = {
+    activeProfile: cfg.activeProfile,
+    profiles: {
+      ...cfg.profiles,
+      [cfg.activeProfile]: profileData,
+    },
+  };
+  await writeFile(CONFIG_PATH, JSON.stringify(stored, null, 2), "utf-8");
+}
+
+// Save the raw profiles structure (for profile management commands — does NOT rewrite active profile from flat fields)
+export async function saveProfiles(
+  activeProfile: string,
+  profiles: Record<string, ProfileConfig>,
+): Promise<void> {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  await writeFile(CONFIG_PATH, JSON.stringify({ activeProfile, profiles }, null, 2), "utf-8");
+}
+
+export function getActiveProfile(cfg: TaskifyConfig): ProfileConfig {
+  return cfg.profiles[cfg.activeProfile] ?? { ...DEFAULT_PROFILE };
+}
+
+export async function setActiveProfile(cfg: TaskifyConfig, name: string): Promise<void> {
+  await saveProfiles(name, cfg.profiles);
+}
+
+export function resolveProfile(cfg: TaskifyConfig, name?: string): ProfileConfig {
+  const profileName = name ?? cfg.activeProfile;
+  return cfg.profiles[profileName] ?? { ...DEFAULT_PROFILE };
 }

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -1,13 +1,15 @@
-#!/usr/bin/env node --experimental-strip-types
+#!/usr/bin/env node
 import { Command } from "commander";
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";
+import { createInterface } from "readline";
 import { nip19 } from "nostr-tools";
-import { loadConfig, saveConfig } from "./config.ts";
-import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.ts";
-import { renderTable, renderTaskCard, renderJson } from "./render.ts";
-import { zshCompletion, bashCompletion, fishCompletion } from "./completions.ts";
-import { readCache, clearCache, CACHE_PATH, CACHE_TTL_MS } from "./taskCache.ts";
+import { loadConfig, saveConfig } from "./config.js";
+import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.js";
+import { renderTable, renderTaskCard, renderJson } from "./render.js";
+import { zshCompletion, bashCompletion, fishCompletion } from "./completions.js";
+import { readCache, clearCache, CACHE_PATH, CACHE_TTL_MS } from "./taskCache.js";
+import { runOnboarding } from "./onboarding.js";
 
 const program = new Command();
 
@@ -1214,7 +1216,7 @@ agentCmd
     }
 
     const today = new Date().toISOString().slice(0, 10);
-    const { callAI } = await import("./aiClient.ts");
+    const { callAI } = await import("./aiClient.js");
 
     const SYSTEM_PROMPT = `You are a task extraction assistant. Extract fields from the description.
 Return ONLY valid JSON (no markdown, no explanation):
@@ -1347,7 +1349,7 @@ agentCmd
         process.exit(0);
       }
 
-      const { callAI } = await import("./aiClient.ts");
+      const { callAI } = await import("./aiClient.js");
 
       const SYSTEM_PROMPT = `You are a task prioritization assistant. Given open tasks, suggest priority (1=low, 2=medium, 3=high) for each.
 Return ONLY a valid JSON array (no markdown):
@@ -2034,4 +2036,32 @@ program
     }
   });
 
-program.parse(process.argv);
+// ---- setup ----
+program
+  .command("setup")
+  .description("Run the first-run onboarding wizard (re-configure or add a new key)")
+  .action(async () => {
+    const existing = await loadConfig();
+    if (existing.nsec) {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const ans = await new Promise<string>((resolve) => {
+        rl.question(
+          "⚠ You already have a private key configured. This will replace it.\nContinue? [Y/n] ",
+          resolve
+        );
+      });
+      rl.close();
+      if (ans.trim().toLowerCase() === "n") {
+        process.exit(0);
+      }
+    }
+    await runOnboarding();
+  });
+
+// ---- auto-onboarding trigger + parse ----
+const cfg = await loadConfig();
+if (!cfg.nsec && process.argv.length <= 2) {
+  await runOnboarding();
+} else {
+  program.parse(process.argv);
+}

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -3,8 +3,8 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";
 import { createInterface } from "readline";
-import { nip19 } from "nostr-tools";
-import { loadConfig, saveConfig } from "./config.js";
+import { nip19, getPublicKey, generateSecretKey } from "nostr-tools";
+import { loadConfig, saveConfig, saveProfiles, DEFAULT_RELAYS, type ProfileConfig } from "./config.js";
 import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.js";
 import { renderTable, renderTaskCard, renderJson } from "./render.js";
 import { zshCompletion, bashCompletion, fishCompletion } from "./completions.js";
@@ -16,7 +16,8 @@ const program = new Command();
 program
   .name("taskify")
   .version("0.1.0")
-  .description("Taskify CLI — manage tasks over Nostr");
+  .description("Taskify CLI — manage tasks over Nostr")
+  .option("-P, --profile <name>", "Use a specific profile for this command (does not change active profile)");
 
 // ---- Validation helpers ----
 
@@ -99,7 +100,7 @@ boardCmd
   .command("list")
   .description("List all configured boards")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
     } else {
@@ -121,7 +122,7 @@ boardCmd
     if (!UUID_RE.test(boardId)) {
       console.warn(chalk.yellow(`Warning: "${boardId}" does not look like a UUID.`));
     }
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const existing = config.boards.find((b) => b.id === boardId);
     if (existing) {
       console.log(chalk.dim(`Already on board ${existing.name} (${boardId})`));
@@ -152,7 +153,7 @@ boardCmd
   .command("sync [boardId]")
   .description("Sync board metadata (kind, columns) from Nostr")
   .action(async (boardId?: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.error(chalk.red("No boards configured."));
       process.exit(1);
@@ -177,7 +178,7 @@ boardCmd
           const meta = await runtime.syncBoard(entry.id);
           const colCount = meta.columns?.length ?? 0;
           const kindStr = meta.kind ?? "unknown";
-          const reloadedEntry = (await loadConfig()).boards.find((b) => b.id === entry.id);
+          const reloadedEntry = (await loadConfig(program.opts().profile as string | undefined)).boards.find((b) => b.id === entry.id);
           const childrenCount = reloadedEntry?.children?.length ?? 0;
           const childrenStr = kindStr === "compound" ? `, children: ${childrenCount}` : "";
           console.log(chalk.green(`✓ Synced: ${entry.name} (kind: ${kindStr}, columns: ${colCount}${childrenStr})`));
@@ -196,7 +197,7 @@ boardCmd
   .command("leave <boardId>")
   .description("Remove a board from config")
   .action(async (boardId: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const before = config.boards.length;
     config.boards = config.boards.filter((b) => b.id !== boardId);
     if (config.boards.length === before) {
@@ -212,7 +213,7 @@ boardCmd
   .command("columns")
   .description("Show cached columns for all configured boards")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
       process.exit(0);
@@ -235,7 +236,7 @@ boardCmd
   .command("children <board>")
   .description("List children of a compound board")
   .action(async (boardArg: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const entry =
       config.boards.find((b) => b.id === boardArg) ??
       config.boards.find((b) => b.name.toLowerCase() === boardArg.toLowerCase());
@@ -268,7 +269,7 @@ program
   .command("boards")
   .description("List configured boards (alias for: board list)")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
     } else {
@@ -335,7 +336,7 @@ program
   .option("--no-cache", "Do not fall back to stale cache if relay returns empty")
   .option("--json", "Output as JSON")
   .action(async (opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -396,7 +397,7 @@ program
   .option("--json", "Output raw task fields as JSON")
   .action(async (taskId: string, opts) => {
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -426,7 +427,7 @@ program
   .option("--board <id|name>", "Limit to a specific board")
   .option("--json", "Output as JSON")
   .action(async (query: string, opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -474,7 +475,7 @@ program
       );
       process.exit(1);
     }
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -520,7 +521,7 @@ program
   .action(async (title: string, opts) => {
     validateDue(opts.due);
     validatePriority(opts.priority);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const boardEntry = config.boards.find((b) => b.id === boardId)!;
 
@@ -595,7 +596,7 @@ program
   .option("--json", "Output updated task as JSON")
   .action(async (taskId: string, opts) => {
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -626,7 +627,7 @@ program
   .option("--json", "Output updated task as JSON")
   .action(async (taskId: string, opts) => {
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -658,7 +659,7 @@ program
   .option("--json", "Output deleted task as JSON")
   .action(async (taskId: string, opts) => {
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -726,7 +727,7 @@ program
       process.exit(1);
     }
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -777,7 +778,7 @@ program
     warnShortTaskId(taskId);
     validateDue(opts.due);
     validatePriority(opts.priority);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -823,7 +824,7 @@ trust
   .command("add <npub>")
   .description("Add a trusted npub")
   .action(async (npub: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.trustedNpubs.includes(npub)) {
       config.trustedNpubs.push(npub);
     }
@@ -836,7 +837,7 @@ trust
   .command("remove <npub>")
   .description("Remove a trusted npub")
   .action(async (npub: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     config.trustedNpubs = config.trustedNpubs.filter((n) => n !== npub);
     await saveConfig(config);
     console.log(chalk.green("✓ Removed"));
@@ -847,7 +848,7 @@ trust
   .command("list")
   .description("List trusted npubs")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.trustedNpubs.length === 0) {
       console.log(chalk.dim("No trusted npubs."));
     } else {
@@ -865,7 +866,7 @@ relayCmd
   .command("status")
   .description("Show connection status of relays in the NDK pool")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -894,7 +895,7 @@ relayCmd
   .command("list")
   .description("Show configured relays with live connection check")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.relays.length === 0) {
       console.log(chalk.dim("No relays configured."));
       process.exit(0);
@@ -915,7 +916,7 @@ relayCmd
   .command("add <url>")
   .description("Add a relay URL to config")
   .action(async (url: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.relays.includes(url)) {
       config.relays.push(url);
       await saveConfig(config);
@@ -930,7 +931,7 @@ relayCmd
   .command("remove <url>")
   .description("Remove a relay URL from config")
   .action(async (url: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const before = config.relays.length;
     config.relays = config.relays.filter((r) => r !== url);
     if (config.relays.length === before) {
@@ -958,7 +959,7 @@ cacheCmd
   .command("status")
   .description("Show per-board cache age and task count")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const cache = readCache();
     const now = Date.now();
     if (Object.keys(cache.boards).length === 0) {
@@ -1007,7 +1008,7 @@ configSet
       console.error(chalk.red(`Invalid nsec: must start with "nsec1".`));
       process.exit(1);
     }
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     config.nsec = nsec;
     await saveConfig(config);
     console.log(chalk.green("✓ nsec saved"));
@@ -1018,7 +1019,7 @@ configSet
   .command("relay <url>")
   .description("Add a relay URL")
   .action(async (url: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.relays.includes(url)) {
       config.relays.push(url);
     }
@@ -1063,7 +1064,7 @@ configCmd
   .command("show")
   .description("Show current config")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const display = {
       ...config,
       nsec: config.nsec ? "nsec1****" : undefined,
@@ -1133,7 +1134,7 @@ agentConfigCmd
   .command("set-key <key>")
   .description("Set the AI API key")
   .action(async (key: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.agent) config.agent = {};
     config.agent.apiKey = key;
     await saveConfig(config);
@@ -1145,7 +1146,7 @@ agentConfigCmd
   .command("set-model <model>")
   .description("Set the AI model")
   .action(async (model: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.agent) config.agent = {};
     config.agent.model = model;
     await saveConfig(config);
@@ -1157,7 +1158,7 @@ agentConfigCmd
   .command("set-url <url>")
   .description("Set the AI base URL (OpenAI-compatible)")
   .action(async (url: string) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     if (!config.agent) config.agent = {};
     config.agent.baseUrl = url;
     await saveConfig(config);
@@ -1169,7 +1170,7 @@ agentConfigCmd
   .command("show")
   .description("Show current agent config (masks API key)")
   .action(async () => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const ag = config.agent ?? {};
     const rawKey = ag.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
     let maskedKey = "(not set)";
@@ -1193,7 +1194,7 @@ agentCmd
   .option("--dry-run", "Show extracted fields without creating")
   .option("--json", "Output created task as JSON")
   .action(async (description: string, opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const apiKey = config.agent?.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
     if (!apiKey) {
       console.error(chalk.red("No AI API key configured. Run: taskify agent config set-key <key>"));
@@ -1331,7 +1332,7 @@ agentCmd
   .option("--dry-run", "Show suggestions without applying")
   .option("--json", "Output suggestions as JSON")
   .action(async (opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const apiKey = config.agent?.apiKey ?? process.env.TASKIFY_AGENT_API_KEY ?? "";
     if (!apiKey) {
       console.error(chalk.red("No AI API key configured. Run: taskify agent config set-key <key>"));
@@ -1502,7 +1503,7 @@ program
   .option("--status <open|done|any>", "Status filter (default: open)", "open")
   .option("--output <file>", "Write to file instead of stdout")
   .action(async (opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -1601,7 +1602,7 @@ program
   .option("--dry-run", "Print preview but do not create tasks")
   .option("--yes", "Skip confirmation prompt")
   .action(async (file: string, opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
 
     let raw: string;
@@ -1758,7 +1759,7 @@ inboxCmd
   .description("List inbox tasks (inboxItem: true)")
   .option("--board <id|name>", "Board to list from")
   .action(async (opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -1784,7 +1785,7 @@ inboxCmd
   .description("Capture a task to inbox (inboxItem: true)")
   .option("--board <id|name>", "Board to add to")
   .action(async (title: string, opts) => {
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const boardEntry = config.boards.find((b) => b.id === boardId)!;
     if (boardEntry.kind === "compound") {
@@ -1822,7 +1823,7 @@ inboxCmd
     validateDue(opts.due);
     validatePriority(opts.priority);
     warnShortTaskId(taskId);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const boardEntry = config.boards.find((b) => b.id === boardId)!;
     const runtime = initRuntime(config);
@@ -1923,7 +1924,7 @@ boardCmd
       process.exit(1);
     }
     const kind = opts.kind as "lists" | "week";
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
@@ -1964,7 +1965,7 @@ program
   .action(async (taskId: string, npubOrHex: string, opts) => {
     warnShortTaskId(taskId);
     const hex = npubOrHexToHex(npubOrHex);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -2006,7 +2007,7 @@ program
   .action(async (taskId: string, npubOrHex: string, opts) => {
     warnShortTaskId(taskId);
     const hex = npubOrHexToHex(npubOrHex);
-    const config = await loadConfig();
+    const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
@@ -2036,18 +2037,277 @@ program
     }
   });
 
+// ---- Helper: readline queue (handles piped stdin correctly) ----
+function makeLineQueue(rl: ReturnType<typeof createInterface>): (prompt: string) => Promise<string> {
+  const lineQueue: string[] = [];
+  const waiters: ((line: string) => void)[] = [];
+  rl.on("line", (line: string) => {
+    if (waiters.length > 0) {
+      waiters.shift()!(line);
+    } else {
+      lineQueue.push(line);
+    }
+  });
+  return (prompt: string) => {
+    process.stdout.write(prompt);
+    return new Promise<string>((resolve) => {
+      if (lineQueue.length > 0) {
+        resolve(lineQueue.shift()!);
+      } else {
+        waiters.push(resolve);
+      }
+    });
+  };
+}
+
+// ---- profile command group ----
+const profileCmd = program
+  .command("profile")
+  .description("Manage named Nostr identity profiles");
+
+// Helper to get npub string from nsec
+function nsecToNpub(nsec: string): string | null {
+  try {
+    const decoded = nip19.decode(nsec);
+    if (decoded.type === "nsec") {
+      const pk = getPublicKey(decoded.data as Uint8Array);
+      return nip19.npubEncode(pk);
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+profileCmd
+  .command("list")
+  .description("List all profiles (► marks active)")
+  .action(async () => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    for (const [name, profile] of Object.entries(config.profiles)) {
+      const isActive = name === config.activeProfile;
+      const marker = isActive ? "►" : " ";
+      let npubStr = "(no key)";
+      if (profile.nsec) {
+        const npub = nsecToNpub(profile.nsec);
+        if (npub) npubStr = npub.slice(0, 12) + "..." + npub.slice(-4);
+      }
+      const boardCount = profile.boards?.length ?? 0;
+      console.log(
+        `  ${marker} ${name.padEnd(14)} ${npubStr.padEnd(22)} ${boardCount} board${boardCount !== 1 ? "s" : ""}`,
+      );
+    }
+    process.exit(0);
+  });
+
+profileCmd
+  .command("add <name>")
+  .description("Add a new profile (runs mini onboarding for the new identity)")
+  .action(async (name: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    if (config.profiles[name]) {
+      console.error(chalk.red(`Profile already exists: "${name}"`));
+      process.exit(1);
+    }
+
+    console.log();
+    console.log(chalk.bold(`Setting up profile: ${name}`));
+    console.log();
+
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const ask = makeLineQueue(rl);
+
+    // Key setup
+    const hasKey = await ask("Do you have a Nostr private key (nsec)? [Y/n] ");
+    let nsec: string | undefined;
+
+    if (hasKey.trim().toLowerCase() !== "n") {
+      while (true) {
+        const input = (await ask("Paste your nsec: ")).trim();
+        if (input.startsWith("nsec1")) {
+          try {
+            nip19.decode(input);
+            nsec = input;
+            break;
+          } catch { /* invalid */ }
+        }
+        console.log("Invalid nsec. Try again or press Ctrl+C to abort.");
+      }
+    } else {
+      const sk = generateSecretKey();
+      const pk = getPublicKey(sk);
+      nsec = nip19.nsecEncode(sk);
+      const npub = nip19.npubEncode(pk);
+      console.log();
+      console.log("✓ Generated new Nostr identity");
+      console.log(`  npub: ${npub}`);
+      console.log(`  nsec: ${nsec}  ← KEEP THIS SECRET — it is your password`);
+      console.log();
+      console.log("Save this nsec somewhere safe. It cannot be recovered if lost.");
+      const cont = await ask("Continue? [Y/n] ");
+      if (cont.trim().toLowerCase() === "n") {
+        rl.close();
+        process.exit(0);
+      }
+    }
+
+    // Relays setup
+    console.log();
+    let relays = [...DEFAULT_RELAYS];
+    const useDefaults = await ask("Use default relays? [Y/n] ");
+    if (useDefaults.trim().toLowerCase() === "n") {
+      relays = [];
+      while (true) {
+        const relay = (await ask("Add relay URL (blank to finish): ")).trim();
+        if (!relay) break;
+        relays.push(relay);
+      }
+      if (relays.length === 0) relays = [...DEFAULT_RELAYS];
+    }
+
+    rl.close();
+
+    const newProfile: ProfileConfig = {
+      nsec,
+      relays,
+      boards: [],
+      trustedNpubs: [],
+      securityMode: "moderate",
+      securityEnabled: true,
+      defaultBoard: "Personal",
+      taskReminders: {},
+    };
+
+    const newProfiles = { ...config.profiles, [name]: newProfile };
+    await saveProfiles(config.activeProfile, newProfiles);
+    console.log();
+    console.log(chalk.green(`✓ Profile '${name}' created. Run: taskify profile use ${name}`));
+    process.exit(0);
+  });
+
+profileCmd
+  .command("use <name>")
+  .description("Switch the active profile")
+  .action(async (name: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    if (!config.profiles[name]) {
+      console.error(
+        chalk.red(`Profile not found: "${name}". Available: ${Object.keys(config.profiles).join(", ")}`),
+      );
+      process.exit(1);
+    }
+    await saveProfiles(name, config.profiles);
+    console.log(chalk.green(`✓ Switched to profile: ${name}`));
+    process.exit(0);
+  });
+
+profileCmd
+  .command("show [name]")
+  .description("Show profile details (defaults to active profile)")
+  .action(async (name?: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const profileName = name ?? config.activeProfile;
+    const profile = config.profiles[profileName];
+    if (!profile) {
+      console.error(
+        chalk.red(`Profile not found: "${profileName}". Available: ${Object.keys(config.profiles).join(", ")}`),
+      );
+      process.exit(1);
+    }
+    const isActive = profileName === config.activeProfile;
+
+    console.log(chalk.bold(`Profile: ${profileName}${isActive ? "  ◄ active" : ""}`));
+
+    let npubStr = "(no key)";
+    if (profile.nsec) {
+      const npub = nsecToNpub(profile.nsec);
+      if (npub) npubStr = npub;
+    }
+    const maskedNsec = profile.nsec ? profile.nsec.slice(0, 8) + "..." : "(not set)";
+
+    console.log(`  nsec:         ${maskedNsec}`);
+    console.log(`  npub:         ${npubStr}`);
+    console.log(`  relays:       ${(profile.relays ?? []).join(", ")}`);
+    console.log(`  boards:       ${profile.boards?.length ?? 0}`);
+    console.log(`  trustedNpubs: ${profile.trustedNpubs?.length ?? 0}`);
+    process.exit(0);
+  });
+
+profileCmd
+  .command("remove <name>")
+  .description("Remove a profile")
+  .option("--force", "Skip confirmation prompt")
+  .action(async (name: string, opts) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    if (!config.profiles[name]) {
+      console.error(chalk.red(`Profile not found: "${name}"`));
+      process.exit(1);
+    }
+    if (name === config.activeProfile) {
+      console.error(
+        chalk.red(`Cannot remove active profile: "${name}". Switch first with: taskify profile use <other>`),
+      );
+      process.exit(1);
+    }
+    if (Object.keys(config.profiles).length === 1) {
+      console.error(chalk.red("Cannot remove the only profile."));
+      process.exit(1);
+    }
+
+    if (!opts.force) {
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const confirmed = await new Promise<boolean>((resolve) => {
+        rl.question(`Remove profile '${name}'? [y/N] `, (ans: string) => {
+          rl.close();
+          resolve(ans.toLowerCase() === "y");
+        });
+      });
+      if (!confirmed) {
+        console.log("Aborted.");
+        process.exit(0);
+      }
+    }
+
+    const { [name]: _removed, ...rest } = config.profiles;
+    await saveProfiles(config.activeProfile, rest);
+    console.log(chalk.green(`✓ Profile '${name}' removed.`));
+    process.exit(0);
+  });
+
+profileCmd
+  .command("rename <old> <new>")
+  .description("Rename a profile")
+  .action(async (oldName: string, newName: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    if (!config.profiles[oldName]) {
+      console.error(chalk.red(`Profile not found: "${oldName}"`));
+      process.exit(1);
+    }
+    if (config.profiles[newName]) {
+      console.error(chalk.red(`Profile already exists: "${newName}"`));
+      process.exit(1);
+    }
+    const { [oldName]: profileData, ...rest } = config.profiles;
+    const newProfiles = { ...rest, [newName]: profileData };
+    const newActive = config.activeProfile === oldName ? newName : config.activeProfile;
+    await saveProfiles(newActive, newProfiles);
+    console.log(chalk.green(`✓ Renamed profile '${oldName}' → '${newName}'`));
+    process.exit(0);
+  });
+
 // ---- setup ----
 program
   .command("setup")
-  .description("Run the first-run onboarding wizard (re-configure or add a new key)")
-  .action(async () => {
-    const existing = await loadConfig();
+  .description("Run the first-run onboarding wizard (re-configure a profile)")
+  .option("--profile <name>", "Profile to configure (defaults to active profile)")
+  .action(async (opts) => {
+    // --profile on setup subcommand takes precedence over global --profile
+    const targetProfile = opts.profile ?? (program.opts().profile as string | undefined);
+    const existing = await loadConfig(targetProfile);
     if (existing.nsec) {
       const rl = createInterface({ input: process.stdin, output: process.stdout });
       const ans = await new Promise<string>((resolve) => {
         rl.question(
-          "⚠ You already have a private key configured. This will replace it.\nContinue? [Y/n] ",
-          resolve
+          `⚠ Profile "${existing.activeProfile}" already has a private key. This will replace it.\nContinue? [Y/n] `,
+          resolve,
         );
       });
       rl.close();
@@ -2055,12 +2315,14 @@ program
         process.exit(0);
       }
     }
-    await runOnboarding();
+    await runOnboarding(targetProfile ?? existing.activeProfile);
   });
 
 // ---- auto-onboarding trigger + parse ----
-const cfg = await loadConfig();
-if (!cfg.nsec && process.argv.length <= 2) {
+const cfg = await loadConfig(program.opts().profile as string | undefined);
+// Trigger onboarding if no profiles have an nsec and no command was given
+const hasAnyNsec = Object.values(cfg.profiles).some((p) => p.nsec);
+if (!hasAnyNsec && process.argv.length <= 2) {
   await runOnboarding();
 } else {
   program.parse(process.argv);

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";
 import { createInterface } from "readline";
+import { createRequire } from "module";
 import { nip19, getPublicKey, generateSecretKey } from "nostr-tools";
 import { loadConfig, saveConfig, saveProfiles, DEFAULT_RELAYS, type ProfileConfig } from "./config.js";
 import { createNostrRuntime, type NostrRuntime } from "./nostrRuntime.js";
@@ -11,11 +12,14 @@ import { zshCompletion, bashCompletion, fishCompletion } from "./completions.js"
 import { readCache, clearCache, CACHE_PATH, CACHE_TTL_MS } from "./taskCache.js";
 import { runOnboarding } from "./onboarding.js";
 
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json");
+
 const program = new Command();
 
 program
   .name("taskify")
-  .version("0.1.0")
+  .version(version)
   .description("Taskify CLI — manage tasks over Nostr")
   .option("-P, --profile <name>", "Use a specific profile for this command (does not change active profile)");
 
@@ -2101,13 +2105,46 @@ profileCmd
 profileCmd
   .command("add <name>")
   .description("Add a new profile (runs mini onboarding for the new identity)")
-  .action(async (name: string) => {
+  .option("--nsec <key>", "Nostr private key (skips interactive prompt)")
+  .option("--relay <url>", "Add a relay (repeatable)", (val: string, acc: string[]) => { acc.push(val); return acc; }, [] as string[])
+  .action(async (name: string, opts: { nsec?: string; relay: string[] }) => {
     const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.profiles[name]) {
       console.error(chalk.red(`Profile already exists: "${name}"`));
       process.exit(1);
     }
 
+    // Non-interactive mode when --nsec is provided
+    if (opts.nsec !== undefined) {
+      const nsecInput = opts.nsec.trim();
+      if (!nsecInput.startsWith("nsec1")) {
+        console.error(chalk.red("Invalid nsec key"));
+        process.exit(1);
+      }
+      try {
+        nip19.decode(nsecInput);
+      } catch {
+        console.error(chalk.red("Invalid nsec key"));
+        process.exit(1);
+      }
+      const relays = opts.relay.length > 0 ? opts.relay : [...DEFAULT_RELAYS];
+      const newProfile: ProfileConfig = {
+        nsec: nsecInput,
+        relays,
+        boards: [],
+        trustedNpubs: [],
+        securityMode: "moderate",
+        securityEnabled: true,
+        defaultBoard: "Personal",
+        taskReminders: {},
+      };
+      const newProfiles = { ...config.profiles, [name]: newProfile };
+      await saveProfiles(config.activeProfile, newProfiles);
+      console.log(chalk.green(`✓ Profile '${name}' created.`));
+      process.exit(0);
+    }
+
+    // Interactive mode
     console.log();
     console.log(chalk.bold(`Setting up profile: ${name}`));
     console.log();

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -2,12 +2,12 @@ import NDK, { NDKEvent, NDKPrivateKeySigner, NDKRelayStatus } from "@nostr-dev-k
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { getPublicKey, nip19 } from "nostr-tools";
-import type { ReminderPreset, Recurrence, Subtask } from "./shared/taskTypes.ts";
-import type { AgentTaskCreateInput, AgentTaskPatchInput, AgentTaskStatus } from "./shared/agentRuntime.ts";
-import type { AgentSecurityConfig } from "./shared/agentSecurity.ts";
-import type { TaskifyConfig, BoardEntry } from "./config.ts";
-import { saveConfig, loadConfig } from "./config.ts";
-import { readCache, writeCache, isCacheFresh, type CachedTask } from "./taskCache.ts";
+import type { ReminderPreset, Recurrence, Subtask } from "./shared/taskTypes.js";
+import type { AgentTaskCreateInput, AgentTaskPatchInput, AgentTaskStatus } from "./shared/agentRuntime.js";
+import type { AgentSecurityConfig } from "./shared/agentSecurity.js";
+import type { TaskifyConfig, BoardEntry } from "./config.js";
+import { saveConfig, loadConfig } from "./config.js";
+import { readCache, writeCache, isCacheFresh, type CachedTask } from "./taskCache.js";
 
 function nowISO(): string {
   return new Date().toISOString();

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -6,7 +6,7 @@ import type { ReminderPreset, Recurrence, Subtask } from "./shared/taskTypes.js"
 import type { AgentTaskCreateInput, AgentTaskPatchInput, AgentTaskStatus } from "./shared/agentRuntime.js";
 import type { AgentSecurityConfig } from "./shared/agentSecurity.js";
 import type { TaskifyConfig, BoardEntry } from "./config.js";
-import { saveConfig, loadConfig } from "./config.js";
+import { saveConfig } from "./config.js";
 import { readCache, writeCache, isCacheFresh, type CachedTask } from "./taskCache.js";
 
 function nowISO(): string {
@@ -534,9 +534,8 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       );
       const events = await Promise.race([fetchPromise, timeoutPromise]);
 
-      // Load fresh config to ensure we have the latest board entry
-      const cfg = await loadConfig();
-      const entry = cfg.boards.find((b) => b.id === boardId);
+      // Use config from closure (avoids extra file read and ensures correct profile)
+      const entry = config.boards.find((b) => b.id === boardId);
       if (!entry) return {};
 
       let kind: string | undefined;
@@ -604,7 +603,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         if (kind) entry.kind = kind as BoardEntry["kind"];
         if (columns && columns.length > 0) entry.columns = columns;
         if (children && children.length > 0) entry.children = children;
-        await saveConfig(cfg);
+        await saveConfig(config);
       }
 
       return { kind, columns, children };
@@ -919,10 +918,9 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
 
     async remindTask(taskId: string, presets: ReminderPreset[]): Promise<void> {
       // Device-local only — NEVER publish to Nostr
-      const cfg = await loadConfig();
-      if (!cfg.taskReminders) cfg.taskReminders = {};
-      cfg.taskReminders[taskId] = presets;
-      await saveConfig(cfg);
+      if (!config.taskReminders) config.taskReminders = {};
+      config.taskReminders[taskId] = presets;
+      await saveConfig(config);
       process.stderr.write(
         "\x1b[2m  Note: Reminders are device-local and will not sync to other devices\x1b[0m\n",
       );
@@ -933,21 +931,19 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
     },
 
     async getAgentSecurityConfig(): Promise<AgentSecurityConfig> {
-      const cfg = await loadConfig();
       return {
-        enabled: cfg.securityEnabled,
-        mode: cfg.securityMode,
-        trustedNpubs: cfg.trustedNpubs,
+        enabled: config.securityEnabled,
+        mode: config.securityMode,
+        trustedNpubs: config.trustedNpubs,
         updatedISO: nowISO(),
       };
     },
 
     async setAgentSecurityConfig(secCfg: AgentSecurityConfig): Promise<AgentSecurityConfig> {
-      const cfg = await loadConfig();
-      cfg.securityEnabled = secCfg.enabled;
-      cfg.securityMode = secCfg.mode;
-      cfg.trustedNpubs = secCfg.trustedNpubs;
-      await saveConfig(cfg);
+      config.securityEnabled = secCfg.enabled;
+      config.securityMode = secCfg.mode;
+      config.trustedNpubs = secCfg.trustedNpubs;
+      await saveConfig(config);
       return secCfg;
     },
 
@@ -1002,15 +998,14 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       }
 
       // Auto-join: save to config
-      const cfg = await loadConfig();
       const newEntry: BoardEntry = {
         id: boardId,
         name: input.name,
         kind: input.kind,
         columns: input.columns ?? [],
       };
-      cfg.boards.push(newEntry);
-      await saveConfig(cfg);
+      config.boards.push(newEntry);
+      await saveConfig(config);
 
       return { boardId };
     },

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -8,6 +8,7 @@ import type { AgentSecurityConfig } from "./shared/agentSecurity.js";
 import type { TaskifyConfig, BoardEntry } from "./config.js";
 import { saveConfig } from "./config.js";
 import { readCache, writeCache, isCacheFresh, type CachedTask } from "./taskCache.js";
+import { pickBestBoardMeta } from "./shared/boardMeta.js";
 
 function nowISO(): string {
   return new Date().toISOString();
@@ -205,7 +206,7 @@ export type NostrRuntime = {
     refresh?: boolean;
     noCache?: boolean;
   }): Promise<FullTaskRecord[]>;
-  syncBoard(boardId: string): Promise<{ kind?: string; columns?: { id: string; name: string }[]; children?: string[] }>;
+  syncBoard(boardId: string): Promise<{ name?: string; kind?: string; columns?: { id: string; name: string }[]; children?: string[] }>;
   createTask(input: AgentTaskCreateInput): Promise<FullTaskRecord>;
   createTaskFull(input: ExtendedCreateInput): Promise<FullTaskRecord>;
   createBoard(input: { name: string; kind: "lists" | "week"; columns?: { id: string; name: string }[] }): Promise<{ boardId: string }>;
@@ -522,11 +523,11 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       return records;
     },
 
-    async syncBoard(boardId: string): Promise<{ kind?: string; columns?: { id: string; name: string }[]; children?: string[] }> {
+    async syncBoard(boardId: string): Promise<{ name?: string; kind?: string; columns?: { id: string; name: string }[]; children?: string[] }> {
       await ensureConnected();
       const bTag = boardTagHash(boardId);
       const fetchPromise = ndk.fetchEvents(
-        { kinds: [30300], "#b": [bTag], limit: 1 } as unknown as Parameters<typeof ndk.fetchEvents>[0],
+        { kinds: [30300], "#b": [bTag], limit: 25 } as unknown as Parameters<typeof ndk.fetchEvents>[0],
         { closeOnEose: true },
       );
       const timeoutPromise = new Promise<Set<NDKEvent>>((resolve) =>
@@ -538,75 +539,44 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       const entry = config.boards.find((b) => b.id === boardId);
       if (!entry) return {};
 
+      let name: string | undefined;
       let kind: string | undefined;
       let columns: { id: string; name: string }[] | undefined;
       let children: string[] | undefined;
 
       if (events.size > 0) {
-        const [event] = events;
-        const kTag = event.tags.find((t) => t[0] === "k");
-        if (kTag?.[1]) kind = kTag[1];
+        const eventLikes: Array<{ tags: string[][]; content: string; created_at?: number }> = [];
 
-        const colTags = event.tags.filter((t) => t[0] === "col" && t[1] && t[2]);
-        if (colTags.length > 0) {
-          columns = colTags.map((t) => ({ id: t[1], name: t[2] }));
-        }
-
-        // Check for "ch" tags
-        const chTags = event.tags.filter((t) => t[0] === "ch" && t[1]);
-        if (chTags.length > 0) {
-          children = chTags.map((t) => t[1]);
-        }
-
-        // Try to decrypt content for additional columns and kind (fallback)
-        try {
-          if (event.content) {
-            const plaintext = await decryptContent(boardId, event.content);
-            const parsed = JSON.parse(plaintext);
-
-            // Extract kind from content if not found in tags
-            if (!kind && parsed.kind) {
-              kind = String(parsed.kind);
-            }
-
-            // Extract columns from content
-            if (Array.isArray(parsed.columns)) {
-              const contentCols: { id: string; name: string }[] = parsed.columns
-                .filter(
-                  (c: unknown) =>
-                    c && typeof c === "object" && "id" in (c as object) && "name" in (c as object),
-                )
-                .map((c: { id: string; name: string }) => ({ id: String(c.id), name: String(c.name) }));
-
-              // Merge with tag-discovered columns (deduplicate by id)
-              const merged = [...(columns ?? [])];
-              for (const cc of contentCols) {
-                if (!merged.find((m) => m.id === cc.id)) {
-                  merged.push(cc);
-                }
-              }
-              if (merged.length > 0) columns = merged;
-            }
-
-            // Extract children from content
-            if (Array.isArray(parsed.children)) {
-              const contentChildren = (parsed.children as unknown[]).filter((c): c is string => typeof c === "string");
-              const mergedChildren = [...(children ?? [])];
-              for (const cc of contentChildren) {
-                if (!mergedChildren.includes(cc)) mergedChildren.push(cc);
-              }
-              if (mergedChildren.length > 0) children = mergedChildren;
+        for (const event of events) {
+          let content = event.content ?? "";
+          if (content) {
+            try {
+              content = await decryptContent(boardId, content);
+            } catch {
+              // Non-fatal: keep original content (may be plaintext/JSON, or unusable encrypted payload)
             }
           }
-        } catch { /* non-fatal — content may not be in expected format */ }
+          eventLikes.push({
+            tags: event.tags ?? [],
+            content,
+            created_at: event.created_at,
+          });
+        }
 
+        const meta = pickBestBoardMeta(eventLikes, boardId);
+        name = meta.name;
+        kind = meta.kind;
+        columns = meta.columns;
+        children = meta.children;
+
+        if (name) entry.name = name;
         if (kind) entry.kind = kind as BoardEntry["kind"];
         if (columns && columns.length > 0) entry.columns = columns;
         if (children && children.length > 0) entry.children = children;
         await saveConfig(config);
       }
 
-      return { kind, columns, children };
+      return { name, kind, columns, children };
     },
 
     async createTask(input: AgentTaskCreateInput): Promise<FullTaskRecord> {

--- a/taskify-cli/src/onboarding.ts
+++ b/taskify-cli/src/onboarding.ts
@@ -1,13 +1,37 @@
 #!/usr/bin/env node
 import * as readline from "readline";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
-import { loadConfig, saveConfig } from "./config.js";
+import { loadConfig, saveProfiles, type ProfileConfig } from "./config.js";
 
-function ask(rl: readline.Interface, question: string): Promise<string> {
-  return new Promise((resolve) => rl.question(question, resolve));
+// Queue-based readline helper that works correctly with piped stdin
+function makeLineQueue(rl: readline.Interface): (prompt: string) => Promise<string> {
+  const lineQueue: string[] = [];
+  const waiters: ((line: string) => void)[] = [];
+  rl.on("line", (line: string) => {
+    if (waiters.length > 0) {
+      waiters.shift()!(line);
+    } else {
+      lineQueue.push(line);
+    }
+  });
+  return (prompt: string) => {
+    process.stdout.write(prompt);
+    return new Promise<string>((resolve) => {
+      if (lineQueue.length > 0) {
+        resolve(lineQueue.shift()!);
+      } else {
+        waiters.push(resolve);
+      }
+    });
+  };
 }
 
-export async function runOnboarding(): Promise<void> {
+/**
+ * Run the onboarding wizard.
+ * @param profileName - If provided, save to this profile name (re-configure).
+ *                      If not provided, ask the user for a profile name.
+ */
+export async function runOnboarding(profileName?: string): Promise<void> {
   console.log();
   console.log("┌─────────────────────────────────────────┐");
   console.log("│  Welcome to taskify-nostr! 🦉           │");
@@ -19,21 +43,30 @@ export async function runOnboarding(): Promise<void> {
     input: process.stdin,
     output: process.stdout,
   });
+  const ask = makeLineQueue(rl);
 
-  const cfg = await loadConfig();
+  const DEFAULT_RELAYS = [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+    "wss://relay.snort.social",
+    "wss://relay.primal.net",
+  ];
+
+  let nsec: string | undefined;
+  let relays: string[] = [...DEFAULT_RELAYS];
 
   // Step 1 — Private key
   console.log("Step 1 — Private key");
-  const hasKey = await ask(rl, "Do you have a Nostr private key (nsec)? [Y/n] ");
+  const hasKey = await ask("Do you have a Nostr private key (nsec)? [Y/n] ");
 
   if (hasKey.trim().toLowerCase() !== "n") {
     // User has a key
-    let nsec = "";
     while (true) {
-      nsec = (await ask(rl, "Paste your nsec: ")).trim();
-      if (nsec.startsWith("nsec1")) {
+      const input = (await ask("Paste your nsec: ")).trim();
+      if (input.startsWith("nsec1")) {
         try {
-          nip19.decode(nsec);
+          nip19.decode(input);
+          nsec = input;
           break;
         } catch {
           // invalid
@@ -41,12 +74,11 @@ export async function runOnboarding(): Promise<void> {
       }
       console.log("Invalid nsec. Try again or press Ctrl+C to abort.");
     }
-    cfg.nsec = nsec;
   } else {
     // Generate new keypair
     const sk = generateSecretKey();
     const pk = getPublicKey(sk);
-    const nsec = nip19.nsecEncode(sk);
+    nsec = nip19.nsecEncode(sk);
     const npub = nip19.npubEncode(pk);
     console.log();
     console.log("✓ Generated new Nostr identity");
@@ -54,48 +86,75 @@ export async function runOnboarding(): Promise<void> {
     console.log(`  nsec: ${nsec}  ← KEEP THIS SECRET — it is your password`);
     console.log();
     console.log("Save this nsec somewhere safe. It cannot be recovered if lost.");
-    const cont = await ask(rl, "Continue? [Y/n] ");
+    const cont = await ask("Continue? [Y/n] ");
     if (cont.trim().toLowerCase() === "n") {
       rl.close();
       process.exit(0);
     }
-    cfg.nsec = nsec;
   }
 
   // Step 2 — Default board
   console.log();
   console.log("Step 2 — Default board");
-  const joinBoard = await ask(rl, "Do you want to join an existing board? [y/N] ");
+  const joinBoard = await ask("Do you want to join an existing board? [y/N] ");
+  let defaultBoard = "Personal";
   if (joinBoard.trim().toLowerCase() === "y") {
-    const boardId = (await ask(rl, "Board ID (Nostr event id): ")).trim();
+    const boardId = (await ask("Board ID (Nostr event id): ")).trim();
     if (boardId) {
-      cfg.defaultBoard = boardId;
+      defaultBoard = boardId;
     }
   }
 
   // Step 3 — Relays
   console.log();
   console.log("Step 3 — Relays");
-  const configRelays = await ask(rl, "Configure relays? Default relays will be used if skipped. [y/N] ");
+  const configRelays = await ask("Configure relays? Default relays will be used if skipped. [y/N] ");
   if (configRelays.trim().toLowerCase() === "y") {
-    const relays: string[] = [];
+    const customRelays: string[] = [];
     while (true) {
-      const relay = (await ask(rl, "Add relay URL (blank to finish): ")).trim();
+      const relay = (await ask("Add relay URL (blank to finish): ")).trim();
       if (!relay) break;
-      relays.push(relay);
+      customRelays.push(relay);
     }
-    if (relays.length > 0) {
-      cfg.relays = relays;
+    if (customRelays.length > 0) {
+      relays = customRelays;
     }
+  }
+
+  // Step 4 — Profile name (only when not re-configuring an existing profile)
+  let resolvedProfileName = profileName;
+  if (!resolvedProfileName) {
+    console.log();
+    console.log("Step 4 — Profile name");
+    const nameInput = (await ask("What should we name this profile? [default] ")).trim();
+    resolvedProfileName = nameInput || "default";
   }
 
   rl.close();
 
-  await saveConfig(cfg);
+  // Load full config to preserve other profiles
+  const fullCfg = await loadConfig();
+  const existingProfile = fullCfg.profiles[resolvedProfileName];
 
-  // Step 4 — Done
+  const newProfile: ProfileConfig = {
+    nsec,
+    relays,
+    boards: existingProfile?.boards ?? [],
+    trustedNpubs: existingProfile?.trustedNpubs ?? [],
+    securityMode: existingProfile?.securityMode ?? "moderate",
+    securityEnabled: existingProfile?.securityEnabled ?? true,
+    defaultBoard,
+    taskReminders: existingProfile?.taskReminders ?? {},
+    agent: existingProfile?.agent,
+  };
+
+  const newProfiles = { ...fullCfg.profiles, [resolvedProfileName]: newProfile };
+  await saveProfiles(resolvedProfileName, newProfiles);
+
+  // Done
   console.log();
-  console.log("✓ Setup complete! Run `taskify boards` to see your boards.");
+  console.log(`✓ Setup complete! Profile: "${resolvedProfileName}"`);
+  console.log("  Run `taskify boards` to see your boards.");
   console.log("  Run `taskify --help` to explore all commands.");
   console.log();
 }

--- a/taskify-cli/src/onboarding.ts
+++ b/taskify-cli/src/onboarding.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import * as readline from "readline";
+import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
+import { loadConfig, saveConfig } from "./config.js";
+
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+export async function runOnboarding(): Promise<void> {
+  console.log();
+  console.log("┌─────────────────────────────────────────┐");
+  console.log("│  Welcome to taskify-nostr! 🦉           │");
+  console.log("│  Nostr-powered task management CLI      │");
+  console.log("└─────────────────────────────────────────┘");
+  console.log();
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const cfg = await loadConfig();
+
+  // Step 1 — Private key
+  console.log("Step 1 — Private key");
+  const hasKey = await ask(rl, "Do you have a Nostr private key (nsec)? [Y/n] ");
+
+  if (hasKey.trim().toLowerCase() !== "n") {
+    // User has a key
+    let nsec = "";
+    while (true) {
+      nsec = (await ask(rl, "Paste your nsec: ")).trim();
+      if (nsec.startsWith("nsec1")) {
+        try {
+          nip19.decode(nsec);
+          break;
+        } catch {
+          // invalid
+        }
+      }
+      console.log("Invalid nsec. Try again or press Ctrl+C to abort.");
+    }
+    cfg.nsec = nsec;
+  } else {
+    // Generate new keypair
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    const nsec = nip19.nsecEncode(sk);
+    const npub = nip19.npubEncode(pk);
+    console.log();
+    console.log("✓ Generated new Nostr identity");
+    console.log(`  npub: ${npub}`);
+    console.log(`  nsec: ${nsec}  ← KEEP THIS SECRET — it is your password`);
+    console.log();
+    console.log("Save this nsec somewhere safe. It cannot be recovered if lost.");
+    const cont = await ask(rl, "Continue? [Y/n] ");
+    if (cont.trim().toLowerCase() === "n") {
+      rl.close();
+      process.exit(0);
+    }
+    cfg.nsec = nsec;
+  }
+
+  // Step 2 — Default board
+  console.log();
+  console.log("Step 2 — Default board");
+  const joinBoard = await ask(rl, "Do you want to join an existing board? [y/N] ");
+  if (joinBoard.trim().toLowerCase() === "y") {
+    const boardId = (await ask(rl, "Board ID (Nostr event id): ")).trim();
+    if (boardId) {
+      cfg.defaultBoard = boardId;
+    }
+  }
+
+  // Step 3 — Relays
+  console.log();
+  console.log("Step 3 — Relays");
+  const configRelays = await ask(rl, "Configure relays? Default relays will be used if skipped. [y/N] ");
+  if (configRelays.trim().toLowerCase() === "y") {
+    const relays: string[] = [];
+    while (true) {
+      const relay = (await ask(rl, "Add relay URL (blank to finish): ")).trim();
+      if (!relay) break;
+      relays.push(relay);
+    }
+    if (relays.length > 0) {
+      cfg.relays = relays;
+    }
+  }
+
+  rl.close();
+
+  await saveConfig(cfg);
+
+  // Step 4 — Done
+  console.log();
+  console.log("✓ Setup complete! Run `taskify boards` to see your boards.");
+  console.log("  Run `taskify --help` to explore all commands.");
+  console.log();
+}

--- a/taskify-cli/src/render.ts
+++ b/taskify-cli/src/render.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
-import type { FullTaskRecord } from "./nostrRuntime.ts";
+import type { FullTaskRecord } from "./nostrRuntime.js";
 import { nip19 } from "nostr-tools";
-import { TASK_PRIORITY_MARKS } from "./shared/taskTypes.ts";
-import type { ReminderPreset } from "./shared/taskTypes.ts";
+import { TASK_PRIORITY_MARKS } from "./shared/taskTypes.js";
+import type { ReminderPreset } from "./shared/taskTypes.js";
 
 const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 

--- a/taskify-cli/src/shared/agentDispatcher.ts
+++ b/taskify-cli/src/shared/agentDispatcher.ts
@@ -1,5 +1,5 @@
-import { toNpub } from "./nostr.ts";
-import { getAgentIdempotencyStore } from "./agentIdempotency.ts";
+import { toNpub } from "./nostr.js";
+import { getAgentIdempotencyStore } from "./agentIdempotency.js";
 import {
   addTrustedNpub,
   annotateTrust,
@@ -9,14 +9,14 @@ import {
   removeTrustedNpub,
   summarizeTrustCounts,
   type AgentSecurityConfig,
-} from "./agentSecurity.ts";
+} from "./agentSecurity.js";
 import {
   getAgentRuntime,
   type AgentTaskRecord,
   type AgentTaskCreateInput,
   type AgentTaskPatchInput,
   type AgentTaskStatus,
-} from "./agentRuntime.ts";
+} from "./agentRuntime.js";
 
 type AgentErrorCode =
   | "PARSE_JSON"

--- a/taskify-cli/src/shared/agentRuntime.ts
+++ b/taskify-cli/src/shared/agentRuntime.ts
@@ -1,4 +1,4 @@
-import type { AgentSecurityConfig } from "./agentSecurity.ts";
+import type { AgentSecurityConfig } from "./agentSecurity.js";
 
 export type AgentTaskRecord = {
   id: string;

--- a/taskify-cli/src/shared/boardMeta.ts
+++ b/taskify-cli/src/shared/boardMeta.ts
@@ -1,0 +1,86 @@
+export type BoardMeta = {
+  name?: string;
+  kind?: string;
+  columns?: { id: string; name: string }[];
+  children?: string[];
+};
+
+type EventLike = {
+  tags?: string[][];
+  content?: string;
+  created_at?: number;
+};
+
+function tagValue(tags: string[][], ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const match = tags.find((t) => t[0] === key && typeof t[1] === "string" && t[1].trim().length > 0);
+    if (match?.[1]) return match[1].trim();
+  }
+  return undefined;
+}
+
+export function extractBoardMetaFromEventLike(event: EventLike, _boardId: string): BoardMeta {
+  const tags = event.tags ?? [];
+
+  const name = tagValue(tags, "name", "title", "n");
+  const kind = tagValue(tags, "k");
+
+  const tagColumns = tags
+    .filter((t) => t[0] === "col" && t[1] && t[2])
+    .map((t) => ({ id: String(t[1]), name: String(t[2]) }));
+
+  const tagChildren = tags.filter((t) => t[0] === "ch" && t[1]).map((t) => String(t[1]));
+
+  let contentName: string | undefined;
+  let contentKind: string | undefined;
+  let contentColumns: { id: string; name: string }[] = [];
+  let contentChildren: string[] = [];
+
+  if (event.content) {
+    try {
+      const parsed = JSON.parse(event.content);
+      if (typeof parsed?.name === "string" && parsed.name.trim()) contentName = parsed.name.trim();
+      if (typeof parsed?.kind === "string" && parsed.kind.trim()) contentKind = parsed.kind.trim();
+
+      if (Array.isArray(parsed?.columns)) {
+        contentColumns = parsed.columns
+          .filter((c: unknown) => c && typeof c === "object" && "id" in (c as object) && "name" in (c as object))
+          .map((c: { id: string; name: string }) => ({ id: String(c.id), name: String(c.name) }));
+      }
+
+      if (Array.isArray(parsed?.children)) {
+        contentChildren = parsed.children.filter((c: unknown): c is string => typeof c === "string");
+      }
+    } catch {
+      // content may be encrypted/non-JSON
+    }
+  }
+
+  const mergedColumns = [...tagColumns];
+  for (const cc of contentColumns) {
+    if (!mergedColumns.find((m) => m.id === cc.id)) mergedColumns.push(cc);
+  }
+
+  const mergedChildren = [...tagChildren];
+  for (const child of contentChildren) {
+    if (!mergedChildren.includes(child)) mergedChildren.push(child);
+  }
+
+  return {
+    name: contentName ?? name,
+    kind: kind ?? contentKind,
+    columns: mergedColumns.length ? mergedColumns : undefined,
+    children: mergedChildren.length ? mergedChildren : undefined,
+  };
+}
+
+export function pickBestBoardMeta(events: EventLike[], boardId: string): BoardMeta {
+  const sorted = [...events].sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+  for (const event of sorted) {
+    const meta = extractBoardMetaFromEventLike(event, boardId);
+    if (meta.name || meta.kind || (meta.columns?.length ?? 0) > 0 || (meta.children?.length ?? 0) > 0) {
+      return meta;
+    }
+  }
+  return {};
+}

--- a/taskify-cli/src/shared/boardUtils.ts
+++ b/taskify-cli/src/shared/boardUtils.ts
@@ -1,4 +1,4 @@
-import type { Task, Board, CalendarEvent, Recurrence, Weekday } from "./taskTypes.ts";
+import type { Task, Board, CalendarEvent, Recurrence, Weekday } from "./taskTypes.js";
 import {
   isoDatePart,
   parseDateKey,
@@ -7,8 +7,8 @@ import {
   formatDateKeyFromParts,
   isoFromDateTime,
   normalizeTimeZone,
-} from "./dateUtils.ts";
-import type { Settings } from "./settingsTypes.ts";
+} from "./dateUtils.js";
+import type { Settings } from "./settingsTypes.js";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/taskify-cli/src/shared/settingsTypes.ts
+++ b/taskify-cli/src/shared/settingsTypes.ts
@@ -1,6 +1,6 @@
 // CLI-adapted version of settingsTypes.ts (browser imports removed)
 
-import type { Weekday } from "./taskTypes.ts";
+import type { Weekday } from "./taskTypes.js";
 
 // ---- Stubs for types not needed in CLI ----
 export type AccentPalette = string;

--- a/taskify-cli/src/shared/taskUtils.ts
+++ b/taskify-cli/src/shared/taskUtils.ts
@@ -1,7 +1,7 @@
-import type { Task, Recurrence } from "./taskTypes.ts";
-import type { TaskPriority } from "./taskTypes.ts";
-import { isoDatePart, isoTimePartUtc, startOfDay } from "./dateUtils.ts";
-import { revealsOnDueDate, isFrequentRecurrence } from "./boardUtils.ts";
+import type { Task, Recurrence } from "./taskTypes.js";
+import type { TaskPriority } from "./taskTypes.js";
+import { isoDatePart, isoTimePartUtc, startOfDay } from "./dateUtils.js";
+import { revealsOnDueDate, isFrequentRecurrence } from "./boardUtils.js";
 
 // ---- Priority normalization ----
 

--- a/taskify-cli/tests/board-meta.test.ts
+++ b/taskify-cli/tests/board-meta.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractBoardMetaFromEventLike, pickBestBoardMeta } from "../src/shared/boardMeta.ts";
+
+test("extracts board name from name/title tags", () => {
+  const fromName = extractBoardMetaFromEventLike({ tags: [["name", "Testing"]], content: "" }, "board-1");
+  assert.equal(fromName.name, "Testing");
+
+  const fromTitle = extractBoardMetaFromEventLike({ tags: [["title", "Sprint Board"]], content: "" }, "board-1");
+  assert.equal(fromTitle.name, "Sprint Board");
+});
+
+test("extracts board name/kind/columns/children from JSON content", () => {
+  const meta = extractBoardMetaFromEventLike(
+    {
+      tags: [["k", "lists"], ["col", "todo", "To Do"]],
+      content: JSON.stringify({ name: "Important Dates", kind: "lists", columns: [{ id: "done", name: "Done" }], children: ["b1"] }),
+    },
+    "board-1",
+  );
+
+  assert.equal(meta.name, "Important Dates");
+  assert.equal(meta.kind, "lists");
+  assert.deepEqual(meta.columns, [
+    { id: "todo", name: "To Do" },
+    { id: "done", name: "Done" },
+  ]);
+  assert.deepEqual(meta.children, ["b1"]);
+});
+
+test("picks newest event metadata when multiple events exist", () => {
+  const selected = pickBestBoardMeta([
+    { created_at: 100, tags: [["name", "Old Name"]], content: "" },
+    { created_at: 200, tags: [["name", "New Name"]], content: "" },
+  ], "board-1");
+
+  assert.equal(selected.name, "New Name");
+});

--- a/taskify-cli/tsconfig.json
+++ b/taskify-cli/tsconfig.json
@@ -3,11 +3,13 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "allowImportingTsExtensions": true,
-    "noEmit": true
+    "declaration": false,
+    "esModuleInterop": true
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- fetch and evaluate board metadata events during sync
- resolve canonical board name from metadata tags/content
- persist synced board name into local config so `board list` shows names
- add tests for metadata extraction and newest-event selection

## Validation
- npm test
- npm run build
- ./dist/index.js board sync --profile cody
- ./dist/index.js board list --profile cody
- taskify board sync --profile cody
- taskify board list --profile cody
