### PR TITLE
fix(week-board): prevent tasks shifting to next day on add/reorder

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -124,6 +124,7 @@ import {
   ensureWeekRecurrencesForCurrentWeek,
   tasksInSameSeries,
 } from "./lib/app/weekRecurrenceDomain";
+import { isoForWeekdayLocal, startOfWeekLocal } from "./lib/app/weekBoardDate";
 import {
   TASKIFY_CALENDAR_EVENT_KIND,
   TASKIFY_CALENDAR_VIEW_KIND,
@@ -3509,12 +3510,7 @@ function isoForWeekday(
   target: Weekday,
   options: { base?: Date; weekStart?: Weekday } = {}
 ): string {
-  const { base = new Date(), weekStart = 0 } = options;
-  const anchor = startOfWeek(base, weekStart);
-  const anchorDay = anchor.getDay() as Weekday;
-  const offset = ((target - anchorDay) % 7 + 7) % 7;
-  const day = startOfDay(new Date(anchor.getTime() + offset * 86400000));
-  return day.toISOString();
+  return isoForWeekdayLocal(target, options);
 }
 
 function isoForToday(base = new Date()): string {
@@ -3764,12 +3760,7 @@ function isVisibleNow(t: Task, now = new Date()): boolean {
 }
 
 function startOfWeek(d: Date, weekStart: Weekday): Date {
-  const sd = startOfDay(d);
-  const current = sd.getDay() as Weekday;
-  const ws = (weekStart === 1 || weekStart === 6) ? weekStart : 0; // only Mon(1)/Sat(6)/Sun(0)
-  let diff = current - ws;
-  if (diff < 0) diff += 7;
-  return new Date(sd.getTime() - diff * 86400000);
+  return startOfWeekLocal(d, weekStart);
 }
 
 /** Decide when the next instance should re-appear (hiddenUntilISO). */

--- a/taskify-pwa/src/lib/app/weekBoardDate.ts
+++ b/taskify-pwa/src/lib/app/weekBoardDate.ts
@@ -1,0 +1,34 @@
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+function startOfDayLocal(date: Date): Date {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
+function addDaysLocal(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+export function startOfWeekLocal(date: Date, weekStart: Weekday): Date {
+  const sd = startOfDayLocal(date);
+  const current = sd.getDay() as Weekday;
+  const ws = weekStart === 1 || weekStart === 6 ? weekStart : 0;
+  let diff = current - ws;
+  if (diff < 0) diff += 7;
+  return startOfDayLocal(addDaysLocal(sd, -diff));
+}
+
+export function isoForWeekdayLocal(
+  target: Weekday,
+  options: { base?: Date; weekStart?: Weekday } = {},
+): string {
+  const { base = new Date(), weekStart = 0 } = options;
+  const anchor = startOfWeekLocal(base, weekStart);
+  const anchorDay = anchor.getDay() as Weekday;
+  const offset = ((target - anchorDay) % 7 + 7) % 7;
+  const day = startOfDayLocal(addDaysLocal(anchor, offset));
+  return day.toISOString();
+}

--- a/taskify-pwa/tests/weekBoardDate.test.ts
+++ b/taskify-pwa/tests/weekBoardDate.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isoForWeekdayLocal } from "../src/lib/app/weekBoardDate.ts";
+
+process.env.TZ = "America/Chicago";
+
+type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+function weekdayFromISO(iso: string): Weekday {
+  const d = new Date(iso);
+  const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay() as Weekday;
+}
+
+test("DST week: isoForWeekdayLocal round-trips to same weekday (weekStart Sunday)", () => {
+  const base = new Date("2026-03-10T12:00:00-05:00"); // week that crosses DST in Chicago
+  for (let target = 0 as Weekday; target <= 6; target = (target + 1) as Weekday) {
+    const iso = isoForWeekdayLocal(target, { base, weekStart: 0 });
+    assert.equal(weekdayFromISO(iso), target, `target=${target} iso=${iso}`);
+  }
+});
+
+test("DST week: isoForWeekdayLocal round-trips to same weekday (weekStart Monday)", () => {
+  const base = new Date("2026-03-10T12:00:00-05:00");
+  for (let target = 0 as Weekday; target <= 6; target = (target + 1) as Weekday) {
+    const iso = isoForWeekdayLocal(target, { base, weekStart: 1 });
+    assert.equal(weekdayFromISO(iso), target, `target=${target} iso=${iso}`);
+  }
+});


### PR DESCRIPTION
## Root cause
Week board date placement used millisecond day math (`* 86400000`) in week helpers. Around DST boundaries this drifts local-midnight alignment and resolves to the following day.

## Fix
- Added `src/lib/app/weekBoardDate.ts` with calendar-day arithmetic (`setDate`)
- Routed `isoForWeekday` and `startOfWeek` through DST-safe helpers
- Added regression tests in `tests/weekBoardDate.test.ts`

## Validation
- `node --test --experimental-strip-types tests/weekBoardDate.test.ts`
