### PR TITLE
fix(week-board): respect dueTimeZone when grouping tasks by weekday

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2597,7 +2597,7 @@ function taskTimeValue(task: Task): number | null {
 }
 
 function taskWeekday(task: Task): Weekday | null {
-  return weekdayFromISO(task.dueISO);
+  return weekdayFromISO(task.dueISO, task.dueTimeZone);
 }
 
 function calendarAnchorFrom(dateStr?: string | null) {


### PR DESCRIPTION
Follow-up fix for week board day drift.

### What changed
- `taskWeekday(task)` now calls `weekdayFromISO(task.dueISO, task.dueTimeZone)`
- This prevents day-column shifts when tasks carry an explicit due timezone.

### Why
Week board grouping previously ignored `dueTimeZone`, so timezone-aware tasks could render under the next day column in local view.
