### PR TITLE
perf(pwa): keep fast load while refreshing updates in background

### DIFF
--- a/taskify-pwa/public/sw.js
+++ b/taskify-pwa/public/sw.js
@@ -11,7 +11,7 @@ self.addEventListener('activate', (event) => {
 });
 
 const CACHE_PREFIX = 'taskify-cache-';
-const CACHE = `${CACHE_PREFIX}v5`;
+const CACHE = `${CACHE_PREFIX}v6`;
 const CONFIG_CACHE = `${CACHE_PREFIX}config`;
 const DEFAULT_WORKER_BASE_URL = self.location.origin;
 let workerBaseUrl = DEFAULT_WORKER_BASE_URL;
@@ -32,13 +32,22 @@ self.addEventListener('fetch', (event) => {
       const cached = await cache.match(event.request);
       const cachedForCompare = cached ? cached.clone() : null;
 
-      // Network-first for app shell/document requests so installed PWAs pick up updates quickly.
+      // Fast app-shell loading: race network briefly, then fall back to cache.
+      // This keeps startup snappy while still refreshing cached HTML when network is available.
       if (isDocumentRequest(event.request)) {
+        if (cached) {
+          const networkAttempt = fetchAndUpdateCache(cache, event.request, cachedForCompare)
+            .then((response) => response || cached)
+            .catch(() => cached);
+          const timeoutFallback = wait(700).then(() => cached);
+          const winner = await Promise.race([networkAttempt, timeoutFallback]);
+          event.waitUntil(networkAttempt.catch(() => undefined));
+          return winner;
+        }
         try {
           const networkResponse = await fetchAndUpdateCache(cache, event.request, cachedForCompare);
           if (networkResponse) return networkResponse;
         } catch {}
-        if (cached) return cached;
         return new Response(null, { status: 504, statusText: 'Gateway Timeout' });
       }
 

--- a/taskify-pwa/public/sw.js
+++ b/taskify-pwa/public/sw.js
@@ -11,7 +11,7 @@ self.addEventListener('activate', (event) => {
 });
 
 const CACHE_PREFIX = 'taskify-cache-';
-const CACHE = `${CACHE_PREFIX}v4`;
+const CACHE = `${CACHE_PREFIX}v5`;
 const CONFIG_CACHE = `${CACHE_PREFIX}config`;
 const DEFAULT_WORKER_BASE_URL = self.location.origin;
 let workerBaseUrl = DEFAULT_WORKER_BASE_URL;
@@ -32,6 +32,17 @@ self.addEventListener('fetch', (event) => {
       const cached = await cache.match(event.request);
       const cachedForCompare = cached ? cached.clone() : null;
 
+      // Network-first for app shell/document requests so installed PWAs pick up updates quickly.
+      if (isDocumentRequest(event.request)) {
+        try {
+          const networkResponse = await fetchAndUpdateCache(cache, event.request, cachedForCompare);
+          if (networkResponse) return networkResponse;
+        } catch {}
+        if (cached) return cached;
+        return new Response(null, { status: 504, statusText: 'Gateway Timeout' });
+      }
+
+      // Stale-while-revalidate for static/data requests.
       const fetchPromise = fetchAndUpdateCache(cache, event.request, cachedForCompare);
 
       if (cached) {
@@ -99,17 +110,19 @@ async function fetchAndUpdateCache(cache, request, cachedResponse) {
   }
 }
 
-async function shouldNotifyUpdate(request, cachedResponse, networkResponse) {
-  if (!cachedResponse) return false;
-
+function isDocumentRequest(request) {
   const destination = request.destination;
   const acceptHeader = request.headers.get('accept') || '';
-  const isDocumentRequest =
+  return (
     request.mode === 'navigate' ||
     destination === 'document' ||
-    acceptHeader.includes('text/html');
+    acceptHeader.includes('text/html')
+  );
+}
 
-  if (!isDocumentRequest) return false;
+async function shouldNotifyUpdate(request, cachedResponse, networkResponse) {
+  if (!cachedResponse) return false;
+  if (!isDocumentRequest(request)) return false;
 
   const cachedEtag = cachedResponse.headers.get('etag');
   const networkEtag = networkResponse.headers.get('etag');

--- a/taskify-pwa/tests/weekBoardGroupingRegression.test.ts
+++ b/taskify-pwa/tests/weekBoardGroupingRegression.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("week board task grouping uses dueTimeZone when resolving weekday", () => {
+  const appPath = resolve(process.cwd(), "src/App.tsx");
+  const source = readFileSync(appPath, "utf8");
+
+  assert.match(
+    source,
+    /function\s+taskWeekday\s*\(task:\s*Task\)\s*:\s*Weekday\s*\|\s*null\s*\{[\s\S]*?weekdayFromISO\(task\.dueISO,\s*task\.dueTimeZone\)/,
+    "Expected taskWeekday() to pass task.dueTimeZone into weekdayFromISO()",
+  );
+});


### PR DESCRIPTION
## Summary
Follow-up PWA update strategy improvements after week-board fixes.

## Changes
- Service worker cache version bumped to `taskify-cache-v6`
- Document/app-shell fetch strategy updated to a hybrid race:
  - start network fetch immediately
  - if network doesn't return quickly (~700ms), serve cached shell
  - continue network request in background and update cache when it completes
- Non-document GET requests remain stale-while-revalidate for performance

## Why
This keeps installed PWA startup/navigation fast while ensuring updates are still pulled and cached in the background.

## Includes
- Prior week-board day-placement and timezone grouping fixes already on this branch
- Regression tests for week-board DST and timezone grouping
