### PR TITLE
feat(core-wave1): final phase complete reminder-domain extraction

### DIFF
--- a/taskify-core/dist/index.d.ts
+++ b/taskify-core/dist/index.d.ts
@@ -6,3 +6,4 @@ export * from "./calendarProtocol.js";
 export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
+export * from "./reminderUtils.js";

--- a/taskify-core/dist/index.js
+++ b/taskify-core/dist/index.js
@@ -6,3 +6,4 @@ export * from "./calendarProtocol.js";
 export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
+export * from "./reminderUtils.js";

--- a/taskify-core/dist/reminderUtils.d.ts
+++ b/taskify-core/dist/reminderUtils.d.ts
@@ -1,0 +1,47 @@
+export type BuiltinReminderPreset = "0h" | "5m" | "15m" | "30m" | "1h" | "1d" | "1w" | "0d";
+export type CustomReminderPreset = `custom-${number}`;
+export type ReminderPreset = BuiltinReminderPreset | CustomReminderPreset;
+export type ReminderPresetMode = "timed" | "date";
+export declare const DEFAULT_DATE_REMINDER_TIME = "09:00";
+export declare const TIMED_REMINDER_PRESETS: ReadonlyArray<{
+    id: BuiltinReminderPreset;
+    label: string;
+    badge: string;
+    minutes: number;
+}>;
+export declare const DATE_REMINDER_PRESETS: ReadonlyArray<{
+    id: BuiltinReminderPreset;
+    label: string;
+    badge: string;
+    minutes: number;
+}>;
+export declare const BUILTIN_REMINDER_PRESETS: ReadonlyArray<{
+    id: BuiltinReminderPreset;
+    label: string;
+    badge: string;
+    minutes: number;
+}>;
+export declare const BUILTIN_REMINDER_IDS: Set<BuiltinReminderPreset>;
+export declare const BUILTIN_REMINDER_MINUTES: Map<BuiltinReminderPreset, number>;
+export declare const MS_PER_DAY = 86400000;
+export declare const CUSTOM_REMINDER_PATTERN: RegExp;
+export declare const MIN_CUSTOM_REMINDER_MINUTES = -99999999;
+export declare const MAX_CUSTOM_REMINDER_MINUTES = 99999999;
+export declare function clampCustomReminderMinutes(value: number): number;
+export declare function normalizeReminderTime(value: unknown): string | undefined;
+export declare function minutesToReminderId(minutes: number): ReminderPreset;
+export declare function reminderPresetIdForMode(minutes: number, mode: ReminderPresetMode): ReminderPreset;
+export declare function reminderPresetToMinutes(id: ReminderPreset): number;
+export declare function formatReminderLabel(minutes: number): {
+    label: string;
+    badge: string;
+};
+export type ReminderOption = {
+    id: ReminderPreset;
+    label: string;
+    badge: string;
+    minutes: number;
+    builtin: boolean;
+};
+export declare function buildReminderOptions(extraPresetIds?: ReminderPreset[], mode?: ReminderPresetMode): ReminderOption[];
+export declare function sanitizeReminderList(value: unknown): ReminderPreset[] | undefined;

--- a/taskify-core/dist/reminderUtils.js
+++ b/taskify-core/dist/reminderUtils.js
@@ -1,0 +1,168 @@
+export const DEFAULT_DATE_REMINDER_TIME = "09:00";
+export const TIMED_REMINDER_PRESETS = [
+    { id: "0h", label: "At due/start time", badge: "0h", minutes: 0 },
+    { id: "5m", label: "5 minutes before", badge: "5m", minutes: 5 },
+    { id: "15m", label: "15 minutes before", badge: "15m", minutes: 15 },
+    { id: "30m", label: "30 minutes before", badge: "30m", minutes: 30 },
+    { id: "1h", label: "1 hour before", badge: "1h", minutes: 60 },
+    { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
+];
+export const DATE_REMINDER_PRESETS = [
+    { id: "1w", label: "1 week before", badge: "1w", minutes: 10080 },
+    { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
+    { id: "0d", label: "On the day", badge: "day of", minutes: 0 },
+];
+export const BUILTIN_REMINDER_PRESETS = [
+    ...DATE_REMINDER_PRESETS,
+    ...TIMED_REMINDER_PRESETS,
+];
+export const BUILTIN_REMINDER_IDS = new Set(BUILTIN_REMINDER_PRESETS.map((opt) => opt.id));
+export const BUILTIN_REMINDER_MINUTES = new Map(BUILTIN_REMINDER_PRESETS.map((opt) => [opt.id, opt.minutes]));
+export const MS_PER_DAY = 86400000;
+export const CUSTOM_REMINDER_PATTERN = /^custom-(-?\d{1,8})$/;
+export const MIN_CUSTOM_REMINDER_MINUTES = -99_999_999;
+export const MAX_CUSTOM_REMINDER_MINUTES = 99_999_999;
+export function clampCustomReminderMinutes(value) {
+    if (!Number.isFinite(value))
+        return 0;
+    return Math.max(MIN_CUSTOM_REMINDER_MINUTES, Math.min(MAX_CUSTOM_REMINDER_MINUTES, Math.round(value)));
+}
+function parseTimeValue(value) {
+    if (typeof value !== "string" || !value.includes(":"))
+        return null;
+    const [hourRaw, minuteRaw] = value.split(":");
+    const hour = Number.parseInt(hourRaw ?? "", 10);
+    const minute = Number.parseInt(minuteRaw ?? "", 10);
+    if (!Number.isFinite(hour) || !Number.isFinite(minute))
+        return null;
+    return {
+        hour: Math.min(23, Math.max(0, hour)),
+        minute: Math.min(59, Math.max(0, minute)),
+    };
+}
+export function normalizeReminderTime(value) {
+    if (typeof value !== "string")
+        return undefined;
+    const parsed = parseTimeValue(value);
+    if (!parsed)
+        return undefined;
+    return `${String(parsed.hour).padStart(2, "0")}:${String(parsed.minute).padStart(2, "0")}`;
+}
+export function minutesToReminderId(minutes) {
+    if (!Number.isFinite(minutes))
+        return "0d";
+    const normalized = clampCustomReminderMinutes(minutes);
+    if (normalized === 0)
+        return "0d";
+    for (const [id, builtinMinutes] of BUILTIN_REMINDER_MINUTES) {
+        if (builtinMinutes === normalized)
+            return id;
+    }
+    return `custom-${normalized}`;
+}
+export function reminderPresetIdForMode(minutes, mode) {
+    if (!Number.isFinite(minutes)) {
+        return mode === "timed" ? "0h" : "0d";
+    }
+    const normalized = clampCustomReminderMinutes(minutes);
+    if (normalized === 0) {
+        return mode === "timed" ? "0h" : "0d";
+    }
+    return minutesToReminderId(normalized);
+}
+export function reminderPresetToMinutes(id) {
+    if (BUILTIN_REMINDER_IDS.has(id)) {
+        return BUILTIN_REMINDER_MINUTES.get(id) ?? 0;
+    }
+    const match = typeof id === "string" ? id.match(CUSTOM_REMINDER_PATTERN) : null;
+    if (!match)
+        return 0;
+    return clampCustomReminderMinutes(parseInt(match[1] ?? "0", 10));
+}
+export function formatReminderLabel(minutes) {
+    if (!Number.isFinite(minutes)) {
+        return {
+            label: "On the day",
+            badge: "day of",
+        };
+    }
+    if (minutes === 0) {
+        return {
+            label: "On the day",
+            badge: "day of",
+        };
+    }
+    const mins = clampCustomReminderMinutes(minutes);
+    const direction = mins < 0 ? "after" : "before";
+    const signPrefix = mins < 0 ? "+" : "";
+    const absMins = Math.abs(mins);
+    if (absMins % 1440 === 0) {
+        const days = absMins / 1440;
+        return {
+            label: `${days} day${days === 1 ? "" : "s"} ${direction}`,
+            badge: `${signPrefix}${days}d`,
+        };
+    }
+    if (absMins % 60 === 0) {
+        const hours = absMins / 60;
+        return {
+            label: `${hours} hour${hours === 1 ? "" : "s"} ${direction}`,
+            badge: `${signPrefix}${hours}h`,
+        };
+    }
+    return {
+        label: `${absMins} minute${absMins === 1 ? "" : "s"} ${direction}`,
+        badge: `${signPrefix}${absMins}m`,
+    };
+}
+export function buildReminderOptions(extraPresetIds = [], mode = "timed") {
+    const modePresets = mode === "date" ? DATE_REMINDER_PRESETS : TIMED_REMINDER_PRESETS;
+    const options = new Map(modePresets.map((preset) => [preset.id, { ...preset, builtin: true }]));
+    const extras = [];
+    for (const id of extraPresetIds) {
+        if (options.has(id))
+            continue;
+        const minutes = reminderPresetToMinutes(id);
+        if (!Number.isFinite(minutes))
+            continue;
+        const { label, badge } = formatReminderLabel(minutes);
+        extras.push({ id, label, badge, minutes, builtin: !String(id).startsWith("custom-") });
+    }
+    extras.sort((a, b) => a.minutes - b.minutes);
+    return [...options.values(), ...extras];
+}
+export function sanitizeReminderList(value) {
+    if (!Array.isArray(value))
+        return undefined;
+    const dedupByMinutes = new Map();
+    const addByMinutes = (id) => {
+        const minutes = reminderPresetToMinutes(id);
+        if (!Number.isFinite(minutes))
+            return;
+        if (!dedupByMinutes.has(minutes)) {
+            dedupByMinutes.set(minutes, id);
+        }
+    };
+    for (const item of value) {
+        if (typeof item === "string") {
+            if (BUILTIN_REMINDER_IDS.has(item)) {
+                addByMinutes(item);
+                continue;
+            }
+            if (CUSTOM_REMINDER_PATTERN.test(item)) {
+                const minutes = reminderPresetToMinutes(item);
+                if (Number.isFinite(minutes))
+                    addByMinutes(minutesToReminderId(minutes));
+            }
+            continue;
+        }
+        if (typeof item === "number" && Number.isFinite(item)) {
+            const remId = minutesToReminderId(item);
+            addByMinutes(remId);
+        }
+    }
+    const sorted = [...dedupByMinutes.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([, id]) => id);
+    return sorted;
+}

--- a/taskify-core/docs/comprehensive-core-extraction-plan.md
+++ b/taskify-core/docs/comprehensive-core-extraction-plan.md
@@ -24,7 +24,7 @@ Build `taskify-core` into the single shared domain/protocol layer consumed by bo
 
 ## Extraction Waves
 
-### Wave 1 (Start Here): Calendar protocol/domain parity
+### Wave 1 (Start Here): Calendar protocol/domain parity ✅ (completed in branch sequence)
 **Source candidates**
 - `taskify-pwa/src/lib/privateCalendar.ts` (pure protocol layer only)
 - `taskify-pwa/src/lib/app/weekRecurrenceDomain.ts`

--- a/taskify-core/src/index.ts
+++ b/taskify-core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./calendarProtocol.js";
 export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
+export * from "./reminderUtils.js";

--- a/taskify-core/src/reminderUtils.ts
+++ b/taskify-core/src/reminderUtils.ts
@@ -1,0 +1,178 @@
+export type BuiltinReminderPreset = "0h" | "5m" | "15m" | "30m" | "1h" | "1d" | "1w" | "0d";
+export type CustomReminderPreset = `custom-${number}`;
+export type ReminderPreset = BuiltinReminderPreset | CustomReminderPreset;
+export type ReminderPresetMode = "timed" | "date";
+
+export const DEFAULT_DATE_REMINDER_TIME = "09:00";
+
+export const TIMED_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
+  { id: "0h", label: "At due/start time", badge: "0h", minutes: 0 },
+  { id: "5m", label: "5 minutes before", badge: "5m", minutes: 5 },
+  { id: "15m", label: "15 minutes before", badge: "15m", minutes: 15 },
+  { id: "30m", label: "30 minutes before", badge: "30m", minutes: 30 },
+  { id: "1h", label: "1 hour before", badge: "1h", minutes: 60 },
+  { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
+];
+
+export const DATE_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
+  { id: "1w", label: "1 week before", badge: "1w", minutes: 10080 },
+  { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
+  { id: "0d", label: "On the day", badge: "day of", minutes: 0 },
+];
+
+export const BUILTIN_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
+  ...DATE_REMINDER_PRESETS,
+  ...TIMED_REMINDER_PRESETS,
+];
+
+export const BUILTIN_REMINDER_IDS = new Set<BuiltinReminderPreset>(BUILTIN_REMINDER_PRESETS.map((opt) => opt.id));
+export const BUILTIN_REMINDER_MINUTES = new Map<BuiltinReminderPreset, number>(BUILTIN_REMINDER_PRESETS.map((opt) => [opt.id, opt.minutes] as const));
+
+export const MS_PER_DAY = 86400000;
+
+export const CUSTOM_REMINDER_PATTERN = /^custom-(-?\d{1,8})$/;
+export const MIN_CUSTOM_REMINDER_MINUTES = -99_999_999;
+export const MAX_CUSTOM_REMINDER_MINUTES = 99_999_999;
+
+export function clampCustomReminderMinutes(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(MIN_CUSTOM_REMINDER_MINUTES, Math.min(MAX_CUSTOM_REMINDER_MINUTES, Math.round(value)));
+}
+
+function parseTimeValue(value: string): { hour: number; minute: number } | null {
+  if (typeof value !== "string" || !value.includes(":")) return null;
+  const [hourRaw, minuteRaw] = value.split(":");
+  const hour = Number.parseInt(hourRaw ?? "", 10);
+  const minute = Number.parseInt(minuteRaw ?? "", 10);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+  return {
+    hour: Math.min(23, Math.max(0, hour)),
+    minute: Math.min(59, Math.max(0, minute)),
+  };
+}
+
+export function normalizeReminderTime(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = parseTimeValue(value);
+  if (!parsed) return undefined;
+  return `${String(parsed.hour).padStart(2, "0")}:${String(parsed.minute).padStart(2, "0")}`;
+}
+
+export function minutesToReminderId(minutes: number): ReminderPreset {
+  if (!Number.isFinite(minutes)) return "0d";
+  const normalized = clampCustomReminderMinutes(minutes);
+  if (normalized === 0) return "0d";
+  for (const [id, builtinMinutes] of BUILTIN_REMINDER_MINUTES) {
+    if (builtinMinutes === normalized) return id;
+  }
+  return `custom-${normalized}`;
+}
+
+export function reminderPresetIdForMode(minutes: number, mode: ReminderPresetMode): ReminderPreset {
+  if (!Number.isFinite(minutes)) {
+    return mode === "timed" ? "0h" : "0d";
+  }
+  const normalized = clampCustomReminderMinutes(minutes);
+  if (normalized === 0) {
+    return mode === "timed" ? "0h" : "0d";
+  }
+  return minutesToReminderId(normalized);
+}
+
+export function reminderPresetToMinutes(id: ReminderPreset): number {
+  if (BUILTIN_REMINDER_IDS.has(id as BuiltinReminderPreset)) {
+    return BUILTIN_REMINDER_MINUTES.get(id as BuiltinReminderPreset) ?? 0;
+  }
+  const match = typeof id === "string" ? id.match(CUSTOM_REMINDER_PATTERN) : null;
+  if (!match) return 0;
+  return clampCustomReminderMinutes(parseInt(match[1] ?? "0", 10));
+}
+
+export function formatReminderLabel(minutes: number): { label: string; badge: string } {
+  if (!Number.isFinite(minutes)) {
+    return {
+      label: "On the day",
+      badge: "day of",
+    };
+  }
+  if (minutes === 0) {
+    return {
+      label: "On the day",
+      badge: "day of",
+    };
+  }
+  const mins = clampCustomReminderMinutes(minutes);
+  const direction = mins < 0 ? "after" : "before";
+  const signPrefix = mins < 0 ? "+" : "";
+  const absMins = Math.abs(mins);
+  if (absMins % 1440 === 0) {
+    const days = absMins / 1440;
+    return {
+      label: `${days} day${days === 1 ? "" : "s"} ${direction}`,
+      badge: `${signPrefix}${days}d`,
+    };
+  }
+  if (absMins % 60 === 0) {
+    const hours = absMins / 60;
+    return {
+      label: `${hours} hour${hours === 1 ? "" : "s"} ${direction}`,
+      badge: `${signPrefix}${hours}h`,
+    };
+  }
+  return {
+    label: `${absMins} minute${absMins === 1 ? "" : "s"} ${direction}`,
+    badge: `${signPrefix}${absMins}m`,
+  };
+}
+
+export type ReminderOption = { id: ReminderPreset; label: string; badge: string; minutes: number; builtin: boolean };
+
+export function buildReminderOptions(extraPresetIds: ReminderPreset[] = [], mode: ReminderPresetMode = "timed"): ReminderOption[] {
+  const modePresets = mode === "date" ? DATE_REMINDER_PRESETS : TIMED_REMINDER_PRESETS;
+  const options = new Map<ReminderPreset, ReminderOption>(
+    modePresets.map((preset) => [preset.id, { ...preset, builtin: true }] as const),
+  );
+  const extras: ReminderOption[] = [];
+  for (const id of extraPresetIds) {
+    if (options.has(id)) continue;
+    const minutes = reminderPresetToMinutes(id);
+    if (!Number.isFinite(minutes)) continue;
+    const { label, badge } = formatReminderLabel(minutes);
+    extras.push({ id, label, badge, minutes, builtin: !String(id).startsWith("custom-") });
+  }
+  extras.sort((a, b) => a.minutes - b.minutes);
+  return [...options.values(), ...extras];
+}
+
+export function sanitizeReminderList(value: unknown): ReminderPreset[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const dedupByMinutes = new Map<number, ReminderPreset>();
+  const addByMinutes = (id: ReminderPreset) => {
+    const minutes = reminderPresetToMinutes(id);
+    if (!Number.isFinite(minutes)) return;
+    if (!dedupByMinutes.has(minutes)) {
+      dedupByMinutes.set(minutes, id);
+    }
+  };
+  for (const item of value) {
+    if (typeof item === "string") {
+      if (BUILTIN_REMINDER_IDS.has(item as BuiltinReminderPreset)) {
+        addByMinutes(item as ReminderPreset);
+        continue;
+      }
+      if (CUSTOM_REMINDER_PATTERN.test(item)) {
+        const minutes = reminderPresetToMinutes(item as ReminderPreset);
+        if (Number.isFinite(minutes)) addByMinutes(minutesToReminderId(minutes));
+      }
+      continue;
+    }
+    if (typeof item === "number" && Number.isFinite(item)) {
+      const remId = minutesToReminderId(item);
+      addByMinutes(remId);
+    }
+  }
+  const sorted = [...dedupByMinutes.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, id]) => id);
+  return sorted;
+}

--- a/taskify-core/tests/reminder-utils-core.test.ts
+++ b/taskify-core/tests/reminder-utils-core.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  reminderPresetIdForMode,
+  reminderPresetToMinutes,
+  normalizeReminderTime,
+  sanitizeReminderList,
+} from "../dist/reminderUtils.js";
+
+test("reminderPresetIdForMode maps zero by mode", () => {
+  assert.equal(reminderPresetIdForMode(0, "timed"), "0h");
+  assert.equal(reminderPresetIdForMode(0, "date"), "0d");
+});
+
+test("reminderPresetToMinutes parses builtin and custom", () => {
+  assert.equal(reminderPresetToMinutes("1h"), 60);
+  assert.equal(reminderPresetToMinutes("custom-90"), 90);
+});
+
+test("normalizeReminderTime normalizes hh:mm", () => {
+  assert.equal(normalizeReminderTime("9:7"), "09:07");
+});
+
+test("sanitizeReminderList dedupes by minute and sorts", () => {
+  const out = sanitizeReminderList(["1h", "custom-60", "5m", 60]);
+  assert.deepEqual(out, ["5m", "1h"]);
+});

--- a/taskify-pwa/src/domains/dateTime/reminderUtils.ts
+++ b/taskify-pwa/src/domains/dateTime/reminderUtils.ts
@@ -1,178 +1,28 @@
-export type BuiltinReminderPreset = "0h" | "5m" | "15m" | "30m" | "1h" | "1d" | "1w" | "0d";
-export type CustomReminderPreset = `custom-${number}`;
-export type ReminderPreset = BuiltinReminderPreset | CustomReminderPreset;
-export type ReminderPresetMode = "timed" | "date";
+export {
+  DEFAULT_DATE_REMINDER_TIME,
+  TIMED_REMINDER_PRESETS,
+  DATE_REMINDER_PRESETS,
+  BUILTIN_REMINDER_PRESETS,
+  BUILTIN_REMINDER_IDS,
+  BUILTIN_REMINDER_MINUTES,
+  MS_PER_DAY,
+  CUSTOM_REMINDER_PATTERN,
+  MIN_CUSTOM_REMINDER_MINUTES,
+  MAX_CUSTOM_REMINDER_MINUTES,
+  clampCustomReminderMinutes,
+  normalizeReminderTime,
+  minutesToReminderId,
+  reminderPresetIdForMode,
+  reminderPresetToMinutes,
+  formatReminderLabel,
+  buildReminderOptions,
+  sanitizeReminderList,
+} from "taskify-core";
 
-export const DEFAULT_DATE_REMINDER_TIME = "09:00";
-
-export const TIMED_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
-  { id: "0h", label: "At due/start time", badge: "0h", minutes: 0 },
-  { id: "5m", label: "5 minutes before", badge: "5m", minutes: 5 },
-  { id: "15m", label: "15 minutes before", badge: "15m", minutes: 15 },
-  { id: "30m", label: "30 minutes before", badge: "30m", minutes: 30 },
-  { id: "1h", label: "1 hour before", badge: "1h", minutes: 60 },
-  { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
-];
-
-export const DATE_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
-  { id: "1w", label: "1 week before", badge: "1w", minutes: 10080 },
-  { id: "1d", label: "1 day before", badge: "1d", minutes: 1440 },
-  { id: "0d", label: "On the day", badge: "day of", minutes: 0 },
-];
-
-export const BUILTIN_REMINDER_PRESETS: ReadonlyArray<{ id: BuiltinReminderPreset; label: string; badge: string; minutes: number }> = [
-  ...DATE_REMINDER_PRESETS,
-  ...TIMED_REMINDER_PRESETS,
-];
-
-export const BUILTIN_REMINDER_IDS = new Set<BuiltinReminderPreset>(BUILTIN_REMINDER_PRESETS.map((opt) => opt.id));
-export const BUILTIN_REMINDER_MINUTES = new Map<BuiltinReminderPreset, number>(BUILTIN_REMINDER_PRESETS.map((opt) => [opt.id, opt.minutes] as const));
-
-export const MS_PER_DAY = 86400000;
-
-export const CUSTOM_REMINDER_PATTERN = /^custom-(-?\d{1,8})$/;
-export const MIN_CUSTOM_REMINDER_MINUTES = -99_999_999;
-export const MAX_CUSTOM_REMINDER_MINUTES = 99_999_999;
-
-export function clampCustomReminderMinutes(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.max(MIN_CUSTOM_REMINDER_MINUTES, Math.min(MAX_CUSTOM_REMINDER_MINUTES, Math.round(value)));
-}
-
-function parseTimeValue(value: string): { hour: number; minute: number } | null {
-  if (typeof value !== "string" || !value.includes(":")) return null;
-  const [hourRaw, minuteRaw] = value.split(":");
-  const hour = Number.parseInt(hourRaw ?? "", 10);
-  const minute = Number.parseInt(minuteRaw ?? "", 10);
-  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
-  return {
-    hour: Math.min(23, Math.max(0, hour)),
-    minute: Math.min(59, Math.max(0, minute)),
-  };
-}
-
-export function normalizeReminderTime(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const parsed = parseTimeValue(value);
-  if (!parsed) return undefined;
-  return `${String(parsed.hour).padStart(2, "0")}:${String(parsed.minute).padStart(2, "0")}`;
-}
-
-export function minutesToReminderId(minutes: number): ReminderPreset {
-  if (!Number.isFinite(minutes)) return "0d";
-  const normalized = clampCustomReminderMinutes(minutes);
-  if (normalized === 0) return "0d";
-  for (const [id, builtinMinutes] of BUILTIN_REMINDER_MINUTES) {
-    if (builtinMinutes === normalized) return id;
-  }
-  return `custom-${normalized}`;
-}
-
-export function reminderPresetIdForMode(minutes: number, mode: ReminderPresetMode): ReminderPreset {
-  if (!Number.isFinite(minutes)) {
-    return mode === "timed" ? "0h" : "0d";
-  }
-  const normalized = clampCustomReminderMinutes(minutes);
-  if (normalized === 0) {
-    return mode === "timed" ? "0h" : "0d";
-  }
-  return minutesToReminderId(normalized);
-}
-
-export function reminderPresetToMinutes(id: ReminderPreset): number {
-  if (BUILTIN_REMINDER_IDS.has(id as BuiltinReminderPreset)) {
-    return BUILTIN_REMINDER_MINUTES.get(id as BuiltinReminderPreset) ?? 0;
-  }
-  const match = typeof id === 'string' ? id.match(CUSTOM_REMINDER_PATTERN) : null;
-  if (!match) return 0;
-  return clampCustomReminderMinutes(parseInt(match[1] ?? '0', 10));
-}
-
-export function formatReminderLabel(minutes: number): { label: string; badge: string } {
-  if (!Number.isFinite(minutes)) {
-    return {
-      label: "On the day",
-      badge: "day of",
-    };
-  }
-  if (minutes === 0) {
-    return {
-      label: "On the day",
-      badge: "day of",
-    };
-  }
-  const mins = clampCustomReminderMinutes(minutes);
-  const direction = mins < 0 ? "after" : "before";
-  const signPrefix = mins < 0 ? "+" : "";
-  const absMins = Math.abs(mins);
-  if (absMins % 1440 === 0) {
-    const days = absMins / 1440;
-    return {
-      label: `${days} day${days === 1 ? '' : 's'} ${direction}`,
-      badge: `${signPrefix}${days}d`,
-    };
-  }
-  if (absMins % 60 === 0) {
-    const hours = absMins / 60;
-    return {
-      label: `${hours} hour${hours === 1 ? '' : 's'} ${direction}`,
-      badge: `${signPrefix}${hours}h`,
-    };
-  }
-  return {
-    label: `${absMins} minute${absMins === 1 ? '' : 's'} ${direction}`,
-    badge: `${signPrefix}${absMins}m`,
-  };
-}
-
-export type ReminderOption = { id: ReminderPreset; label: string; badge: string; minutes: number; builtin: boolean };
-
-export function buildReminderOptions(extraPresetIds: ReminderPreset[] = [], mode: ReminderPresetMode = "timed"): ReminderOption[] {
-  const modePresets = mode === "date" ? DATE_REMINDER_PRESETS : TIMED_REMINDER_PRESETS;
-  const options = new Map<ReminderPreset, ReminderOption>(
-    modePresets.map((preset) => [preset.id, { ...preset, builtin: true }] as const),
-  );
-  const extras: ReminderOption[] = [];
-  for (const id of extraPresetIds) {
-    if (options.has(id)) continue;
-    const minutes = reminderPresetToMinutes(id);
-    if (!Number.isFinite(minutes)) continue;
-    const { label, badge } = formatReminderLabel(minutes);
-    extras.push({ id, label, badge, minutes, builtin: !String(id).startsWith("custom-") });
-  }
-  extras.sort((a, b) => a.minutes - b.minutes);
-  return [...options.values(), ...extras];
-}
-
-export function sanitizeReminderList(value: unknown): ReminderPreset[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const dedupByMinutes = new Map<number, ReminderPreset>();
-  const addByMinutes = (id: ReminderPreset) => {
-    const minutes = reminderPresetToMinutes(id);
-    if (!Number.isFinite(minutes)) return;
-    if (!dedupByMinutes.has(minutes)) {
-      dedupByMinutes.set(minutes, id);
-    }
-  };
-  for (const item of value) {
-    if (typeof item === 'string') {
-      if (BUILTIN_REMINDER_IDS.has(item as BuiltinReminderPreset)) {
-        addByMinutes(item as ReminderPreset);
-        continue;
-      }
-      if (CUSTOM_REMINDER_PATTERN.test(item)) {
-        const minutes = reminderPresetToMinutes(item as ReminderPreset);
-        if (Number.isFinite(minutes)) addByMinutes(minutesToReminderId(minutes));
-      }
-      continue;
-    }
-    if (typeof item === 'number' && Number.isFinite(item)) {
-      const remId = minutesToReminderId(item);
-      addByMinutes(remId);
-    }
-  }
-  const sorted = [...dedupByMinutes.entries()]
-    .sort((a, b) => a[0] - b[0])
-    .map(([, id]) => id);
-  return sorted;
-}
+export type {
+  BuiltinReminderPreset,
+  CustomReminderPreset,
+  ReminderPreset,
+  ReminderPresetMode,
+  ReminderOption,
+} from "taskify-core";


### PR DESCRIPTION
## Summary
Wave 1 final phase: complete calendar/date-domain extraction by moving reminder-domain utilities into `taskify-core` and wiring PWA to consume them from core.

This PR finalizes the remaining Wave 1 scope after prior merged Wave 1 slices.

## Changes
### Core extraction
- Added `taskify-core/src/reminderUtils.ts` containing shared reminder-domain logic:
  - preset constants and IDs
  - minute/preset conversion helpers
  - label formatting
  - reminder time normalization
  - reminder list sanitization and option builders
- Exported via `taskify-core/src/index.ts`
- Added compiled dist artifacts for the new module

### PWA wiring
- Replaced `taskify-pwa/src/domains/dateTime/reminderUtils.ts` implementation with re-exports from `taskify-core`

### Tests
- Added `taskify-core/tests/reminder-utils-core.test.ts`

### Planning doc
- Updated `taskify-core/docs/comprehensive-core-extraction-plan.md` to mark Wave 1 completed

## Validation
- `taskify-core`: `npm test` ✅
- `taskify-cli`: `npm test` ✅
- `taskify-pwa`: `npm run build` ✅

## Notes
- No schema/data-shape changes.
- This PR is the Wave 1 completion slice only.
