### PR TITLE
feat(core-wave2): extract task/board/contact contracts into taskify-core

### DIFF
--- a/taskify-core/dist/boardContracts.d.ts
+++ b/taskify-core/dist/boardContracts.d.ts
@@ -1,0 +1,9 @@
+import type { Board } from "./taskContracts.js";
+export declare function parseCompoundChildInput(raw: string): {
+    boardId: string;
+    relays: string[];
+};
+export declare function findBoardByCompoundChildId(boards: Board[], childId: string): Board | undefined;
+export declare function compoundChildMatchesBoard(childId: string, board: Board): boolean;
+export declare function normalizeCompoundChildId(boards: Board[], childId: string): string;
+export declare function boardScopeIds(board: Board, boards: Board[]): string[];

--- a/taskify-core/dist/boardContracts.js
+++ b/taskify-core/dist/boardContracts.js
@@ -1,0 +1,52 @@
+export function parseCompoundChildInput(raw) {
+    const trimmed = raw.trim();
+    if (!trimmed)
+        return { boardId: "", relays: [] };
+    let boardId = trimmed;
+    let relaySegment = "";
+    const atIndex = trimmed.indexOf("@");
+    if (atIndex >= 0) {
+        boardId = trimmed.slice(0, atIndex).trim();
+        relaySegment = trimmed.slice(atIndex + 1).trim();
+    }
+    else {
+        const spaceIndex = trimmed.search(/\s/);
+        if (spaceIndex >= 0) {
+            boardId = trimmed.slice(0, spaceIndex).trim();
+            relaySegment = trimmed.slice(spaceIndex + 1).trim();
+        }
+    }
+    const relays = relaySegment ? relaySegment.split(/[\s,]+/).map((relay) => relay.trim()).filter(Boolean) : [];
+    return { boardId, relays };
+}
+export function findBoardByCompoundChildId(boards, childId) {
+    return boards.find((board) => board.id === childId || (!!board.nostr?.boardId && board.nostr.boardId === childId));
+}
+export function compoundChildMatchesBoard(childId, board) {
+    return childId === board.id || (!!board.nostr?.boardId && childId === board.nostr.boardId);
+}
+export function normalizeCompoundChildId(boards, childId) {
+    const match = findBoardByCompoundChildId(boards, childId);
+    return match ? match.id : childId;
+}
+export function boardScopeIds(board, boards) {
+    const ids = new Set();
+    const addId = (value) => {
+        if (typeof value === "string" && value)
+            ids.add(value);
+    };
+    const addBoard = (target) => {
+        if (!target)
+            return;
+        addId(target.id);
+        addId(target.nostr?.boardId);
+    };
+    addBoard(board);
+    if (board.kind === "compound") {
+        board.children.forEach((childId) => {
+            addId(childId);
+            addBoard(findBoardByCompoundChildId(boards, childId));
+        });
+    }
+    return Array.from(ids);
+}

--- a/taskify-core/dist/contactContracts.d.ts
+++ b/taskify-core/dist/contactContracts.d.ts
@@ -1,0 +1,17 @@
+export type Nip05CheckState = {
+    status: "pending" | "valid" | "invalid";
+    nip05: string;
+    npub: string;
+    checkedAt: number;
+    contactUpdatedAt?: number | null;
+};
+export type ContactLike = {
+    id?: string;
+    npub?: string;
+    nip05?: string;
+};
+export declare function normalizeNip05(value?: string | null): string | null;
+export declare function compressedToRawHex(value: string): string;
+export declare function normalizeNostrPubkeyHex(value: string | null | undefined): string | null;
+export declare function contactVerifiedNip05(contact: ContactLike, cache: Record<string, Nip05CheckState>): string | null;
+export declare function contactInitials(value: string): string;

--- a/taskify-core/dist/contactContracts.js
+++ b/taskify-core/dist/contactContracts.js
@@ -1,0 +1,62 @@
+export function normalizeNip05(value) {
+    const trimmed = value?.trim();
+    if (!trimmed)
+        return null;
+    const atIndex = trimmed.indexOf("@");
+    if (atIndex <= 0 || atIndex === trimmed.length - 1)
+        return null;
+    const name = trimmed.slice(0, atIndex).trim().toLowerCase();
+    const domain = trimmed.slice(atIndex + 1).trim().toLowerCase();
+    if (!name || !domain)
+        return null;
+    return `${name}@${domain}`;
+}
+export function compressedToRawHex(value) {
+    if (typeof value !== "string")
+        return value;
+    if (/^(02|03)[0-9a-fA-F]{64}$/.test(value))
+        return value.slice(-64);
+    if (/^0x[0-9a-fA-F]{64}$/.test(value))
+        return value.slice(-64);
+    if (/^[0-9a-fA-F]{64}$/.test(value))
+        return value.toLowerCase();
+    return value;
+}
+export function normalizeNostrPubkeyHex(value) {
+    const trimmed = (value || "").trim().toLowerCase();
+    if (!trimmed)
+        return null;
+    const raw = compressedToRawHex(trimmed).toLowerCase();
+    return /^[0-9a-f]{64}$/.test(raw) ? raw : null;
+}
+export function contactVerifiedNip05(contact, cache) {
+    if (!contact?.id)
+        return null;
+    const nip05 = contact.nip05?.trim();
+    const npub = contact.npub?.trim();
+    if (!nip05 || !npub)
+        return null;
+    const normalizedNip05 = normalizeNip05(nip05);
+    const contactHex = normalizeNostrPubkeyHex(npub);
+    if (!normalizedNip05 || !contactHex)
+        return null;
+    const entry = cache[contact.id];
+    if (!entry || entry.status !== "valid")
+        return null;
+    const cachedNip05 = normalizeNip05(entry.nip05);
+    const cachedHex = normalizeNostrPubkeyHex(entry.npub);
+    if (!cachedNip05 || cachedNip05 !== normalizedNip05)
+        return null;
+    if (!cachedHex || cachedHex !== contactHex)
+        return null;
+    return nip05 || entry.nip05;
+}
+export function contactInitials(value) {
+    const trimmed = (value || "").trim();
+    if (!trimmed)
+        return "?";
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+    if (parts.length === 1)
+        return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/taskify-core/dist/index.d.ts
+++ b/taskify-core/dist/index.d.ts
@@ -1,5 +1,6 @@
 export * from "./activityLog.js";
-export * from "./events.js";
+export { buildCalendarEventDraft } from "./events.js";
+export type { CalendarEvent as DraftCalendarEvent } from "./events.js";
 export * from "./calendarPayload.js";
 export * from "./mutationContracts.js";
 export * from "./calendarProtocol.js";
@@ -7,3 +8,6 @@ export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
 export * from "./reminderUtils.js";
+export * from "./taskContracts.js";
+export * from "./boardContracts.js";
+export * from "./contactContracts.js";

--- a/taskify-core/dist/index.js
+++ b/taskify-core/dist/index.js
@@ -1,5 +1,5 @@
 export * from "./activityLog.js";
-export * from "./events.js";
+export { buildCalendarEventDraft } from "./events.js";
 export * from "./calendarPayload.js";
 export * from "./mutationContracts.js";
 export * from "./calendarProtocol.js";
@@ -7,3 +7,6 @@ export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
 export * from "./reminderUtils.js";
+export * from "./taskContracts.js";
+export * from "./boardContracts.js";
+export * from "./contactContracts.js";

--- a/taskify-core/dist/taskContracts.d.ts
+++ b/taskify-core/dist/taskContracts.d.ts
@@ -1,0 +1,238 @@
+export type TaskPriority = 1 | 2 | 3;
+export declare const TASK_PRIORITY_MARKS: Record<TaskPriority, string>;
+import type { Weekday } from "./weekDate.js";
+import type { ReminderPreset } from "./reminderUtils.js";
+import type { CalendarRsvpFb, CalendarRsvpStatus } from "./calendarDecode.js";
+export type Recurrence = {
+    type: "none";
+    untilISO?: string;
+} | {
+    type: "daily";
+    untilISO?: string;
+} | {
+    type: "weekly";
+    days: Weekday[];
+    untilISO?: string;
+} | {
+    type: "every";
+    n: number;
+    unit: "hour" | "day" | "week";
+    untilISO?: string;
+} | {
+    type: "monthlyDay";
+    day: number;
+    interval?: number;
+    untilISO?: string;
+};
+export type Subtask = {
+    id: string;
+    title: string;
+    completed?: boolean;
+};
+export type InboxSender = {
+    pubkey: string;
+    name?: string;
+    npub?: string;
+};
+export type InboxItemStatus = "pending" | "accepted" | "declined" | "tentative" | "deleted" | "read";
+export type SharedContactPayload = Record<string, unknown>;
+export type SharedTaskPayload = Record<string, unknown>;
+export type TaskDocument = Record<string, unknown>;
+export type InboxItem = {
+    type: "board";
+    boardId: string;
+    boardName?: string;
+    relays?: string[];
+    sender: InboxSender;
+    receivedAt: string;
+    status?: InboxItemStatus;
+    dmEventId?: string;
+} | {
+    type: "contact";
+    contact: SharedContactPayload;
+    sender: InboxSender;
+    receivedAt: string;
+    status?: InboxItemStatus;
+    dmEventId?: string;
+} | {
+    type: "task";
+    task: SharedTaskPayload;
+    sender: InboxSender;
+    receivedAt: string;
+    status?: InboxItemStatus;
+    dmEventId?: string;
+};
+export type TaskAssigneeStatus = "pending" | "accepted" | "declined" | "tentative";
+export type TaskAssignee = {
+    pubkey: string;
+    relay?: string;
+    status?: TaskAssigneeStatus;
+    respondedAt?: number;
+};
+export type Task = {
+    id: string;
+    boardId: string;
+    title: string;
+    dueISO: string;
+    createdBy?: string;
+    lastEditedBy?: string;
+    createdAt?: number;
+    updatedAt?: string;
+    priority?: TaskPriority;
+    note?: string;
+    images?: string[];
+    documents?: TaskDocument[];
+    dueDateEnabled?: boolean;
+    completed?: boolean;
+    completedAt?: string;
+    completedBy?: string;
+    recurrence?: Recurrence;
+    column?: "day";
+    columnId?: string;
+    hiddenUntilISO?: string;
+    order?: number;
+    streak?: number;
+    longestStreak?: number;
+    seriesId?: string;
+    subtasks?: Subtask[];
+    assignees?: TaskAssignee[];
+    dueTimeEnabled?: boolean;
+    dueTimeZone?: string;
+    reminders?: ReminderPreset[];
+    reminderTime?: string;
+    scriptureMemoryId?: string;
+    scriptureMemoryStage?: number;
+    scriptureMemoryPrevReviewISO?: string | null;
+    scriptureMemoryScheduledAt?: string;
+    bountyLists?: string[];
+    bountyDeletedAt?: string;
+    inboxItem?: InboxItem;
+    bounty?: {
+        id: string;
+        token: string;
+        amount?: number;
+        mint?: string;
+        lock?: "p2pk" | "htlc" | "none" | "unknown";
+        owner?: string;
+        sender?: string;
+        receiver?: string;
+        state: "locked" | "unlocked" | "revoked" | "claimed";
+        updatedAt: string;
+        enc?: {
+            alg: "aes-gcm-256";
+            iv: string;
+            ct: string;
+        } | {
+            alg: "nip04";
+            data: string;
+        } | null;
+    };
+};
+export type CalendarEventParticipant = {
+    pubkey: string;
+    relay?: string;
+    role?: string;
+};
+export type CalendarEventBase = {
+    id: string;
+    boardId: string;
+    title: string;
+    createdBy?: string;
+    lastEditedBy?: string;
+    columnId?: string;
+    order?: number;
+    summary?: string;
+    description?: string;
+    documents?: TaskDocument[];
+    image?: string;
+    locations?: string[];
+    geohash?: string;
+    participants?: CalendarEventParticipant[];
+    hashtags?: string[];
+    references?: string[];
+    reminders?: ReminderPreset[];
+    reminderTime?: string;
+    hiddenUntilISO?: string;
+    recurrence?: Recurrence;
+    seriesId?: string;
+    readOnly?: boolean;
+    external?: boolean;
+    originBoardId?: string;
+    eventKey?: string;
+    inviteTokens?: Record<string, string>;
+    canonicalAddress?: string;
+    viewAddress?: string;
+    inviteToken?: string;
+    inviteRelays?: string[];
+    boardPubkey?: string;
+    rsvpStatus?: CalendarRsvpStatus;
+    rsvpCreatedAt?: number;
+    rsvpFb?: CalendarRsvpFb;
+};
+export type DateCalendarEvent = CalendarEventBase & {
+    kind: "date";
+    startDate: string;
+    endDate?: string;
+};
+export type TimeCalendarEvent = CalendarEventBase & {
+    kind: "time";
+    startISO: string;
+    endISO?: string;
+    startTzid?: string;
+    endTzid?: string;
+};
+export type CalendarEvent = DateCalendarEvent | TimeCalendarEvent;
+export type ExternalCalendarEvent = CalendarEvent & {
+    external: true;
+    boardPubkey: string;
+};
+export declare function isExternalCalendarEvent(event: CalendarEvent): event is ExternalCalendarEvent;
+export type EditItemType = "task" | "event";
+export type EditingState = {
+    type: "task";
+    originalType: EditItemType;
+    originalId: string;
+    task: Task;
+} | {
+    type: "event";
+    originalType: EditItemType;
+    originalId: string;
+    event: CalendarEvent;
+};
+export type BoardSortMode = "manual" | "due" | "priority" | "created" | "alpha";
+export type BoardSortDirection = "asc" | "desc";
+export type UpcomingBoardGrouping = "mixed" | "grouped";
+export type ListColumn = {
+    id: string;
+    name: string;
+};
+export type CompoundChildId = string;
+export type BoardBase = {
+    id: string;
+    name: string;
+    nostr?: {
+        boardId: string;
+        relays: string[];
+    };
+    archived?: boolean;
+    hidden?: boolean;
+    clearCompletedDisabled?: boolean;
+};
+export type Board = (BoardBase & {
+    kind: "week";
+}) | (BoardBase & {
+    kind: "lists";
+    columns: ListColumn[];
+    indexCardEnabled?: boolean;
+}) | (BoardBase & {
+    kind: "compound";
+    children: CompoundChildId[];
+    indexCardEnabled?: boolean;
+    hideChildBoardNames?: boolean;
+}) | (BoardBase & {
+    kind: "bible";
+});
+export type ListLikeBoard = Extract<Board, {
+    kind: "lists" | "compound";
+}>;
+export declare function isListLikeBoard(board: Board | null | undefined): board is ListLikeBoard;

--- a/taskify-core/dist/taskContracts.js
+++ b/taskify-core/dist/taskContracts.js
@@ -1,0 +1,9 @@
+export const TASK_PRIORITY_MARKS = {
+    1: "!",
+    2: "!!",
+    3: "!!!",
+};
+export function isExternalCalendarEvent(event) { return event.external === true; }
+export function isListLikeBoard(board) {
+    return !!board && (board.kind === "lists" || board.kind === "compound");
+}

--- a/taskify-core/docs/comprehensive-core-extraction-plan.md
+++ b/taskify-core/docs/comprehensive-core-extraction-plan.md
@@ -50,7 +50,7 @@ Build `taskify-core` into the single shared domain/protocol layer consumed by bo
 - PWA + CLI build and tests pass
 - No behavior change in event CRUD and parsing semantics
 
-### Wave 2: Task/board/contact contracts
+### Wave 2: Task/board/contact contracts ✅ (completed on `feat/core-wave2-contracts`)
 **Source candidates**
 - `taskify-pwa/src/domains/tasks/taskTypes.ts`
 - `taskify-pwa/src/domains/tasks/taskUtils.ts`

--- a/taskify-core/src/boardContracts.ts
+++ b/taskify-core/src/boardContracts.ts
@@ -1,0 +1,56 @@
+import type { Board } from "./taskContracts.js";
+
+export function parseCompoundChildInput(raw: string): { boardId: string; relays: string[] } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { boardId: "", relays: [] };
+  let boardId = trimmed;
+  let relaySegment = "";
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex >= 0) {
+    boardId = trimmed.slice(0, atIndex).trim();
+    relaySegment = trimmed.slice(atIndex + 1).trim();
+  } else {
+    const spaceIndex = trimmed.search(/\s/);
+    if (spaceIndex >= 0) {
+      boardId = trimmed.slice(0, spaceIndex).trim();
+      relaySegment = trimmed.slice(spaceIndex + 1).trim();
+    }
+  }
+  const relays = relaySegment ? relaySegment.split(/[\s,]+/).map((relay) => relay.trim()).filter(Boolean) : [];
+  return { boardId, relays };
+}
+
+export function findBoardByCompoundChildId(boards: Board[], childId: string): Board | undefined {
+  return boards.find((board) => board.id === childId || (!!board.nostr?.boardId && board.nostr.boardId === childId));
+}
+
+export function compoundChildMatchesBoard(childId: string, board: Board): boolean {
+  return childId === board.id || (!!board.nostr?.boardId && childId === board.nostr.boardId);
+}
+
+export function normalizeCompoundChildId(boards: Board[], childId: string): string {
+  const match = findBoardByCompoundChildId(boards, childId);
+  return match ? match.id : childId;
+}
+
+export function boardScopeIds(board: Board, boards: Board[]): string[] {
+  const ids = new Set<string>();
+  const addId = (value?: string | null) => {
+    if (typeof value === "string" && value) ids.add(value);
+  };
+  const addBoard = (target: Board | undefined) => {
+    if (!target) return;
+    addId(target.id);
+    addId(target.nostr?.boardId);
+  };
+
+  addBoard(board);
+  if (board.kind === "compound") {
+    board.children.forEach((childId) => {
+      addId(childId);
+      addBoard(findBoardByCompoundChildId(boards, childId));
+    });
+  }
+
+  return Array.from(ids);
+}

--- a/taskify-core/src/contactContracts.ts
+++ b/taskify-core/src/contactContracts.ts
@@ -1,0 +1,60 @@
+export type Nip05CheckState = {
+  status: "pending" | "valid" | "invalid";
+  nip05: string;
+  npub: string;
+  checkedAt: number;
+  contactUpdatedAt?: number | null;
+};
+
+export type ContactLike = { id?: string; npub?: string; nip05?: string };
+
+export function normalizeNip05(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex <= 0 || atIndex === trimmed.length - 1) return null;
+  const name = trimmed.slice(0, atIndex).trim().toLowerCase();
+  const domain = trimmed.slice(atIndex + 1).trim().toLowerCase();
+  if (!name || !domain) return null;
+  return `${name}@${domain}`;
+}
+
+export function compressedToRawHex(value: string): string {
+  if (typeof value !== "string") return value;
+  if (/^(02|03)[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
+  if (/^0x[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
+  if (/^[0-9a-fA-F]{64}$/.test(value)) return value.toLowerCase();
+  return value;
+}
+
+export function normalizeNostrPubkeyHex(value: string | null | undefined): string | null {
+  const trimmed = (value || "").trim().toLowerCase();
+  if (!trimmed) return null;
+  const raw = compressedToRawHex(trimmed).toLowerCase();
+  return /^[0-9a-f]{64}$/.test(raw) ? raw : null;
+}
+
+export function contactVerifiedNip05(contact: ContactLike, cache: Record<string, Nip05CheckState>): string | null {
+  if (!contact?.id) return null;
+  const nip05 = contact.nip05?.trim();
+  const npub = contact.npub?.trim();
+  if (!nip05 || !npub) return null;
+  const normalizedNip05 = normalizeNip05(nip05);
+  const contactHex = normalizeNostrPubkeyHex(npub);
+  if (!normalizedNip05 || !contactHex) return null;
+  const entry = cache[contact.id];
+  if (!entry || entry.status !== "valid") return null;
+  const cachedNip05 = normalizeNip05(entry.nip05);
+  const cachedHex = normalizeNostrPubkeyHex(entry.npub);
+  if (!cachedNip05 || cachedNip05 !== normalizedNip05) return null;
+  if (!cachedHex || cachedHex !== contactHex) return null;
+  return nip05 || entry.nip05;
+}
+
+export function contactInitials(value: string): string {
+  const trimmed = (value || "").trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/taskify-core/src/index.ts
+++ b/taskify-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./activityLog.js";
-export * from "./events.js";
+export { buildCalendarEventDraft } from "./events.js";
+export type { CalendarEvent as DraftCalendarEvent } from "./events.js";
 export * from "./calendarPayload.js";
 export * from "./mutationContracts.js";
 export * from "./calendarProtocol.js";
@@ -7,3 +8,6 @@ export * from "./calendarDecode.js";
 export * from "./weekDate.js";
 export * from "./weekRecurrence.js";
 export * from "./reminderUtils.js";
+export * from "./taskContracts.js";
+export * from "./boardContracts.js";
+export * from "./contactContracts.js";

--- a/taskify-core/src/taskContracts.ts
+++ b/taskify-core/src/taskContracts.ts
@@ -1,0 +1,89 @@
+export type TaskPriority = 1 | 2 | 3;
+
+export const TASK_PRIORITY_MARKS: Record<TaskPriority, string> = {
+  1: "!",
+  2: "!!",
+  3: "!!!",
+};
+
+import type { Weekday } from "./weekDate.js";
+import type { BuiltinReminderPreset, CustomReminderPreset, ReminderPreset } from "./reminderUtils.js";
+import type { CalendarRsvpFb, CalendarRsvpStatus } from "./calendarDecode.js";
+
+export type Recurrence =
+  | { type: "none"; untilISO?: string }
+  | { type: "daily"; untilISO?: string }
+  | { type: "weekly"; days: Weekday[]; untilISO?: string }
+  | { type: "every"; n: number; unit: "hour" | "day" | "week"; untilISO?: string }
+  | { type: "monthlyDay"; day: number; interval?: number; untilISO?: string };
+
+export type Subtask = { id: string; title: string; completed?: boolean };
+
+export type InboxSender = { pubkey: string; name?: string; npub?: string };
+export type InboxItemStatus = "pending" | "accepted" | "declined" | "tentative" | "deleted" | "read";
+
+export type SharedContactPayload = Record<string, unknown>;
+export type SharedTaskPayload = Record<string, unknown>;
+export type TaskDocument = Record<string, unknown>;
+export type InboxItem =
+  | { type: "board"; boardId: string; boardName?: string; relays?: string[]; sender: InboxSender; receivedAt: string; status?: InboxItemStatus; dmEventId?: string }
+  | { type: "contact"; contact: SharedContactPayload; sender: InboxSender; receivedAt: string; status?: InboxItemStatus; dmEventId?: string }
+  | { type: "task"; task: SharedTaskPayload; sender: InboxSender; receivedAt: string; status?: InboxItemStatus; dmEventId?: string };
+
+export type TaskAssigneeStatus = "pending" | "accepted" | "declined" | "tentative";
+export type TaskAssignee = { pubkey: string; relay?: string; status?: TaskAssigneeStatus; respondedAt?: number };
+
+export type Task = {
+  id: string; boardId: string; title: string; dueISO: string;
+  createdBy?: string; lastEditedBy?: string; createdAt?: number; updatedAt?: string;
+  priority?: TaskPriority; note?: string; images?: string[]; documents?: TaskDocument[]; dueDateEnabled?: boolean;
+  completed?: boolean; completedAt?: string; completedBy?: string; recurrence?: Recurrence; column?: "day"; columnId?: string;
+  hiddenUntilISO?: string; order?: number; streak?: number; longestStreak?: number; seriesId?: string; subtasks?: Subtask[];
+  assignees?: TaskAssignee[]; dueTimeEnabled?: boolean; dueTimeZone?: string; reminders?: ReminderPreset[]; reminderTime?: string;
+  scriptureMemoryId?: string; scriptureMemoryStage?: number; scriptureMemoryPrevReviewISO?: string | null; scriptureMemoryScheduledAt?: string;
+  bountyLists?: string[]; bountyDeletedAt?: string; inboxItem?: InboxItem;
+  bounty?: {
+    id: string; token: string; amount?: number; mint?: string; lock?: "p2pk" | "htlc" | "none" | "unknown";
+    owner?: string; sender?: string; receiver?: string; state: "locked" | "unlocked" | "revoked" | "claimed"; updatedAt: string;
+    enc?: { alg: "aes-gcm-256"; iv: string; ct: string } | { alg: "nip04"; data: string } | null;
+  };
+};
+
+export type CalendarEventParticipant = { pubkey: string; relay?: string; role?: string };
+export type CalendarEventBase = {
+  id: string; boardId: string; title: string; createdBy?: string; lastEditedBy?: string; columnId?: string; order?: number;
+  summary?: string; description?: string; documents?: TaskDocument[]; image?: string; locations?: string[]; geohash?: string;
+  participants?: CalendarEventParticipant[]; hashtags?: string[]; references?: string[]; reminders?: ReminderPreset[]; reminderTime?: string;
+  hiddenUntilISO?: string; recurrence?: Recurrence; seriesId?: string; readOnly?: boolean; external?: boolean; originBoardId?: string;
+  eventKey?: string; inviteTokens?: Record<string, string>; canonicalAddress?: string; viewAddress?: string; inviteToken?: string;
+  inviteRelays?: string[]; boardPubkey?: string; rsvpStatus?: CalendarRsvpStatus; rsvpCreatedAt?: number; rsvpFb?: CalendarRsvpFb;
+};
+
+export type DateCalendarEvent = CalendarEventBase & { kind: "date"; startDate: string; endDate?: string };
+export type TimeCalendarEvent = CalendarEventBase & { kind: "time"; startISO: string; endISO?: string; startTzid?: string; endTzid?: string };
+export type CalendarEvent = DateCalendarEvent | TimeCalendarEvent;
+export type ExternalCalendarEvent = CalendarEvent & { external: true; boardPubkey: string };
+export function isExternalCalendarEvent(event: CalendarEvent): event is ExternalCalendarEvent { return event.external === true; }
+
+export type EditItemType = "task" | "event";
+export type EditingState =
+  | { type: "task"; originalType: EditItemType; originalId: string; task: Task }
+  | { type: "event"; originalType: EditItemType; originalId: string; event: CalendarEvent };
+
+export type BoardSortMode = "manual" | "due" | "priority" | "created" | "alpha";
+export type BoardSortDirection = "asc" | "desc";
+export type UpcomingBoardGrouping = "mixed" | "grouped";
+
+export type ListColumn = { id: string; name: string };
+export type CompoundChildId = string;
+export type BoardBase = { id: string; name: string; nostr?: { boardId: string; relays: string[] }; archived?: boolean; hidden?: boolean; clearCompletedDisabled?: boolean };
+export type Board =
+  | (BoardBase & { kind: "week" })
+  | (BoardBase & { kind: "lists"; columns: ListColumn[]; indexCardEnabled?: boolean })
+  | (BoardBase & { kind: "compound"; children: CompoundChildId[]; indexCardEnabled?: boolean; hideChildBoardNames?: boolean })
+  | (BoardBase & { kind: "bible" });
+
+export type ListLikeBoard = Extract<Board, { kind: "lists" | "compound" }>;
+export function isListLikeBoard(board: Board | null | undefined): board is ListLikeBoard {
+  return !!board && (board.kind === "lists" || board.kind === "compound");
+}

--- a/taskify-core/tests/board-contracts-core.test.ts
+++ b/taskify-core/tests/board-contracts-core.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCompoundChildInput, boardScopeIds, normalizeCompoundChildId } from "../dist/boardContracts.js";
+
+test("parseCompoundChildInput parses board and relays", () => {
+  const out = parseCompoundChildInput("child@wss://a,wss://b");
+  assert.equal(out.boardId, "child");
+  assert.equal(out.relays.length, 2);
+});
+
+test("boardScopeIds includes ids and child ids", () => {
+  const boards = [
+    { id: "p", name: "P", kind: "compound", children: ["c"], nostr: { boardId: "np", relays: [] } },
+    { id: "c", name: "C", kind: "week", nostr: { boardId: "nc", relays: [] } },
+  ];
+  const ids = boardScopeIds(boards[0] as any, boards as any);
+  assert.equal(ids.includes("p"), true);
+  assert.equal(ids.includes("c"), true);
+  assert.equal(normalizeCompoundChildId(boards as any, "nc"), "c");
+});

--- a/taskify-core/tests/contact-contracts-core.test.ts
+++ b/taskify-core/tests/contact-contracts-core.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeNip05, contactInitials, contactVerifiedNip05 } from "../dist/contactContracts.js";
+
+test("normalizeNip05 lowercases and validates", () => {
+  assert.equal(normalizeNip05("Alice@Example.com"), "alice@example.com");
+  assert.equal(normalizeNip05("bad"), null);
+});
+
+test("contactInitials handles simple names", () => {
+  assert.equal(contactInitials("Jane Doe"), "JD");
+  assert.equal(contactInitials("x"), "X");
+});
+
+test("contactVerifiedNip05 validates against cache", () => {
+  const contact = { id: "1", nip05: "a@b.com", npub: "a".repeat(64) };
+  const cache = { "1": { status: "valid", nip05: "a@b.com", npub: "a".repeat(64), checkedAt: 1 } };
+  assert.equal(contactVerifiedNip05(contact, cache as any), "a@b.com");
+});

--- a/taskify-core/tests/task-contracts-core.test.ts
+++ b/taskify-core/tests/task-contracts-core.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { TASK_PRIORITY_MARKS, isListLikeBoard, isExternalCalendarEvent } from "../dist/taskContracts.js";
+
+test("task priority marks are stable", () => {
+  assert.equal(TASK_PRIORITY_MARKS[1], "!");
+  assert.equal(TASK_PRIORITY_MARKS[3], "!!!");
+});
+
+test("board and external event type guards behave correctly", () => {
+  assert.equal(isListLikeBoard({ id: "1", name: "A", kind: "lists", columns: [] }), true);
+  assert.equal(isListLikeBoard({ id: "1", name: "A", kind: "week" }), false);
+  assert.equal(isExternalCalendarEvent({ id: "e", boardId: "b", title: "x", kind: "date", startDate: "2026-01-01", external: true, boardPubkey: "p" }), true);
+});

--- a/taskify-pwa/src/domains/tasks/contactUtils.ts
+++ b/taskify-pwa/src/domains/tasks/contactUtils.ts
@@ -1,49 +1,28 @@
 // Contact helper functions extracted from App.tsx
 
 import type { Contact } from "../../lib/contacts";
+import {
+  normalizeNip05,
+  compressedToRawHex,
+  normalizeNostrPubkeyHex,
+  contactVerifiedNip05 as contactVerifiedNip05Core,
+  contactInitials,
+  type Nip05CheckState,
+} from "taskify-core";
 import { normalizeNostrPubkey } from "../../lib/nostr";
 import { idbKeyValue } from "../../storage/idbKeyValue";
 import { TASKIFY_STORE_NOSTR } from "../../storage/taskifyDb";
 import { LS_CONTACT_NIP05_CACHE } from "../../localStorageKeys";
 
-// ---- NIP-05 check state ----
-
-export type Nip05CheckState = {
-  status: "pending" | "valid" | "invalid";
-  nip05: string;
-  npub: string;
-  checkedAt: number;
-  contactUpdatedAt?: number | null;
+export {
+  normalizeNip05,
+  compressedToRawHex,
+  normalizeNostrPubkeyHex,
+  contactInitials,
 };
+export type { Nip05CheckState };
 
-// ---- NIP-05 helpers ----
-
-export function normalizeNip05(value?: string | null): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-  const atIndex = trimmed.indexOf("@");
-  if (atIndex <= 0 || atIndex === trimmed.length - 1) return null;
-  const name = trimmed.slice(0, atIndex).trim().toLowerCase();
-  const domain = trimmed.slice(atIndex + 1).trim().toLowerCase();
-  if (!name || !domain) return null;
-  return `${name}@${domain}`;
-}
-
-export function compressedToRawHex(value: string): string {
-  if (typeof value !== "string") return value;
-  if (/^(02|03)[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
-  if (/^0x[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
-  if (/^[0-9a-fA-F]{64}$/.test(value)) return value.toLowerCase();
-  return value;
-}
-
-export function normalizeNostrPubkeyHex(value: string | null | undefined): string | null {
-  const trimmed = (value || "").trim();
-  if (!trimmed) return null;
-  const normalized = normalizeNostrPubkey(trimmed);
-  const raw = compressedToRawHex(normalized ?? trimmed).toLowerCase();
-  return /^[0-9a-f]{64}$/.test(raw) ? raw : null;
-}
+// ---- NIP-05 check state + pure helpers now sourced from taskify-core ----
 
 export function loadNip05Cache(): Record<string, Nip05CheckState> {
   try {
@@ -76,27 +55,10 @@ export function loadNip05Cache(): Record<string, Nip05CheckState> {
 }
 
 export function contactVerifiedNip05(contact: Contact, cache: Record<string, Nip05CheckState>): string | null {
-  if (!contact?.id) return null;
-  const nip05 = contact.nip05?.trim();
-  const npub = contact.npub?.trim();
-  if (!nip05 || !npub) return null;
-  const normalizedNip05 = normalizeNip05(nip05);
-  const normalizedNpub = normalizeNostrPubkey(npub);
-  if (!normalizedNip05 || !normalizedNpub) return null;
-  const entry = cache[contact.id];
-  if (!entry || entry.status !== "valid") return null;
-  const cachedNip05 = normalizeNip05(entry.nip05);
-  const cachedHex = (entry.npub || "").toLowerCase();
-  const contactHex = compressedToRawHex(normalizedNpub).toLowerCase();
-  if (!cachedNip05 || cachedNip05 !== normalizedNip05) return null;
-  if (!cachedHex || cachedHex !== contactHex) return null;
-  return nip05 || entry.nip05;
-}
-
-export function contactInitials(value: string): string {
-  const trimmed = (value || "").trim();
-  if (!trimmed) return "?";
-  const parts = trimmed.split(/\s+/).filter(Boolean);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  const normalizedNpub = normalizeNostrPubkey(contact.npub || "");
+  return contactVerifiedNip05Core({
+    id: contact.id,
+    nip05: contact.nip05,
+    npub: normalizedNpub || contact.npub,
+  }, cache);
 }

--- a/taskify-pwa/src/domains/tasks/taskTypes.ts
+++ b/taskify-pwa/src/domains/tasks/taskTypes.ts
@@ -1,247 +1,42 @@
-import type { TaskDocument } from "../../lib/documents";
-import type { CalendarRsvpFb, CalendarRsvpStatus } from "../../lib/privateCalendar";
-import type { SharedContactPayload, SharedTaskPayload } from "../../lib/shareInbox";
+export {
+  TASK_PRIORITY_MARKS,
+  isExternalCalendarEvent,
+  isListLikeBoard,
+} from "taskify-core";
 
-// ---- Priority ----
+export type {
+  TaskPriority,
+  Weekday,
+  Recurrence,
+  Subtask,
+  BuiltinReminderPreset,
+  CustomReminderPreset,
+  ReminderPreset,
+  InboxSender,
+  InboxItemStatus,
+  InboxItem,
+  TaskAssigneeStatus,
+  TaskAssignee,
+  Task,
+  CalendarEventParticipant,
+  CalendarEventBase,
+  DateCalendarEvent,
+  TimeCalendarEvent,
+  CalendarEvent,
+  ExternalCalendarEvent,
+  EditItemType,
+  EditingState,
+  BoardSortMode,
+  BoardSortDirection,
+  UpcomingBoardGrouping,
+  ListColumn,
+  CompoundChildId,
+  BoardBase,
+  Board,
+  ListLikeBoard,
+} from "taskify-core";
 
-export type TaskPriority = 1 | 2 | 3;
-
-export const TASK_PRIORITY_MARKS: Record<TaskPriority, string> = {
-  1: "!",
-  2: "!!",
-  3: "!!!",
-};
-
-// ---- Recurrence ----
-
-export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0=Sun
-
-export type Recurrence =
-  | { type: "none"; untilISO?: string }
-  | { type: "daily"; untilISO?: string }
-  | { type: "weekly"; days: Weekday[]; untilISO?: string }
-  | { type: "every"; n: number; unit: "hour" | "day" | "week"; untilISO?: string }
-  | { type: "monthlyDay"; day: number; interval?: number; untilISO?: string };
-
-// ---- Subtask ----
-
-export type Subtask = {
-  id: string;
-  title: string;
-  completed?: boolean;
-};
-
-// ---- Reminders ----
-
-export type BuiltinReminderPreset = "0h" | "5m" | "15m" | "30m" | "1h" | "1d" | "1w" | "0d";
-export type CustomReminderPreset = `custom-${number}`;
-export type ReminderPreset = BuiltinReminderPreset | CustomReminderPreset;
-
-// ---- Inbox ----
-
-export type InboxSender = {
-  pubkey: string;
-  name?: string;
-  npub?: string;
-};
-
-export type InboxItemStatus =
-  | "pending"
-  | "accepted"
-  | "declined"
-  | "tentative"
-  | "deleted"
-  | "read";
-
-export type InboxItem =
-  | {
-      type: "board";
-      boardId: string;
-      boardName?: string;
-      relays?: string[];
-      sender: InboxSender;
-      receivedAt: string;
-      status?: InboxItemStatus;
-      dmEventId?: string;
-    }
-  | {
-      type: "contact";
-      contact: SharedContactPayload;
-      sender: InboxSender;
-      receivedAt: string;
-      status?: InboxItemStatus;
-      dmEventId?: string;
-    }
-  | {
-      type: "task";
-      task: SharedTaskPayload;
-      sender: InboxSender;
-      receivedAt: string;
-      status?: InboxItemStatus;
-      dmEventId?: string;
-    };
-
-export type TaskAssigneeStatus = "pending" | "accepted" | "declined" | "tentative";
-
-export type TaskAssignee = {
-  pubkey: string;
-  relay?: string;
-  status?: TaskAssigneeStatus;
-  respondedAt?: number;
-};
-
-// ---- Task ----
-
-export type Task = {
-  id: string;
-  boardId: string;
-  createdBy?: string;             // nostr pubkey of task creator
-  lastEditedBy?: string;          // nostr pubkey of latest task editor
-  createdAt?: number;             // unix ms timestamp (local)
-  updatedAt?: string;             // iso timestamp of latest local edit when known
-  title: string;
-  priority?: TaskPriority;        // 1-3 exclamation marks
-  note?: string;
-  images?: string[];              // base64 data URLs for pasted images
-  documents?: TaskDocument[];     // supported document attachments
-  dueISO: string;                 // for week board day grouping
-  dueDateEnabled?: boolean;       // whether the due date is active
-  completed?: boolean;
-  completedAt?: string;
-  completedBy?: string;           // nostr pubkey of user who marked complete
-  recurrence?: Recurrence;
-  // Week board columns:
-  column?: "day";
-  // Custom boards (multi-list):
-  columnId?: string;
-  hiddenUntilISO?: string;        // controls visibility (appear at/after this date)
-  order?: number;                 // order within the board for manual reordering
-  streak?: number;                // consecutive completion count
-  longestStreak?: number;         // highest recorded streak for the series
-  seriesId?: string;              // identifier for a recurring series
-  subtasks?: Subtask[];           // optional list of subtasks
-  assignees?: TaskAssignee[];     // optional assignment list with response states
-  bounty?: {
-    id: string;                   // bounty id (uuid)
-    token: string;                // cashu token string (locked or unlocked)
-    amount?: number;              // optional, sats
-    mint?: string;                // optional hint
-    lock?: "p2pk" | "htlc" | "none" | "unknown";
-    owner?: string;               // hex pubkey of task creator (who can unlock)
-    sender?: string;              // hex pubkey of funder (who can revoke)
-    receiver?: string;            // hex pubkey of intended recipient (who can decrypt nip04)
-    state: "locked" | "unlocked" | "revoked" | "claimed";
-    updatedAt: string;            // iso
-    enc?:
-      | {                         // optional encrypted form (hidden until funder reveals)
-          alg: "aes-gcm-256";
-          iv: string;            // base64
-          ct: string;            // base64
-        }
-      | {
-          alg: "nip04";         // encrypted to receiver's nostr pubkey (nip04 format)
-          data: string;          // ciphertext returned by nip04.encrypt
-      }
-      | null;
-  };
-  dueTimeEnabled?: boolean;       // whether a specific due time is set
-  dueTimeZone?: string;           // IANA time zone for due time (defaults to device zone)
-  reminders?: ReminderPreset[];   // preset reminder offsets before due time
-  reminderTime?: string;          // HH:mm reminder clock used when due time is not set
-  scriptureMemoryId?: string;     // reference to scripture memory entry when auto-created
-  scriptureMemoryStage?: number;  // stage at time of scheduling (for undo)
-  scriptureMemoryPrevReviewISO?: string | null; // previous review timestamp snapshot
-  scriptureMemoryScheduledAt?: string; // when this memory task was generated
-  bountyLists?: string[];         // local-only set of bounty list keys the task belongs to
-  bountyDeletedAt?: string;       // local-only marker for recoverable bounty-task deletes
-  inboxItem?: InboxItem;          // shared inbox metadata (boards/contacts/tasks)
-};
-
-// ---- Calendar event types ----
-
-export type CalendarEventParticipant = {
-  pubkey: string;
-  relay?: string;
-  role?: string;
-};
-
-export type CalendarEventBase = {
-  id: string;                     // stable event identifier
-  boardId: string;
-  createdBy?: string;             // nostr pubkey of event creator
-  lastEditedBy?: string;          // nostr pubkey of latest event editor
-  columnId?: string;              // list boards only
-  order?: number;                 // manual ordering within board/column
-  title: string;
-  summary?: string;
-  description?: string;
-  documents?: TaskDocument[];     // supported document attachments
-  image?: string;
-  locations?: string[];
-  geohash?: string;
-  participants?: CalendarEventParticipant[];
-  hashtags?: string[];
-  references?: string[];
-  reminders?: ReminderPreset[];   // per-device push reminders (not published)
-  reminderTime?: string;          // HH:mm reminder clock used for all-day events
-  hiddenUntilISO?: string;        // local visibility gating for board lists
-  recurrence?: Recurrence;        // client-managed recurrence
-  seriesId?: string;              // client-managed recurrence grouping
-  readOnly?: boolean;             // view-only event (cannot publish edits)
-  external?: boolean;             // boardless invitee event
-  originBoardId?: string;         // board id to publish edits/deletions when different from boardId
-  eventKey?: string;              // per-event share key (base64)
-  inviteTokens?: Record<string, string>; // board-only invite tokens keyed by pubkey
-  canonicalAddress?: string;      // canonical event address for invitees
-  viewAddress?: string;           // shareable view address for invitees
-  inviteToken?: string;           // invitee token for RSVP
-  inviteRelays?: string[];        // relays to fetch view + RSVP
-  boardPubkey?: string;           // canonical board pubkey for external RSVP
-  rsvpStatus?: CalendarRsvpStatus; // local RSVP state (external)
-  rsvpCreatedAt?: number;         // created_at for local RSVP (external)
-  rsvpFb?: CalendarRsvpFb;         // free/busy for local RSVP (external)
-};
-
-export type DateCalendarEvent = CalendarEventBase & {
-  kind: "date";
-  startDate: string;              // YYYY-MM-DD
-  endDate?: string;               // inclusive YYYY-MM-DD (UI-facing)
-};
-
-export type TimeCalendarEvent = CalendarEventBase & {
-  kind: "time";
-  startISO: string;               // ISO timestamp (UTC)
-  endISO?: string;                // ISO timestamp (UTC)
-  startTzid?: string;             // IANA TZID tag
-  endTzid?: string;
-};
-
-export type CalendarEvent = DateCalendarEvent | TimeCalendarEvent;
-export type ExternalCalendarEvent = CalendarEvent & {
-  external: true;
-  boardPubkey: string;
-};
-
-export function isExternalCalendarEvent(event: CalendarEvent): event is ExternalCalendarEvent {
-  return event.external === true;
-}
-
-// ---- Edit state ----
-
-export type EditItemType = "task" | "event";
-
-export type EditingState =
-  | { type: "task"; originalType: EditItemType; originalId: string; task: Task }
-  | { type: "event"; originalType: EditItemType; originalId: string; event: CalendarEvent };
-
-// ---- Board sort / grouping ----
-
-export type BoardSortMode = "manual" | "due" | "priority" | "created" | "alpha";
-export type BoardSortDirection = "asc" | "desc";
-export type UpcomingBoardGrouping = "mixed" | "grouped";
-
-// ---- Publish / complete function types ----
-
+// Legacy aliases retained for compatibility with existing imports
 export type PublishTaskFn = (
   task: Task,
   boardOverride?: Board,
@@ -269,43 +64,3 @@ export type CompleteTaskFn = (
   id: string,
   options?: { skipScriptureMemoryUpdate?: boolean; inboxAction?: "accept" | "dismiss" | "decline" | "maybe" }
 ) => CompleteTaskResult;
-
-// ---- Board types ----
-
-export type ListColumn = { id: string; name: string };
-
-export type CompoundIndexGroup = {
-  key: string;
-  boardId: string;
-  boardName: string;
-  columns: { id: string; name: string }[];
-};
-
-export type BoardBase = {
-  id: string;
-  name: string;
-  // Optional Nostr sharing metadata
-  nostr?: { boardId: string; relays: string[] };
-  archived?: boolean;
-  hidden?: boolean;
-  clearCompletedDisabled?: boolean;
-};
-
-export type CompoundChildId = string;
-
-export type Board =
-  | (BoardBase & { kind: "week" }) // fixed Sun–Sat
-  | (BoardBase & { kind: "lists"; columns: ListColumn[]; indexCardEnabled?: boolean }) // multiple customizable columns
-  | (BoardBase & {
-      kind: "compound";
-      children: CompoundChildId[];
-      indexCardEnabled?: boolean;
-      hideChildBoardNames?: boolean;
-    })
-  | (BoardBase & { kind: "bible" });
-
-export type ListLikeBoard = Extract<Board, { kind: "lists" | "compound" }>;
-
-export function isListLikeBoard(board: Board | null | undefined): board is ListLikeBoard {
-  return !!board && (board.kind === "lists" || board.kind === "compound");
-}


### PR DESCRIPTION
## Summary
Wave 2 phase PR: extract shared task/board/contact contracts into `taskify-core` and wire PWA task/contact domains to consume core contracts/helpers.

## Changes
### Core modules added
- `taskify-core/src/taskContracts.ts`
- `taskify-core/src/boardContracts.ts`
- `taskify-core/src/contactContracts.ts`

### Core exports
- Updated `taskify-core/src/index.ts` to export new Wave 2 modules.

### PWA wiring
- `taskify-pwa/src/domains/tasks/taskTypes.ts`
  - now sources task/board/event contract types + guards from `taskify-core`
  - preserves local compatibility aliases for existing function signatures
- `taskify-pwa/src/domains/tasks/contactUtils.ts`
  - now imports/uses core pure contact/NIP-05 helpers
  - retains local storage-specific cache loading (`loadNip05Cache`) in PWA

### Tests added
- `taskify-core/tests/task-contracts-core.test.ts`
- `taskify-core/tests/board-contracts-core.test.ts`
- `taskify-core/tests/contact-contracts-core.test.ts`

### Plan status
- Marked Wave 2 complete in `taskify-core/docs/comprehensive-core-extraction-plan.md`.

## Validation
- `taskify-core`: `npm test` ✅
- `taskify-cli`: `npm test` ✅
- `taskify-pwa`: `npm run build` ✅

## Notes
- No schema/data-shape changes.
- This PR is the complete Wave 2 phase slice.
