### PR TITLE
feat(core-wave4): extract nostr pure primitives into taskify-core

### DIFF
--- a/taskify-core/dist/index.d.ts
+++ b/taskify-core/dist/index.d.ts
@@ -13,3 +13,4 @@ export * from "./boardContracts.js";
 export * from "./contactContracts.js";
 export * from "./shareContracts.js";
 export * from "./backupContracts.js";
+export * from "./nostrPrimitives.js";

--- a/taskify-core/dist/index.js
+++ b/taskify-core/dist/index.js
@@ -12,3 +12,4 @@ export * from "./boardContracts.js";
 export * from "./contactContracts.js";
 export * from "./shareContracts.js";
 export * from "./backupContracts.js";
+export * from "./nostrPrimitives.js";

--- a/taskify-core/dist/nostrPrimitives.d.ts
+++ b/taskify-core/dist/nostrPrimitives.d.ts
@@ -1,0 +1,18 @@
+export declare const DEFAULT_NOSTR_RELAYS: readonly ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.snort.social", "wss://relay.primal.net"];
+export type DefaultRelay = typeof DEFAULT_NOSTR_RELAYS[number];
+export declare function sha256(data: Uint8Array): Promise<Uint8Array>;
+export declare function bytesHexToBytes(hex: string): Uint8Array;
+export declare function bytesToHexString(b: Uint8Array): string;
+export declare function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBuffer>;
+export declare function b64encode(buf: ArrayBuffer | Uint8Array): string;
+export declare function b64decode(s: string): Uint8Array;
+export declare const CLOUD_BACKUP_KEY_LABEL: Uint8Array<ArrayBuffer>;
+export declare function deriveBackupAesKey(skHex: string): Promise<CryptoKey>;
+export declare function encryptBackupWithSecretKey(skHex: string, plain: string): Promise<{
+    iv: string;
+    ciphertext: string;
+}>;
+export declare function decryptBackupWithSecretKey(skHex: string, payload: {
+    iv: string;
+    ciphertext: string;
+}): Promise<string>;

--- a/taskify-core/dist/nostrPrimitives.js
+++ b/taskify-core/dist/nostrPrimitives.js
@@ -1,0 +1,64 @@
+export const DEFAULT_NOSTR_RELAYS = [
+    "wss://relay.damus.io",
+    "wss://nos.lol",
+    "wss://relay.snort.social",
+    "wss://relay.primal.net",
+];
+function toArrayBuffer(bytes) {
+    return Uint8Array.from(bytes).buffer;
+}
+export async function sha256(data) {
+    const view = data instanceof Uint8Array ? data : new Uint8Array(data);
+    const h = await crypto.subtle.digest("SHA-256", toArrayBuffer(view));
+    return new Uint8Array(h);
+}
+export function bytesHexToBytes(hex) {
+    const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+    const out = new Uint8Array(clean.length / 2);
+    for (let i = 0; i < out.length; i++)
+        out[i] = parseInt(clean.substr(i * 2, 2), 16);
+    return out;
+}
+export function bytesToHexString(b) {
+    return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+export function concatBytes(a, b) {
+    const out = new Uint8Array(a.length + b.length);
+    out.set(a);
+    out.set(b, a.length);
+    return out;
+}
+export function b64encode(buf) {
+    const b = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let s = "";
+    for (let i = 0; i < b.length; i++)
+        s += String.fromCharCode(b[i]);
+    return btoa(s);
+}
+export function b64decode(s) {
+    const bin = atob(s);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++)
+        out[i] = bin.charCodeAt(i);
+    return out;
+}
+export const CLOUD_BACKUP_KEY_LABEL = new TextEncoder().encode("taskify-cloud-backup-v1");
+export async function deriveBackupAesKey(skHex) {
+    const raw = concatBytes(bytesHexToBytes(skHex), CLOUD_BACKUP_KEY_LABEL);
+    const digest = await sha256(raw);
+    return await crypto.subtle.importKey("raw", toArrayBuffer(digest), "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+export async function encryptBackupWithSecretKey(skHex, plain) {
+    const key = await deriveBackupAesKey(skHex);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const plainBytes = new TextEncoder().encode(plain);
+    const ctBuf = await crypto.subtle.encrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, toArrayBuffer(plainBytes));
+    return { iv: b64encode(iv), ciphertext: b64encode(ctBuf) };
+}
+export async function decryptBackupWithSecretKey(skHex, payload) {
+    const key = await deriveBackupAesKey(skHex);
+    const iv = b64decode(payload.iv);
+    const ct = b64decode(payload.ciphertext);
+    const ptBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, toArrayBuffer(ct));
+    return new TextDecoder().decode(new Uint8Array(ptBuf));
+}

--- a/taskify-core/docs/comprehensive-core-extraction-plan.md
+++ b/taskify-core/docs/comprehensive-core-extraction-plan.md
@@ -74,7 +74,7 @@ Build `taskify-core` into the single shared domain/protocol layer consumed by bo
 - transport-agnostic envelope builders/parsers
 - backup snapshot/merge/sanitize domain helpers
 
-### Wave 4: Nostr pure primitives
+### Wave 4: Nostr pure primitives ✅ (completed on `feat/core-wave4-nostr-primitives`)
 **Source candidates**
 - `taskify-pwa/src/domains/nostr/nostrKeyUtils.ts`
 - `taskify-pwa/src/domains/nostr/nostrCrypto.ts`

--- a/taskify-core/src/index.ts
+++ b/taskify-core/src/index.ts
@@ -13,3 +13,4 @@ export * from "./boardContracts.js";
 export * from "./contactContracts.js";
 export * from "./shareContracts.js";
 export * from "./backupContracts.js";
+export * from "./nostrPrimitives.js";

--- a/taskify-core/src/nostrPrimitives.ts
+++ b/taskify-core/src/nostrPrimitives.ts
@@ -1,0 +1,74 @@
+export const DEFAULT_NOSTR_RELAYS = [
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.snort.social",
+  "wss://relay.primal.net",
+] as const;
+
+export type DefaultRelay = typeof DEFAULT_NOSTR_RELAYS[number];
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return Uint8Array.from(bytes).buffer;
+}
+
+export async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  const view = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const h = await crypto.subtle.digest("SHA-256", toArrayBuffer(view));
+  return new Uint8Array(h);
+}
+
+export function bytesHexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  return out;
+}
+
+export function bytesToHexString(b: Uint8Array): string {
+  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+export function concatBytes(a: Uint8Array, b: Uint8Array) {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a);
+  out.set(b, a.length);
+  return out;
+}
+
+export function b64encode(buf: ArrayBuffer | Uint8Array): string {
+  const b = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+  return btoa(s);
+}
+
+export function b64decode(s: string): Uint8Array {
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export const CLOUD_BACKUP_KEY_LABEL = new TextEncoder().encode("taskify-cloud-backup-v1");
+
+export async function deriveBackupAesKey(skHex: string): Promise<CryptoKey> {
+  const raw = concatBytes(bytesHexToBytes(skHex), CLOUD_BACKUP_KEY_LABEL);
+  const digest = await sha256(raw);
+  return await crypto.subtle.importKey("raw", toArrayBuffer(digest), "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+
+export async function encryptBackupWithSecretKey(skHex: string, plain: string): Promise<{ iv: string; ciphertext: string }> {
+  const key = await deriveBackupAesKey(skHex);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plainBytes = new TextEncoder().encode(plain);
+  const ctBuf = await crypto.subtle.encrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, toArrayBuffer(plainBytes));
+  return { iv: b64encode(iv), ciphertext: b64encode(ctBuf) };
+}
+
+export async function decryptBackupWithSecretKey(skHex: string, payload: { iv: string; ciphertext: string }): Promise<string> {
+  const key = await deriveBackupAesKey(skHex);
+  const iv = b64decode(payload.iv);
+  const ct = b64decode(payload.ciphertext);
+  const ptBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv: toArrayBuffer(iv) }, key, toArrayBuffer(ct));
+  return new TextDecoder().decode(new Uint8Array(ptBuf));
+}

--- a/taskify-core/tests/nostr-primitives-core.test.ts
+++ b/taskify-core/tests/nostr-primitives-core.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_NOSTR_RELAYS,
+  bytesHexToBytes,
+  bytesToHexString,
+  b64encode,
+  b64decode,
+} from "../dist/nostrPrimitives.js";
+
+test("default nostr relays are defined", () => {
+  assert.equal(DEFAULT_NOSTR_RELAYS.length > 0, true);
+});
+
+test("hex byte helpers round-trip", () => {
+  const hex = "a1b2c3";
+  const bytes = bytesHexToBytes(hex);
+  assert.equal(bytesToHexString(bytes), hex);
+});
+
+test("base64 helpers round-trip", () => {
+  const input = new Uint8Array([1, 2, 3, 4]);
+  const b64 = b64encode(input);
+  const out = b64decode(b64);
+  assert.deepEqual(Array.from(out), [1, 2, 3, 4]);
+});

--- a/taskify-pwa/src/domains/nostr/nostrCrypto.ts
+++ b/taskify-pwa/src/domains/nostr/nostrCrypto.ts
@@ -1,52 +1,48 @@
 import { nip04 } from "nostr-tools";
 import { kvStorage } from "../../storage/kvStorage";
 import { LS_NOSTR_SK } from "../../nostrKeys";
+import {
+  sha256,
+  bytesHexToBytes as hexToBytes,
+  bytesToHexString as bytesToHex,
+  concatBytes,
+  b64encode,
+  b64decode,
+  CLOUD_BACKUP_KEY_LABEL,
+  deriveBackupAesKey,
+  encryptBackupWithSecretKey,
+  decryptBackupWithSecretKey,
+} from "taskify-core";
 
-/* ================== Crypto helpers (AES-GCM via local Nostr key) ================== */
-export async function sha256(data: Uint8Array): Promise<Uint8Array> {
-  const h = await crypto.subtle.digest("SHA-256", data);
-  return new Uint8Array(h);
-}
-export function hexToBytes(hex: string): Uint8Array {
-  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
-  const out = new Uint8Array(clean.length / 2);
-  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.substr(i * 2, 2), 16);
-  return out;
-}
-export function bytesToHex(b: Uint8Array): string {
-  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
-}
-export function concatBytes(a: Uint8Array, b: Uint8Array) {
-  const out = new Uint8Array(a.length + b.length);
-  out.set(a); out.set(b, a.length);
-  return out;
-}
-export function b64encode(buf: ArrayBuffer | Uint8Array): string {
-  const b = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
-  let s = ""; for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
-  return btoa(s);
-}
-export function b64decode(s: string): Uint8Array {
-  const bin = atob(s);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
+export {
+  sha256,
+  hexToBytes,
+  bytesToHex,
+  concatBytes,
+  b64encode,
+  b64decode,
+  CLOUD_BACKUP_KEY_LABEL,
+  deriveBackupAesKey,
+  encryptBackupWithSecretKey,
+  decryptBackupWithSecretKey,
+};
+
 async function deriveAesKeyFromLocalSk(): Promise<CryptoKey> {
-  // Derive a stable AES key from local Nostr SK: AES-GCM 256 with SHA-256(sk || label)
   const skHex = kvStorage.getItem(LS_NOSTR_SK) || "";
   if (!skHex || !/^[0-9a-fA-F]{64}$/.test(skHex)) throw new Error("No local Nostr secret key");
   const label = new TextEncoder().encode("taskify-ecash-v1");
   const raw = concatBytes(hexToBytes(skHex), label);
   const digest = await sha256(raw);
-  return await crypto.subtle.importKey("raw", digest, "AES-GCM", false, ["encrypt","decrypt"]);
+  return await crypto.subtle.importKey("raw", digest, "AES-GCM", false, ["encrypt", "decrypt"]);
 }
+
 export async function encryptEcashTokenForFunder(plain: string): Promise<{alg:"aes-gcm-256";iv:string;ct:string}> {
   const key = await deriveAesKeyFromLocalSk();
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ctBuf = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, new TextEncoder().encode(plain));
   return { alg: "aes-gcm-256", iv: b64encode(iv), ct: b64encode(ctBuf) };
 }
+
 export async function decryptEcashTokenForFunder(enc: {alg:"aes-gcm-256";iv:string;ct:string}): Promise<string> {
   if (enc.alg !== "aes-gcm-256") throw new Error("Unsupported cipher");
   const key = await deriveAesKeyFromLocalSk();
@@ -56,7 +52,6 @@ export async function decryptEcashTokenForFunder(enc: {alg:"aes-gcm-256";iv:stri
   return new TextDecoder().decode(new Uint8Array(ptBuf));
 }
 
-// NIP-04 encryption for recipient
 export async function encryptEcashTokenForRecipient(recipientHex: string, plain: string): Promise<{ alg: "nip04"; data: string }> {
   const skHex = kvStorage.getItem(LS_NOSTR_SK) || "";
   if (!/^[0-9a-fA-F]{64}$/.test(skHex)) throw new Error("No local Nostr secret key");
@@ -70,30 +65,4 @@ export async function decryptEcashTokenForRecipient(senderHex: string, enc: { al
   if (!/^[0-9a-fA-F]{64}$/.test(skHex)) throw new Error("No local Nostr secret key");
   if (!/^[0-9a-fA-F]{64}$/.test(senderHex)) throw new Error("Invalid sender pubkey");
   return await nip04.decrypt(skHex, senderHex, enc.data);
-}
-
-export const CLOUD_BACKUP_KEY_LABEL = new TextEncoder().encode("taskify-cloud-backup-v1");
-
-export async function deriveBackupAesKey(skHex: string): Promise<CryptoKey> {
-  const raw = concatBytes(hexToBytes(skHex), CLOUD_BACKUP_KEY_LABEL);
-  const digest = await sha256(raw);
-  return await crypto.subtle.importKey("raw", digest, "AES-GCM", false, ["encrypt", "decrypt"]);
-}
-
-export async function encryptBackupWithSecretKey(skHex: string, plain: string): Promise<{ iv: string; ciphertext: string }> {
-  const key = await deriveBackupAesKey(skHex);
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const ctBuf = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, new TextEncoder().encode(plain));
-  return { iv: b64encode(iv), ciphertext: b64encode(ctBuf) };
-}
-
-export async function decryptBackupWithSecretKey(
-  skHex: string,
-  payload: { iv: string; ciphertext: string },
-): Promise<string> {
-  const key = await deriveBackupAesKey(skHex);
-  const iv = b64decode(payload.iv);
-  const ct = b64decode(payload.ciphertext);
-  const ptBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
-  return new TextDecoder().decode(new Uint8Array(ptBuf));
 }

--- a/taskify-pwa/src/lib/relays.ts
+++ b/taskify-pwa/src/lib/relays.ts
@@ -1,8 +1,2 @@
-export const DEFAULT_NOSTR_RELAYS = [
-  "wss://relay.damus.io",
-  "wss://nos.lol",
-  "wss://relay.snort.social",
-  "wss://relay.primal.net",
-] as const;
-
-export type DefaultRelay = typeof DEFAULT_NOSTR_RELAYS[number];
+export { DEFAULT_NOSTR_RELAYS } from "taskify-core";
+export type { DefaultRelay } from "taskify-core";


### PR DESCRIPTION
## Summary
Wave 4 phase PR: extract Nostr pure primitives into `taskify-core` and wire PWA relay/crypto helpers to consume core primitives.

## Changes
### Core module added
- `taskify-core/src/nostrPrimitives.ts`
  - default Nostr relay constants
  - byte/hex/base64 utility primitives
  - SHA-256 helper
  - backup AES key derivation + encrypt/decrypt helpers

### Core exports
- Updated `taskify-core/src/index.ts` to export `nostrPrimitives`.

### PWA wiring
- `taskify-pwa/src/lib/relays.ts`
  - now uses core relay constants/types
- `taskify-pwa/src/domains/nostr/nostrCrypto.ts`
  - now imports core pure crypto/byte primitives
  - keeps app-local key/session behavior in PWA domain

### Tests added
- `taskify-core/tests/nostr-primitives-core.test.ts`

### Plan status
- Marked Wave 4 complete in `taskify-core/docs/comprehensive-core-extraction-plan.md`.

## Validation
- `taskify-core`: `npm test` ✅
- `taskify-cli`: `npm test` ✅
- `taskify-pwa`: `npm run build` ✅

## Notes
- No schema/data-shape changes.
- This PR is the complete Wave 4 phase slice.
