### PR TITLE
refactor(core/runtime): final extraction cleanup + docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Taskify_Release/
 │   ├── public/                # Static assets, PWA manifest
 │   └── package.json           # PWA dependencies (React 19, NDK, Cashu, nostr-tools)
 │
+├── taskify-core/              # Shared pure domain contracts/normalizers/utilities
+├── taskify-runtime-nostr/     # Shared Nostr runtime transport/orchestration modules
+├── taskify-cli/               # CLI surface built on shared core/runtime packages
+│
 ├── worker/                    # Cloudflare Worker (push, reminders, backups, static assets)
 │   ├── src/index.ts           # Worker entry — all backend logic in one file
 │   └── migrations/            # D1 SQL migrations

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -8,7 +8,7 @@ Minimize drift across CLI and PWA by centralizing shared behavior, while keeping
 ### `taskify-core` (pure domain)
 Use for platform-agnostic business/domain logic only:
 - contracts and payload normalization
-- calendar/task/share/backup domain rules
+- calendar/task/share/contact/backup domain rules
 - pure parsing/validation helpers
 - pure crypto primitives and deterministic transforms
 
@@ -22,7 +22,8 @@ Must not own:
 Use for Nostr runtime orchestration shared by multiple apps:
 - board key derivation manager
 - relay URL normalization
-- (future) session/publisher/subscription orchestration extracted from PWA
+- session/publisher/subscription orchestration extracted from PWA
+- relay auth/health/info cache and runtime composition primitives
 
 Must not own:
 - PWA-only UX/state wiring

--- a/taskify-core/dist/calendarPayload.d.ts
+++ b/taskify-core/dist/calendarPayload.d.ts
@@ -14,4 +14,9 @@ export type CalendarNormalizedPayload = {
     references?: string[];
     deleted?: boolean;
 };
+export declare function normalizeDelimitedValues(raw: string, delimiter: RegExp, options?: {
+    stripPrefix?: string;
+    dedupe?: boolean;
+}): string[] | undefined;
+export declare function normalizeLocationList(list: string[]): string[] | undefined;
 export declare function normalizeCalendarEventPayload(raw: unknown): CalendarNormalizedPayload | null;

--- a/taskify-core/dist/calendarPayload.js
+++ b/taskify-core/dist/calendarPayload.js
@@ -12,6 +12,28 @@ function normalizeStringArray(value) {
         .filter(Boolean);
     return out.length ? out : undefined;
 }
+export function normalizeDelimitedValues(raw, delimiter, options) {
+    const values = (raw || "")
+        .split(delimiter)
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map((value) => {
+        if (options?.stripPrefix && value.startsWith(options.stripPrefix)) {
+            return value.slice(options.stripPrefix.length);
+        }
+        return value;
+    })
+        .filter(Boolean);
+    if (!values.length)
+        return undefined;
+    if (options?.dedupe === false)
+        return values;
+    return Array.from(new Set(values));
+}
+export function normalizeLocationList(list) {
+    const out = (list || []).map((value) => value.trim()).filter(Boolean);
+    return out.length ? out : undefined;
+}
 export function normalizeCalendarEventPayload(raw) {
     if (!raw || typeof raw !== "object")
         return null;

--- a/taskify-core/dist/relayNormalize.d.ts
+++ b/taskify-core/dist/relayNormalize.d.ts
@@ -1,1 +1,2 @@
 export declare function normalizeRelayList(value: unknown): string[] | undefined;
+export declare function normalizeRelayListSorted(value: unknown): string[] | undefined;

--- a/taskify-core/dist/relayNormalize.js
+++ b/taskify-core/dist/relayNormalize.js
@@ -6,3 +6,9 @@ export function normalizeRelayList(value) {
         .filter(Boolean);
     return relays.length ? Array.from(new Set(relays)) : undefined;
 }
+export function normalizeRelayListSorted(value) {
+    const normalized = normalizeRelayList(value);
+    if (!normalized?.length)
+        return undefined;
+    return [...normalized].sort();
+}

--- a/taskify-core/dist/shareNormalize.d.ts
+++ b/taskify-core/dist/shareNormalize.d.ts
@@ -1,1 +1,7 @@
+export type BoardSharePayload = {
+    boardId: string;
+    boardName?: string;
+    relaysCsv?: string;
+};
 export declare function normalizeCalendarAddress(value: unknown, allowedKinds: number[]): string | null;
+export declare function parseBoardSharePayload(raw: string): BoardSharePayload | null;

--- a/taskify-core/dist/shareNormalize.js
+++ b/taskify-core/dist/shareNormalize.js
@@ -1,4 +1,6 @@
 import { parseCalendarAddress } from "./calendarProtocol.js";
+import { parseShareEnvelope } from "./shareContracts.js";
+const BOARD_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 export function normalizeCalendarAddress(value, allowedKinds) {
     if (typeof value !== "string")
         return null;
@@ -8,4 +10,21 @@ export function normalizeCalendarAddress(value, allowedKinds) {
     if (!allowedKinds.includes(parsed.kind))
         return null;
     return `${parsed.kind}:${parsed.pubkey}:${parsed.d}`;
+}
+export function parseBoardSharePayload(raw) {
+    const trimmed = (raw || "").trim();
+    if (!trimmed)
+        return null;
+    const envelope = parseShareEnvelope(trimmed);
+    if (envelope?.item?.type === "board") {
+        const relaysCsv = envelope.item.relays?.length ? envelope.item.relays.join(",") : undefined;
+        return {
+            boardId: envelope.item.boardId,
+            boardName: envelope.item.boardName || undefined,
+            relaysCsv,
+        };
+    }
+    if (!BOARD_ID_REGEX.test(trimmed))
+        return null;
+    return { boardId: trimmed };
 }

--- a/taskify-core/src/calendarPayload.ts
+++ b/taskify-core/src/calendarPayload.ts
@@ -29,6 +29,28 @@ function normalizeStringArray(value: unknown): string[] | undefined {
   return out.length ? out : undefined;
 }
 
+export function normalizeDelimitedValues(raw: string, delimiter: RegExp, options?: { stripPrefix?: string; dedupe?: boolean }): string[] | undefined {
+  const values = (raw || "")
+    .split(delimiter)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => {
+      if (options?.stripPrefix && value.startsWith(options.stripPrefix)) {
+        return value.slice(options.stripPrefix.length);
+      }
+      return value;
+    })
+    .filter(Boolean);
+  if (!values.length) return undefined;
+  if (options?.dedupe === false) return values;
+  return Array.from(new Set(values));
+}
+
+export function normalizeLocationList(list: string[]): string[] | undefined {
+  const out = (list || []).map((value) => value.trim()).filter(Boolean);
+  return out.length ? out : undefined;
+}
+
 export function normalizeCalendarEventPayload(raw: unknown): CalendarNormalizedPayload | null {
   if (!raw || typeof raw !== "object") return null;
   const deleted = (raw as any).deleted === true;

--- a/taskify-core/src/relayNormalize.ts
+++ b/taskify-core/src/relayNormalize.ts
@@ -5,3 +5,9 @@ export function normalizeRelayList(value: unknown): string[] | undefined {
     .filter(Boolean);
   return relays.length ? Array.from(new Set(relays)) : undefined;
 }
+
+export function normalizeRelayListSorted(value: unknown): string[] | undefined {
+  const normalized = normalizeRelayList(value);
+  if (!normalized?.length) return undefined;
+  return [...normalized].sort();
+}

--- a/taskify-core/src/shareNormalize.ts
+++ b/taskify-core/src/shareNormalize.ts
@@ -1,4 +1,13 @@
 import { parseCalendarAddress } from "./calendarProtocol.js";
+import { parseShareEnvelope } from "./shareContracts.js";
+
+const BOARD_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type BoardSharePayload = {
+  boardId: string;
+  boardName?: string;
+  relaysCsv?: string;
+};
 
 export function normalizeCalendarAddress(value: unknown, allowedKinds: number[]): string | null {
   if (typeof value !== "string") return null;
@@ -6,4 +15,20 @@ export function normalizeCalendarAddress(value: unknown, allowedKinds: number[])
   if (!parsed) return null;
   if (!allowedKinds.includes(parsed.kind)) return null;
   return `${parsed.kind}:${parsed.pubkey}:${parsed.d}`;
+}
+
+export function parseBoardSharePayload(raw: string): BoardSharePayload | null {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) return null;
+  const envelope = parseShareEnvelope(trimmed);
+  if (envelope?.item?.type === "board") {
+    const relaysCsv = envelope.item.relays?.length ? envelope.item.relays.join(",") : undefined;
+    return {
+      boardId: envelope.item.boardId,
+      boardName: envelope.item.boardName || undefined,
+      relaysCsv,
+    };
+  }
+  if (!BOARD_ID_REGEX.test(trimmed)) return null;
+  return { boardId: trimmed };
 }

--- a/taskify-core/tests/calendar-payload-core.test.ts
+++ b/taskify-core/tests/calendar-payload-core.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeCalendarEventPayload } from "../src/calendarPayload.ts";
+import { normalizeCalendarEventPayload, normalizeDelimitedValues, normalizeLocationList } from "../src/calendarPayload.ts";
 
 test("normalizeCalendarEventPayload accepts valid time payload", () => {
   const out = normalizeCalendarEventPayload({
@@ -46,4 +46,14 @@ test("normalizeCalendarEventPayload drops non-increasing timed end", () => {
   });
   assert.ok(out);
   assert.equal(out?.endISO, undefined);
+});
+
+test("normalizeDelimitedValues trims, strips prefixes, and dedupes", () => {
+  const out = normalizeDelimitedValues(" #alpha, beta\n#alpha ", /[,\n]+/g, { stripPrefix: "#" });
+  assert.deepEqual(out, ["alpha", "beta"]);
+});
+
+test("normalizeLocationList trims and drops empty entries", () => {
+  assert.deepEqual(normalizeLocationList([" HQ ", "", "  ", "Remote"]), ["HQ", "Remote"]);
+  assert.equal(normalizeLocationList([" ", ""]), undefined);
 });

--- a/taskify-core/tests/contact-contracts-core.test.ts
+++ b/taskify-core/tests/contact-contracts-core.test.ts
@@ -1,10 +1,28 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeNip05, contactInitials, contactVerifiedNip05 } from "../dist/contactContracts.js";
+import {
+  normalizeNip05,
+  compressedToRawHex,
+  normalizeNostrPubkeyHex,
+  contactInitials,
+  contactVerifiedNip05,
+} from "../dist/contactContracts.js";
 
 test("normalizeNip05 lowercases and validates", () => {
   assert.equal(normalizeNip05("Alice@Example.com"), "alice@example.com");
   assert.equal(normalizeNip05("bad"), null);
+});
+
+test("compressedToRawHex normalizes compressed and prefixed keys", () => {
+  assert.equal(compressedToRawHex(`02${"a".repeat(64)}`), "a".repeat(64));
+  assert.equal(compressedToRawHex(`0x${"b".repeat(64)}`), "b".repeat(64));
+  assert.equal(compressedToRawHex("c".repeat(64)), "c".repeat(64));
+});
+
+test("normalizeNostrPubkeyHex accepts compressed and raw hex", () => {
+  assert.equal(normalizeNostrPubkeyHex(`03${"d".repeat(64)}`), "d".repeat(64));
+  assert.equal(normalizeNostrPubkeyHex("e".repeat(64)), "e".repeat(64));
+  assert.equal(normalizeNostrPubkeyHex("npub1nothex"), null);
 });
 
 test("contactInitials handles simple names", () => {
@@ -13,7 +31,7 @@ test("contactInitials handles simple names", () => {
 });
 
 test("contactVerifiedNip05 validates against cache", () => {
-  const contact = { id: "1", nip05: "a@b.com", npub: "a".repeat(64) };
+  const contact = { id: "1", nip05: "a@b.com", npub: `02${"a".repeat(64)}` };
   const cache = { "1": { status: "valid", nip05: "a@b.com", npub: "a".repeat(64), checkedAt: 1 } };
   assert.equal(contactVerifiedNip05(contact, cache as any), "a@b.com");
 });

--- a/taskify-core/tests/relayNormalize.test.ts
+++ b/taskify-core/tests/relayNormalize.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeRelayList } from "../dist/index.js";
+import { normalizeRelayList, normalizeRelayListSorted } from "../dist/index.js";
 
 test("normalizeRelayList trims and dedupes", () => {
   const result = normalizeRelayList([" wss://a ", "wss://a", "", "wss://b"]);
@@ -10,4 +10,9 @@ test("normalizeRelayList trims and dedupes", () => {
 test("normalizeRelayList returns undefined for invalid", () => {
   assert.equal(normalizeRelayList(null), undefined);
   assert.equal(normalizeRelayList("x"), undefined);
+});
+
+test("normalizeRelayListSorted sorts while preserving trim + dedupe", () => {
+  const result = normalizeRelayListSorted([" wss://b ", "wss://a", "wss://b", ""]);
+  assert.deepEqual(result, ["wss://a", "wss://b"]);
 });

--- a/taskify-core/tests/shareNormalize.test.ts
+++ b/taskify-core/tests/shareNormalize.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { normalizeCalendarAddress } from "../dist/index.js";
+import { buildBoardShareEnvelope, normalizeCalendarAddress, parseBoardSharePayload } from "../dist/index.js";
 
 test("normalizeCalendarAddress returns canonical address", () => {
   const pk = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -11,4 +11,21 @@ test("normalizeCalendarAddress returns canonical address", () => {
 test("normalizeCalendarAddress rejects wrong kind/invalid", () => {
   assert.equal(normalizeCalendarAddress("31924:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef:my-event", [31925]), null);
   assert.equal(normalizeCalendarAddress("bad", [31925]), null);
+});
+
+test("parseBoardSharePayload parses board share envelopes", () => {
+  const envelope = buildBoardShareEnvelope("123e4567-e89b-12d3-a456-426614174000", "Team", ["wss://relay.example"]);
+  const parsed = parseBoardSharePayload(JSON.stringify(envelope));
+  assert.deepEqual(parsed, {
+    boardId: "123e4567-e89b-12d3-a456-426614174000",
+    boardName: "Team",
+    relaysCsv: "wss://relay.example",
+  });
+});
+
+test("parseBoardSharePayload parses bare board ids and rejects invalid input", () => {
+  assert.deepEqual(parseBoardSharePayload("123e4567-e89b-12d3-a456-426614174000"), {
+    boardId: "123e4567-e89b-12d3-a456-426614174000",
+  });
+  assert.equal(parseBoardSharePayload("not-a-board"), null);
 });

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -10,6 +10,7 @@ import {
   normalizeCalendarDeleteMutationPayload,
   normalizeCalendarMutationPayload,
   normalizeRelayListSorted,
+  parseBoardSharePayload,
 } from "taskify-core";
 const loadCashuWalletModal = () => import("./components/CashuWalletModal");
 const CashuWalletModal = lazy(loadCashuWalletModal);
@@ -234,28 +235,6 @@ const SPECIAL_CALENDAR_US_HOLIDAY_RANGE_PAST_YEARS = 1;
 const SPECIAL_CALENDAR_US_HOLIDAY_RANGE_FUTURE_YEARS = 8;
 
 type ScanResult = QrScannerLib.ScanResult;
-
-type BoardSharePayload = {
-  boardId: string;
-  boardName?: string;
-  relaysCsv?: string;
-};
-
-function parseBoardSharePayload(raw: string): BoardSharePayload | null {
-  const trimmed = (raw || "").trim();
-  if (!trimmed) return null;
-  const envelope = parseShareEnvelope(trimmed);
-  if (envelope?.item?.type === "board") {
-    const relaysCsv = envelope.item.relays?.length ? envelope.item.relays.join(",") : undefined;
-    return {
-      boardId: envelope.item.boardId,
-      boardName: envelope.item.boardName || undefined,
-      relaysCsv,
-    };
-  }
-  if (!BOARD_ID_REGEX.test(trimmed)) return null;
-  return { boardId: trimmed };
-}
 
 /* ================= Types ================= */
 type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0=Sun

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -6,7 +6,11 @@ import { createPortal } from "react-dom";
 import { QRCodeCanvas } from "qrcode.react";
 import QrScannerLib from "qr-scanner";
 import { finalizeEvent, getPublicKey, generateSecretKey, type EventTemplate, nip04, nip19, nip44 } from "nostr-tools";
-import { normalizeCalendarDeleteMutationPayload, normalizeCalendarMutationPayload } from "taskify-core";
+import {
+  normalizeCalendarDeleteMutationPayload,
+  normalizeCalendarMutationPayload,
+  normalizeRelayListSorted,
+} from "taskify-core";
 const loadCashuWalletModal = () => import("./components/CashuWalletModal");
 const CashuWalletModal = lazy(loadCashuWalletModal);
 import {
@@ -6993,14 +6997,10 @@ export default function App() {
     return next;
   }, []);
   const [nostrRefresh, setNostrRefresh] = useState(0);
-  const normalizeRelayList = useCallback((relays: string[] | null | undefined) => {
-    const normalized = Array.isArray(relays)
-      ? relays.map((r) => (typeof r === "string" ? r.trim() : "")).filter(Boolean)
-      : [];
-    const unique = Array.from(new Set(normalized));
-    unique.sort();
-    return unique;
-  }, []);
+  const normalizeRelayList = useCallback(
+    (relays: string[] | null | undefined) => normalizeRelayListSorted(relays) ?? [],
+    [],
+  );
 
   const sanitizeSettingsForBackup = useCallback(
     (raw: Settings | Record<string, unknown>): Partial<Settings> =>

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -11,6 +11,11 @@ import {
   normalizeCalendarMutationPayload,
   normalizeRelayListSorted,
   parseBoardSharePayload,
+  normalizeNip05,
+  compressedToRawHex,
+  contactInitials,
+  contactVerifiedNip05 as contactVerifiedNip05Core,
+  normalizeTaskAssignmentStatus,
 } from "taskify-core";
 const loadCashuWalletModal = () => import("./components/CashuWalletModal");
 const CashuWalletModal = lazy(loadCashuWalletModal);
@@ -384,25 +389,6 @@ type CalendarRsvpEnvelope = {
   inviteToken?: string;
 };
 
-function normalizeNip05(value?: string | null): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-  const atIndex = trimmed.indexOf("@");
-  if (atIndex <= 0 || atIndex === trimmed.length - 1) return null;
-  const name = trimmed.slice(0, atIndex).trim().toLowerCase();
-  const domain = trimmed.slice(atIndex + 1).trim().toLowerCase();
-  if (!name || !domain) return null;
-  return `${name}@${domain}`;
-}
-
-function compressedToRawHex(value: string): string {
-  if (typeof value !== "string") return value;
-  if (/^(02|03)[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
-  if (/^0x[0-9a-fA-F]{64}$/.test(value)) return value.slice(-64);
-  if (/^[0-9a-fA-F]{64}$/.test(value)) return value.toLowerCase();
-  return value;
-}
-
 function normalizeNostrPubkeyHex(value: string | null | undefined): string | null {
   const trimmed = (value || "").trim();
   if (!trimmed) return null;
@@ -416,14 +402,6 @@ function normalizeAgentPubkey(value: unknown): string | undefined {
   return normalizeNostrPubkeyHex(value) ?? undefined;
 }
 
-function normalizeTaskAssigneeStatus(value: unknown): TaskAssigneeStatus | undefined {
-  if (value === "pending" || value === "accepted" || value === "declined" || value === "tentative") {
-    return value;
-  }
-  if (value === "maybe") return "tentative";
-  return undefined;
-}
-
 function normalizeTaskAssignees(value: unknown): TaskAssignee[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const normalized: TaskAssignee[] = [];
@@ -434,7 +412,7 @@ function normalizeTaskAssignees(value: unknown): TaskAssignee[] | undefined {
     if (!pubkey || seen.has(pubkey)) return;
     seen.add(pubkey);
     const relay = typeof (entry as any).relay === "string" ? (entry as any).relay.trim() : "";
-    const status = normalizeTaskAssigneeStatus((entry as any).status);
+    const status = normalizeTaskAssignmentStatus((entry as any).status) as TaskAssigneeStatus | undefined;
     const respondedAtRaw = Number((entry as any).respondedAt);
     const respondedAt =
       Number.isFinite(respondedAtRaw) && respondedAtRaw > 0 ? Math.round(respondedAtRaw) : undefined;
@@ -510,29 +488,15 @@ function loadNip05Cache(): Record<string, Nip05CheckState> {
 }
 
 function contactVerifiedNip05(contact: Contact, cache: Record<string, Nip05CheckState>): string | null {
-  if (!contact?.id) return null;
-  const nip05 = contact.nip05?.trim();
-  const npub = contact.npub?.trim();
-  if (!nip05 || !npub) return null;
-  const normalizedNip05 = normalizeNip05(nip05);
-  const normalizedNpub = normalizeNostrPubkey(npub);
-  if (!normalizedNip05 || !normalizedNpub) return null;
-  const entry = cache[contact.id];
-  if (!entry || entry.status !== "valid") return null;
-  const cachedNip05 = normalizeNip05(entry.nip05);
-  const cachedHex = (entry.npub || "").toLowerCase();
-  const contactHex = compressedToRawHex(normalizedNpub).toLowerCase();
-  if (!cachedNip05 || cachedNip05 !== normalizedNip05) return null;
-  if (!cachedHex || cachedHex !== contactHex) return null;
-  return nip05 || entry.nip05;
-}
-
-function contactInitials(value: string): string {
-  const trimmed = (value || "").trim();
-  if (!trimmed) return "?";
-  const parts = trimmed.split(/\s+/).filter(Boolean);
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  const normalizedNpub = normalizeNostrPubkey(contact.npub || "");
+  return contactVerifiedNip05Core(
+    {
+      id: contact.id,
+      nip05: contact.nip05,
+      npub: normalizedNpub || contact.npub,
+    },
+    cache,
+  );
 }
 
 function VerifiedBadgeIcon(props: React.SVGProps<SVGSVGElement>) {

--- a/taskify-pwa/src/lib/shareInbox.ts
+++ b/taskify-pwa/src/lib/shareInbox.ts
@@ -345,11 +345,5 @@ function toRelayList(input: unknown): string[] {
   } else if (input && typeof input === "object" && (input as any)[Symbol.iterator]) {
     candidates = Array.from(input as Iterable<unknown>);
   }
-  return Array.from(
-    new Set(
-      candidates
-        .map((r) => (typeof r === "string" ? r.trim() : ""))
-        .filter(Boolean),
-    ),
-  );
+  return normalizeRelayList(candidates) ?? [];
 }

--- a/taskify-pwa/src/ui/board/AddBoardModal.tsx
+++ b/taskify-pwa/src/ui/board/AddBoardModal.tsx
@@ -1,32 +1,9 @@
 import React, { useState, useCallback, useEffect, useRef } from "react";
-import { parseShareEnvelope } from "../../lib/shareInbox";
+import { parseBoardSharePayload } from "taskify-core";
 import { useToast } from "../../context/ToastContext";
 import { Modal } from "../Modal";
 import { BoardQrScanner } from "./BoardQrScanner";
 
-const BOARD_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-type BoardSharePayload = {
-  boardId: string;
-  boardName?: string;
-  relaysCsv?: string;
-};
-
-function parseBoardSharePayload(raw: string): BoardSharePayload | null {
-  const trimmed = (raw || "").trim();
-  if (!trimmed) return null;
-  const envelope = parseShareEnvelope(trimmed);
-  if (envelope?.item?.type === "board") {
-    const relaysCsv = envelope.item.relays?.length ? envelope.item.relays.join(",") : undefined;
-    return {
-      boardId: envelope.item.boardId,
-      boardName: envelope.item.boardName || undefined,
-      relaysCsv,
-    };
-  }
-  if (!BOARD_ID_REGEX.test(trimmed)) return null;
-  return { boardId: trimmed };
-}
 
 export function AddBoardModal({
   onClose,

--- a/taskify-pwa/src/ui/calendar/EventEditModal.tsx
+++ b/taskify-pwa/src/ui/calendar/EventEditModal.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { nip19 } from "nostr-tools";
-import { normalizeCalendarEventPayload } from "taskify-core";
+import { normalizeCalendarEventPayload, normalizeDelimitedValues, normalizeLocationList } from "taskify-core";
 
 // Sub-sheet components
 import { CustomReminderSheet } from "../reminders/CustomReminderSheet";
@@ -738,29 +738,13 @@ function EventEditModal({
     setEndTime(isoTimePart(nextEnd, safeEndTzid));
   }, [allDay, endDate, endTime, safeEndTzid, safeStartTzid, startDate, startTime]);
 
-  const normalizeHashtags = (raw: string): string[] | undefined => {
-    const parts = raw
-      .split(/[,\n]+/g)
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .map((value) => (value.startsWith("#") ? value.slice(1) : value));
-    const unique = Array.from(new Set(parts));
-    return unique.length ? unique : undefined;
-  };
+  const normalizeHashtags = (raw: string): string[] | undefined =>
+    normalizeDelimitedValues(raw, /[,\n]+/g, { stripPrefix: "#" });
 
-  const normalizeReferences = (raw: string): string[] | undefined => {
-    const lines = raw
-      .split(/\n+/g)
-      .map((value) => value.trim())
-      .filter(Boolean);
-    const unique = Array.from(new Set(lines));
-    return unique.length ? unique : undefined;
-  };
+  const normalizeReferences = (raw: string): string[] | undefined =>
+    normalizeDelimitedValues(raw, /\n+/g);
 
-  const normalizeLocations = (list: string[]): string[] | undefined => {
-    const out = list.map((value) => value.trim()).filter(Boolean);
-    return out.length ? out : undefined;
-  };
+  const normalizeLocations = (list: string[]): string[] | undefined => normalizeLocationList(list);
 
   const buildDraft = (): CalendarEvent => {
     const boardId = selectedBoardId;

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { nip19 } from "nostr-tools";
+import { normalizeTaskAssignmentStatus } from "taskify-core";
 
 // Sub-sheet components
 import { CustomReminderSheet } from "../reminders/CustomReminderSheet";
@@ -183,12 +184,6 @@ function normalizeAssigneePubkey(value: string | null | undefined): string | nul
   return /^[0-9a-f]{64}$/.test(raw) ? raw : null;
 }
 
-function normalizeAssigneeStatus(value: unknown): TaskAssignee["status"] | undefined {
-  if (value === "pending" || value === "accepted" || value === "declined" || value === "tentative") return value;
-  if (value === "maybe") return "tentative";
-  return undefined;
-}
-
 function normalizeAssigneeList(value: Task["assignees"] | undefined): TaskAssignee[] {
   if (!Array.isArray(value)) return [];
   const normalized: TaskAssignee[] = [];
@@ -198,7 +193,7 @@ function normalizeAssigneeList(value: Task["assignees"] | undefined): TaskAssign
     if (!pubkey || seen.has(pubkey)) return;
     seen.add(pubkey);
     const relay = typeof assignee?.relay === "string" ? assignee.relay.trim() : "";
-    const status = normalizeAssigneeStatus(assignee?.status);
+    const status = normalizeTaskAssignmentStatus(assignee?.status) as TaskAssignee["status"] | undefined;
     const respondedAtRaw = Number(assignee?.respondedAt);
     const respondedAt = Number.isFinite(respondedAtRaw) && respondedAtRaw > 0 ? Math.round(respondedAtRaw) : undefined;
     normalized.push({


### PR DESCRIPTION
## Summary
Final extraction cleanup pass for shared platform-agnostic logic plus documentation alignment.

## Included
- Consolidated remaining share/calendar/contact normalizer clones into `taskify-core` and rewired PWA callsites.
- Consolidated relay normalization helpers and removed local duplicates.
- Added/expanded core tests for extracted helpers.
- Updated architecture docs to reflect current package boundaries and extraction status.

## Docs updates
- `README.md`: package map now includes `taskify-core`, `taskify-runtime-nostr`, and `taskify-cli`.
- `docs/architecture-boundaries.md`: updated core/runtime boundary bullets to match current extracted modules.

## Validation
- `taskify-core npm test` ✅
- `taskify-runtime-nostr npm test` ✅
- `taskify-cli npm test` ✅
- `taskify-pwa npm run build` ✅
