### PR TITLE
refactor(core/runtime): final cleanup + pwa build resolution fix

### DIFF
--- a/taskify-pwa/package-lock.json
+++ b/taskify-pwa/package-lock.json
@@ -11,6 +11,7 @@
         "@cashu/cashu-ts": "3.0.0",
         "@cashu/crypto": "^0.3.4",
         "@gandlaf21/bc-ur": "^1.1.12",
+        "@noble/hashes": "^1.8.0",
         "@nostr-dev-kit/ndk": "^2.18.1",
         "@scure/bip39": "^1.2.1",
         "bech32": "^2.0.0",

--- a/taskify-pwa/package.json
+++ b/taskify-pwa/package.json
@@ -15,6 +15,7 @@
     "@cashu/cashu-ts": "3.0.0",
     "@cashu/crypto": "^0.3.4",
     "@gandlaf21/bc-ur": "^1.1.12",
+    "@noble/hashes": "^1.8.0",
     "@nostr-dev-kit/ndk": "^2.18.1",
     "@scure/bip39": "^1.2.1",
     "bech32": "^2.0.0",
@@ -22,8 +23,6 @@
     "events": "^3.3.0",
     "jszip": "^3.10.1",
     "nostr-tools": "^2.16.2",
-    "taskify-core": "file:../taskify-core",
-    "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
     "pdfjs-dist": "^4.7.76",
     "process": "^0.11.10",
     "qr-scanner": "^1.4.2",
@@ -32,6 +31,8 @@
     "react-dom": "^19.1.1",
     "read-excel-file": "^7.0.0",
     "stream-browserify": "^3.0.0",
+    "taskify-core": "file:../taskify-core",
+    "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
     "util": "^0.12.5"
   },
   "devDependencies": {

--- a/taskify-pwa/vite.config.ts
+++ b/taskify-pwa/vite.config.ts
@@ -14,6 +14,7 @@ const walletVendors = [
 export default defineConfig({
   plugins: [react()],
   resolve: {
+    preserveSymlinks: true,
     alias: {
       buffer: "buffer",
       process: "process/browser",


### PR DESCRIPTION
## Summary
Follow-up PR for final extraction cleanup and build stabilization on `feat/runtime-nostr-slice1`.

## Included
- Remaining platform-agnostic normalizer extraction/rewiring (share/calendar/contact helpers) into `taskify-core`.
- Documentation alignment for package boundaries after extraction.
- Build fix for PWA workspace symlink resolution:
  - set `resolve.preserveSymlinks: true` in Vite
  - add explicit `@noble/hashes` dependency in `taskify-pwa`

## Validation
- `taskify-core npm test` ✅
- `taskify-runtime-nostr npm test` ✅
- `taskify-cli npm test` ✅
- `taskify-pwa npm run build` ✅
