### PR TITLE
feat: CLI improvements, PWA cursor sync, dev philosophy docs

### DIFF
--- a/.openclaw/skills/taskify-cli/SKILL.md
+++ b/.openclaw/skills/taskify-cli/SKILL.md
@@ -24,13 +24,16 @@ If `taskify` is missing globally, run via local package:
 ```bash
 taskify profile list               # see all profiles and which is active (marked *)
 taskify profile use <name>         # switch to the right profile
-taskify board list                 # verify expected boards are visible
+taskify board list                 # verify expected boards are visible (auto-syncs display names)
 ```
 
 - Each profile has its own boards, keys, and relay config. The default profile may not have access to the user's personal boards.
-- If board names show as raw UUIDs with no display names, you are on the wrong profile — switch profiles and re-run `taskify board list`.
-- When a user references a named board (e.g. "Personal schedule"), resolve which profile owns it by iterating profiles until that board appears.
-- Use `--profile <name>` for quick one-shot commands without permanently switching: `taskify list --profile nathan --board "Personal schedule"`
+- `taskify board list` now **auto-syncs display names** for any board showing as a raw UUID — no manual `taskify board sync` needed.
+- When a user references a named board (e.g. "Personal schedule"), resolve which profile owns it by iterating profiles until that board appears by name.
+- Use `--profile <name>` for quick one-shot commands without permanently switching: `taskify list --profile ink --board "Personal schedule"`
+
+### If you still see raw UUIDs after `board list`
+Run `taskify board sync` manually — it forces a relay fetch for all boards and updates the local cache.
 
 ## Safety and reliability rules
 

--- a/.openclaw/skills/taskify-cli/SKILL.md
+++ b/.openclaw/skills/taskify-cli/SKILL.md
@@ -63,6 +63,22 @@ taskify board list                 # verify expected boards are visible
 - Reopen: `taskify reopen <taskId> --board "<board>"`
 - Delete: `taskify delete <taskId> --board "<board>" --force`
 
+### Recurring task instances
+Recurring tasks on week boards generate virtual instances with IDs like `recurrence:<seriesKey>:<date>`.
+These show in the table with a `~YYYY-MM-DD` display ID. **Do not use the 8-char prefix** — it will be `~2026-03` for all instances and won't resolve.
+
+**Preferred approach — resolve by title + due date:**
+```bash
+taskify done --title "Bible plan" --due 2026-03-14 --board "Personal schedule"
+taskify reopen --title "Bible plan" --due 2026-03-14 --board "Personal schedule"
+```
+
+**Alternative — use the full recurring instance ID from `--json`:**
+```bash
+taskify list --board "Personal schedule" --json | jq '.[] | select(.title | test("Bible"; "i")) | {id, title, dueISO}'
+# Then: taskify done "<full-recurrence:...:date-id>" --board "Personal schedule"
+```
+
 ### Inbox triage
 - List inbox: `taskify inbox list --board "<board>"`
 - Quick add: `taskify inbox add "<title>" --board "<board>"`

--- a/.openclaw/skills/taskify-cli/SKILL.md
+++ b/.openclaw/skills/taskify-cli/SKILL.md
@@ -17,6 +17,21 @@ If `taskify` is missing globally, run via local package:
 - `npm run build` (if needed)
 - `node dist/index.js <args>`
 
+## Profile rule — always do this first
+
+**Before any Taskify command**, check and switch to the correct profile:
+
+```bash
+taskify profile list               # see all profiles and which is active (marked *)
+taskify profile use <name>         # switch to the right profile
+taskify board list                 # verify expected boards are visible
+```
+
+- Each profile has its own boards, keys, and relay config. The default profile may not have access to the user's personal boards.
+- If board names show as raw UUIDs with no display names, you are on the wrong profile — switch profiles and re-run `taskify board list`.
+- When a user references a named board (e.g. "Personal schedule"), resolve which profile owns it by iterating profiles until that board appears.
+- Use `--profile <name>` for quick one-shot commands without permanently switching: `taskify list --profile nathan --board "Personal schedule"`
+
 ## Safety and reliability rules
 
 1. Prefer read commands first (`list`, `show`, `search`, `boards`, `board columns`) before mutating state.

--- a/AGENT.md
+++ b/AGENT.md
@@ -190,6 +190,55 @@ PRs that change behavior without updating relevant docs will be flagged in revie
 
 ---
 
+## Development Philosophy
+
+These principles apply to all Taskify work — PWA, CLI, Worker, and Core.
+
+### Bug workflow — test first, always
+**Never fix a reported bug without a failing test first.**
+1. Write a test that reproduces the bug and confirm it fails
+2. Implement the fix
+3. Confirm the test now passes
+
+This prevents regressions and proves the fix is real, not accidental.
+
+### Nevernesting
+Favor early returns and guard clauses over nested conditionals.
+
+```ts
+// ❌ Bad
+if (user) {
+  if (task) {
+    if (boardId) {
+      doThing();
+    }
+  }
+}
+
+// ✅ Good
+if (!user) return;
+if (!task) return;
+if (!boardId) return;
+doThing();
+```
+
+### Core is source of truth
+`taskify-core` and `taskify-runtime-nostr` own business logic. The PWA and CLI are thin consumers — they call core, they never reimplement it. If you find duplicate logic in the UI layer, move it to core.
+
+### No dead code
+Delete commented-out code. Commented code is dead code. Add comments only for genuinely non-obvious logic — not to explain what the code already says.
+
+### Logically distinct, standalone commits
+Each commit must build and run on its own. One logical change per commit. Reviewers should be able to bisect safely.
+
+### Never block the render thread (PWA)
+All network requests, relay queries, and expensive computations must be async. Never perform synchronous blocking work in React hooks, renders, or component bodies. Use `async/await` and keep UI updates on the React thread.
+
+### Minimize agent output noise
+Build and test scripts should output clear `✓`/`✗` indicators with errors only on failure. Verbose output by default makes agent verification harder.
+
+---
+
 ## Safe Contribution Rules
 
 1. **Never modify `main` directly.** All changes go through PRs.

--- a/docs/engineering-roadmap.md
+++ b/docs/engineering-roadmap.md
@@ -136,3 +136,36 @@ A milestone is complete when:
 - Coverage percentage tooling (c8, nyc) — will be added once domain tests are in place
 - CI/CD pipeline changes — separate infrastructure track
 - Product feature work — this roadmap is documentation and testing only
+
+---
+
+## Feature Backlog
+
+### Originless File Attachment Integration
+
+**Priority:** Medium  
+**Blocked by:** Usage allowance availability  
+**Source:** 2026-03-14 — reviewed Originless open-source project
+
+Add IPFS-based file attachments to tasks using [Originless](https://github.com/besoeasy/Originless) as the storage backend.
+
+#### Requirements
+
+- **Encryption is mandatory**: Files must be encrypted to the board key client-side *before* upload — same encryption model as task content. The Originless server never sees plaintext.
+- Decrypt on download using the board key, client-side.
+- Use `documents` field already present in the task payload schema (zero schema changes needed).
+- Document shape: `{ url: string, cid: string, filename: string, type: string }`
+- Default to public gateway (`https://originless.besoeasy.com`); allow self-hosted URL override in settings.
+- Check `/health` endpoint before rendering upload UI.
+
+#### PWA scope
+- "Attach file" on task create/edit → upload encrypted file → store document entry → display attachments inline
+
+#### CLI scope
+- `taskify attach <taskId> <file> --board <board>` — encrypt + upload + patch task
+- `taskify attachments <taskId>` — list attached file URLs
+
+#### Notes
+- Self-hosted Originless runs via Docker (`ghcr.io/besoeasy/originless`) — no accounts, no API keys for basic ops
+- Pin management (keep forever) requires Daku auth token — optional for initial implementation
+- Fits cleanly into existing agent workflow: agent uploads → returns IPFS URL → patches task via normal update flow

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -1,28 +1,26 @@
 {
   "name": "taskify-nostr",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskify-nostr",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.4.0",
-        "@nostr-dev-kit/ndk": "^2.18.1",
-        "chalk": "^5.3.0",
-        "commander": "^12.0.0",
-        "nostr-tools": "^2.16.2",
-        "taskify-core": "file:../taskify-core",
-        "taskify-runtime-nostr": "file:../taskify-runtime-nostr"
-      },
       "bin": {
         "taskify": "dist/index.js"
       },
       "devDependencies": {
+        "@noble/hashes": "^1.4.0",
+        "@nostr-dev-kit/ndk": "^2.18.1",
         "@types/node": "^25.4.0",
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0",
         "esbuild": "^0.27.4",
+        "nostr-tools": "^2.16.2",
+        "taskify-core": "file:../taskify-core",
+        "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -31,12 +29,14 @@
     },
     "../taskify-core": {
       "version": "0.1.0",
+      "dev": true,
       "devDependencies": {
         "typescript": "^5.9.3"
       }
     },
     "../taskify-runtime-nostr": {
       "version": "0.1.0",
+      "dev": true,
       "devDependencies": {
         "@noble/hashes": "^1.4.0",
         "@nostr-dev-kit/ndk": "^2.18.1",
@@ -53,6 +53,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
       "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "dev": true,
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "outvariant": "^1.4.0",
@@ -63,6 +64,7 @@
       "version": "2.19.8",
       "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
       "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@codesandbox/nodebox": "0.1.8",
@@ -519,6 +521,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
       "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -531,6 +534,7 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -546,6 +550,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -558,6 +563,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
       "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -567,6 +573,7 @@
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.18.1.tgz",
       "integrity": "sha512-LTXXheGfmyN1y8x+8v/Dmkx8YX7LqaoVk0DTSaigETB5RZsxw7dLBKK++kZd4DVIxtj0tRfmSOsTr1E+M4653Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codesandbox/sandpack-client": "^2.19.8",
@@ -591,12 +598,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -606,6 +615,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
       "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.0.1",
@@ -620,6 +630,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
       "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1"
@@ -635,6 +646,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -647,6 +659,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -656,6 +669,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
       "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1",
@@ -669,6 +683,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -681,6 +696,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -690,6 +706,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
       "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -702,6 +719,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
       "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -713,6 +731,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
       "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -723,6 +742,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
       "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0"
@@ -732,6 +752,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
       "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0"
@@ -741,6 +762,7 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
       "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -751,12 +773,14 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -766,6 +790,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -785,18 +810,21 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -817,6 +845,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -841,6 +870,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -851,6 +881,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -863,6 +894,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -873,6 +905,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -883,6 +916,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -893,6 +927,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -902,6 +937,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -919,6 +955,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -928,6 +965,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -941,6 +979,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -995,6 +1034,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -1018,6 +1058,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -1031,6 +1072,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1041,6 +1083,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1061,6 +1104,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
       "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@scure/base": "1.1.1"
@@ -1070,6 +1114,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1082,6 +1127,7 @@
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -1103,6 +1149,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1123,6 +1170,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1139,6 +1187,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1160,6 +1209,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1176,6 +1226,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1192,6 +1243,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1201,12 +1253,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nostr-tools": {
       "version": "2.23.3",
       "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
       "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "2.1.1",
@@ -1230,6 +1284,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
       "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1"
@@ -1245,6 +1300,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -1257,6 +1313,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1266,18 +1323,21 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
       "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
       "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
       "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "oniguruma-parser": "^0.12.1",
@@ -1289,12 +1349,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
       "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1305,6 +1367,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
       "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -1314,6 +1377,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -1323,12 +1387,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
       "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "3.23.0",
@@ -1345,6 +1411,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1355,6 +1422,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
       "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.1.0",
@@ -1367,12 +1435,14 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
       "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -1395,6 +1465,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1405,13 +1476,14 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
       "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1425,6 +1497,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/typescript-lru-cache/-/typescript-lru-cache-2.0.0.tgz",
       "integrity": "sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -1438,6 +1511,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -1451,6 +1525,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -1464,6 +1539,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -1477,6 +1553,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1492,6 +1569,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1506,6 +1584,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1520,6 +1599,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1534,6 +1614,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/taskify-cli/package-lock.json
+++ b/taskify-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskify-nostr",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskify-nostr",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "bin": {
         "taskify": "dist/index.js"

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskify-nostr",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskify-nostr",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -180,11 +180,37 @@ boardCmd
     const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
-    } else {
-      for (const b of config.boards) {
-        const relays = b.relays?.length ? `  [${b.relays.join(", ")}]` : "";
-        console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}${relays}`);
-      }
+      process.exit(0);
+    }
+
+    // Auto-sync any board whose stored name looks like a raw UUID prefix
+    // (happens when a board was joined without a --name or metadata wasn't fetched).
+    // This ensures agents always see human-readable names without a manual board sync step.
+    const UUID_PREFIX_RE = /^[0-9a-f]{8}(-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/i;
+    const stale = config.boards.filter(
+      (b) => UUID_PREFIX_RE.test(b.name) || b.name === b.id || b.name === b.id.slice(0, 8),
+    );
+
+    if (stale.length > 0) {
+      process.stderr.write(chalk.dim(`Fetching display names for ${stale.length} board(s)…\n`));
+      try {
+        const runtime = initRuntime(config);
+        for (const b of stale) {
+          try {
+            const meta = await runtime.syncBoard(b.id);
+            if (meta.name) b.name = meta.name;
+            if (meta.kind) b.kind = meta.kind;
+            if (meta.columns) b.columns = meta.columns;
+          } catch { /* non-fatal — show whatever name we have */ }
+        }
+        await runtime.disconnect();
+        await saveConfig(config);
+      } catch { /* non-fatal */ }
+    }
+
+    for (const b of config.boards) {
+      const relays = b.relays?.length ? `  [${b.relays.join(", ")}]` : "";
+      console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}${relays}`);
     }
     process.exit(0);
   });
@@ -594,10 +620,33 @@ program
     const config = await loadConfig(program.opts().profile as string | undefined);
     if (config.boards.length === 0) {
       console.log(chalk.dim("No boards configured. Use: taskify board join <id> --name <name>"));
-    } else {
-      for (const b of config.boards) {
-        console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}`);
-      }
+      process.exit(0);
+    }
+
+    const UUID_PREFIX_RE = /^[0-9a-f]{8}(-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/i;
+    const stale = config.boards.filter(
+      (b) => UUID_PREFIX_RE.test(b.name) || b.name === b.id || b.name === b.id.slice(0, 8),
+    );
+
+    if (stale.length > 0) {
+      process.stderr.write(chalk.dim(`Fetching display names for ${stale.length} board(s)…\n`));
+      try {
+        const runtime = initRuntime(config);
+        for (const b of stale) {
+          try {
+            const meta = await runtime.syncBoard(b.id);
+            if (meta.name) b.name = meta.name;
+            if (meta.kind) b.kind = meta.kind;
+            if (meta.columns) b.columns = meta.columns;
+          } catch { /* non-fatal */ }
+        }
+        await runtime.disconnect();
+        await saveConfig(config);
+      } catch { /* non-fatal */ }
+    }
+
+    for (const b of config.boards) {
+      console.log(`  ${chalk.bold(b.name.padEnd(16))} ${chalk.dim(b.id)}`);
     }
     process.exit(0);
   });

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -65,6 +65,49 @@ function warnShortTaskId(taskId: string): void {
   }
 }
 
+/**
+ * Resolve a task by title + optional due-date when no taskId is provided.
+ * Returns the matched taskId or exits with an error if ambiguous / not found.
+ * This is the primary fallback for recurring instances whose IDs start with
+ * "recurrence:" and can't be identified by a short 8-char prefix.
+ */
+async function resolveTaskIdByTitle(
+  runtime: ReturnType<typeof initRuntime>,
+  title: string,
+  due: string | undefined,
+  boardId: string | undefined,
+  config: Awaited<ReturnType<typeof loadConfig>>,
+): Promise<string> {
+  const tasks = await runtime.listTasks({
+    boardId,
+    status: "any",
+    refresh: false,
+    noCache: false,
+  });
+  const titleLower = title.toLowerCase();
+  const duePart = due ? due.slice(0, 10) : undefined;
+  const matches = tasks.filter((t) => {
+    const titleMatch = t.title.toLowerCase().includes(titleLower);
+    const dueMatch = !duePart || (t.dueISO ?? "").startsWith(duePart);
+    return titleMatch && dueMatch;
+  });
+  if (matches.length === 0) {
+    const hint = duePart ? ` due ${duePart}` : "";
+    console.error(chalk.red(`No task found matching title "${title}"${hint}.`));
+    console.error(chalk.dim("Tip: use taskify search to find the exact task first."));
+    process.exit(1);
+  }
+  if (matches.length > 1) {
+    console.error(chalk.red(`Ambiguous: ${matches.length} tasks match "${title}"${duePart ? ` on ${duePart}` : ""}.`));
+    console.error(chalk.dim("Add --due YYYY-MM-DD to narrow down, or pass the full task ID."));
+    for (const t of matches.slice(0, 5)) {
+      console.error(chalk.dim(`  ${t.id.slice(0, 20)}  ${t.title}  ${(t.dueISO ?? "").slice(0, 10)}`));
+    }
+    process.exit(1);
+  }
+  return matches[0].id;
+}
+
 const VALID_REMINDER_PRESETS = new Set(["0h", "5m", "15m", "30m", "1h", "1d", "1w"]);
 
 function parseJsonOption(label: string, raw: string | undefined): unknown {
@@ -1384,20 +1427,31 @@ program
 
 // ---- done ----
 program
-  .command("done <taskId>")
-  .description("Mark a task as done (accepts 8-char prefix or full UUID)")
+  .command("done [taskId]")
+  .description("Mark a task as done (accepts 8-char prefix, full UUID, or full recurring instance ID)")
   .option("--board <id|name>", "Board the task belongs to")
+  .option("--title <title>", "Resolve task by title match (use with --due for recurring instances)")
+  .option("--due <YYYY-MM-DD>", "Filter by due date when resolving by title")
   .option("--json", "Output updated task as JSON")
-  .action(async (taskId: string, opts) => {
-    warnShortTaskId(taskId);
+  .action(async (taskId: string | undefined, opts) => {
     const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
-      const task = await runtime.setTaskStatus(taskId, "done", boardId);
+      let resolvedId = taskId;
+      if (!resolvedId) {
+        if (!opts.title) {
+          console.error(chalk.red("Provide a taskId or --title to identify the task."));
+          process.exit(1);
+        }
+        resolvedId = await resolveTaskIdByTitle(runtime, opts.title, opts.due, boardId, config);
+      } else {
+        warnShortTaskId(resolvedId);
+      }
+      const task = await runtime.setTaskStatus(resolvedId, "done", boardId);
       if (!task) {
-        console.error(chalk.red(`Task not found: ${taskId}`));
+        console.error(chalk.red(`Task not found: ${resolvedId}`));
         exitCode = 1;
       } else if (opts.json) {
         renderJson(task);
@@ -1415,20 +1469,31 @@ program
 
 // ---- reopen ----
 program
-  .command("reopen <taskId>")
-  .description("Reopen a completed task (accepts 8-char prefix or full UUID)")
+  .command("reopen [taskId]")
+  .description("Reopen a completed task (accepts 8-char prefix, full UUID, or full recurring instance ID)")
   .option("--board <id|name>", "Board the task belongs to")
+  .option("--title <title>", "Resolve task by title match (use with --due for recurring instances)")
+  .option("--due <YYYY-MM-DD>", "Filter by due date when resolving by title")
   .option("--json", "Output updated task as JSON")
-  .action(async (taskId: string, opts) => {
-    warnShortTaskId(taskId);
+  .action(async (taskId: string | undefined, opts) => {
     const config = await loadConfig(program.opts().profile as string | undefined);
     const boardId = await resolveBoardId(opts.board, config);
     const runtime = initRuntime(config);
     let exitCode = 0;
     try {
-      const task = await runtime.setTaskStatus(taskId, "open", boardId);
+      let resolvedId = taskId;
+      if (!resolvedId) {
+        if (!opts.title) {
+          console.error(chalk.red("Provide a taskId or --title to identify the task."));
+          process.exit(1);
+        }
+        resolvedId = await resolveTaskIdByTitle(runtime, opts.title, opts.due, boardId, config);
+      } else {
+        warnShortTaskId(resolvedId);
+      }
+      const task = await runtime.setTaskStatus(resolvedId, "open", boardId);
       if (!task) {
-        console.error(chalk.red(`Task not found: ${taskId}`));
+        console.error(chalk.red(`Task not found: ${resolvedId}`));
         exitCode = 1;
       } else if (opts.json) {
         renderJson(task);

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -538,12 +538,17 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
   // Resolves a full UUID from a short prefix — fetches all board events and scans "d" tags.
   async function resolveTaskId(boardId: string, taskIdOrPrefix: string): Promise<string | null> {
     const exact = taskIdOrPrefix.trim();
+    // Standard UUID (36 chars) — return directly without a relay lookup
     if (exact.length === 36) return exact;
 
     const allEvents = await fetchBoardEvents(boardId);
     const entries = Array.from(allEvents)
       .map((event) => ({ id: readTagValue(event.tags, "d") ?? "" }))
       .filter((entry) => entry.id);
+
+    // For recurring instance IDs ("recurrence:...") the full ID can be >36 chars.
+    // resolveIdentifierReference does an exact-match first, so passing the full
+    // recurrence ID will always land on the right instance.
     return resolveIdentifierReference(entries, taskIdOrPrefix)?.id ?? null;
   }
 

--- a/taskify-cli/src/render.ts
+++ b/taskify-cli/src/render.ts
@@ -110,7 +110,24 @@ function formatAssignee(task: FullTaskRecord): string {
   return truncated.padEnd(12);
 }
 
-const COL_HEADER = `${"ID".padEnd(8)}  ${"TITLE".padEnd(40)}  ${"LIST".padEnd(12)}  ${"DUE".padEnd(12)}  ${"PRI".padEnd(4)}  ${"REC".padEnd(5)}  ${"BOUNTY".padEnd(8)}  ${"ASSIGN".padEnd(12)}  TRUST`;
+/**
+ * Return a short, human-useful display ID for a task.
+ * For recurring instances (id starts with "recurrence:"), the full ID is
+ * "recurrence:<seriesKey>:<datePart>". We show "~YYYY-MM-DD" (9 chars max)
+ * so agents can clearly distinguish instances.
+ * For regular tasks we use the standard 8-char UUID prefix.
+ */
+export function shortTaskId(id: string): string {
+  if (id.startsWith("recurrence:")) {
+    // Last segment after final ":" is the date/time part
+    const lastColon = id.lastIndexOf(":");
+    const datePart = id.slice(lastColon + 1); // e.g. "2026-03-14"
+    return ("~" + datePart).slice(0, 11).padEnd(11);
+  }
+  return id.slice(0, 8).padEnd(8);
+}
+
+const COL_HEADER = `${"ID".padEnd(11)}  ${"TITLE".padEnd(40)}  ${"LIST".padEnd(12)}  ${"DUE".padEnd(12)}  ${"PRI".padEnd(4)}  ${"REC".padEnd(5)}  ${"BOUNTY".padEnd(8)}  ${"ASSIGN".padEnd(12)}  TRUST`;
 
 export function renderTable(
   tasks: FullTaskRecord[],
@@ -141,7 +158,7 @@ export function renderTable(
     console.log("\n" + chalk.bold(boardHeader));
     console.log(chalk.dim(COL_HEADER));
     for (const task of boardTasks) {
-      const id = task.id.slice(0, 8).padEnd(8);
+      const id = shortTaskId(task.id);
       const title = truncateWithSubtasks(task, 40);
       // Resolve column UUID → name, fall back to short ID, blank if no column
       const colLabel = task.column

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1664,6 +1664,7 @@ function isSameLocalDate(aMs: number, bMs: number): boolean {
 
 const R_NONE: Recurrence = { type: "none" };
 const LS_TASKS = "taskify_tasks_v5";
+const LS_BOARD_SYNC_CURSORS = "taskify_board_sync_cursors_v1";
 const LS_CALENDAR_EVENTS = "taskify_calendar_events_v1";
 const LS_EXTERNAL_CALENDAR_EVENTS = "taskify_calendar_external_events_v1";
 const LS_CALENDAR_INVITES = "taskify_calendar_invites_v2";
@@ -2008,6 +2009,9 @@ declare global {
 const NOSTR_MIN_EVENT_INTERVAL_MS = 200;
 const NOSTR_MIGRATION_BUFFER_MS = 15000;
 const NOSTR_INITIAL_SYNC_TIMEOUT_MS = 8000;
+// How many seconds to look back before the stored cursor to guard against
+// clock skew and events that arrived slightly out of order across relays.
+const NOSTR_CURSOR_LOOKBACK_SECS = 300;
 
 function loadDefaultRelays(): string[] {
   try {
@@ -6204,6 +6208,16 @@ export default function App() {
   const pendingNostrCalendarRef = useRef<Set<string>>(new Set());
   const completedNostrInitialSyncRef = useRef<Set<string>>(new Set());
   const [pendingNostrInitialSyncByBoardTag, setPendingNostrInitialSyncByBoardTag] = useState<Record<string, true>>({});
+  // In-memory cursor: tracks the highest created_at seen per board tag this session.
+  // Persisted to IDB after EOSE so subsequent opens only fetch new events.
+  const boardSyncCursorsRef = useRef<Record<string, number>>(() => {
+    try {
+      const raw = idbKeyValue.getItem(TASKIFY_STORE_TASKS, LS_BOARD_SYNC_CURSORS);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  });
   const markNostrBoardInitialSyncComplete = useCallback((bTag: string) => {
     if (!bTag) return;
     completedNostrInitialSyncRef.current.add(bTag);
@@ -12858,6 +12872,11 @@ export default function App() {
     if (ev.created_at === last && isPending) return;
     // Accept equal timestamps so rapid consecutive updates still apply
     m.set(taskId, ev.created_at);
+    // Advance the in-memory cursor for this board so we know the high-water mark
+    if (typeof ev.created_at === "number" && Number.isFinite(ev.created_at)) {
+      const prev = boardSyncCursorsRef.current[bTag] ?? 0;
+      if (ev.created_at > prev) boardSyncCursorsRef.current = { ...boardSyncCursorsRef.current, [bTag]: ev.created_at };
+    }
 
     let payload: any = {};
     try {
@@ -17105,10 +17124,18 @@ export default function App() {
       }
       pool.setRelays(rls);
       ensureMigrationState(it.id);
+      // Use a cursor (since) if we've synced this board before, so we only fetch
+      // events newer than our last high-water mark. This avoids re-fetching hundreds
+      // of old events on every app open, which was the cause of a ~60 second flicker
+      // where completed/deleted tasks would appear then disappear as old events were processed.
+      // First-time sync (no cursor): use limit:500 to bootstrap.
+      // Subsequent syncs: use since:(cursor - lookback) with no hard limit.
+      const cursor = boardSyncCursorsRef.current[it.id];
+      const sinceFilter = cursor ? { since: Math.max(0, cursor - NOSTR_CURSOR_LOOKBACK_SECS) } : { limit: 500 };
       const filters = [
-        { kinds: [30300, 30301], "#b": [it.id], limit: 500 },
+        { kinds: [30300, 30301], "#b": [it.id], ...sinceFilter },
         { kinds: [30300], "#d": [it.id], limit: 1 },
-        { kinds: [TASKIFY_CALENDAR_EVENT_KIND], "#b": [it.id], limit: 500 },
+        { kinds: [TASKIFY_CALENDAR_EVENT_KIND], "#b": [it.id], ...sinceFilter },
       ];
       const unsub = pool.subscribe(rls, filters, (ev) => {
         if (ev.kind === 30300) enqueueNostrApply(() => applyBoardEvent(ev)).catch(() => {});
@@ -17119,6 +17146,10 @@ export default function App() {
         nostrApplyQueue.current.catch(() => {}).then(() => {
           clearSyncTimeout(it.id);
           markNostrBoardInitialSyncComplete(it.id);
+          // Persist the updated cursor so the next startup fetches only new events
+          try {
+            idbKeyValue.setItem(TASKIFY_STORE_TASKS, LS_BOARD_SYNC_CURSORS, JSON.stringify(boardSyncCursorsRef.current));
+          } catch { /* non-fatal */ }
           setTimeout(() => migrateBoardRef.current(it.id), NOSTR_MIGRATION_BUFFER_MS);
         });
       });


### PR DESCRIPTION
## Summary

5 commits shipping from this session:

### 🐛 Fixes

**fix(pwa): cursor-based relay sync to eliminate startup task flicker** (`54d5440`)
- Every open re-fetched up to 500 events per board from scratch, flooding in for ~60 seconds
- Completed/deleted tasks would appear then vanish as stale events processed out of order
- Now stores a high-water-mark cursor (highest `created_at`) per board in IndexedDB after each EOSE
- Subsequent opens use `since: cursor - 5min` instead of `limit: 500` — only new events fetched
- First-time sync still bootstraps with `limit: 500`; after first open, flicker is gone

**fix(cli): auto-sync board display names on `board list`** (`a9a70ee`)
- `board list` and `boards` now detect boards with UUID-only names and auto-fetch display names from relays
- Agents no longer need to manually run `taskify board sync` to see human-readable board names
- Updated names persist to local config

**fix(cli): recurring task display and resolution** (`779197c`) — shipped in `taskify-nostr@0.3.3`
- Table now shows `~YYYY-MM-DD` for recurring instance IDs instead of `recurren` (useless 8-char prefix)
- `resolveTaskId` now handles full `recurrence:...` IDs via exact match
- `done` and `reopen` commands now accept `--title` + `--due` flags for title-based resolution
  - e.g. `taskify done --title "Bible plan" --due 2026-03-14 --board "Personal schedule"`

### 📖 Docs

**docs: add dev philosophy standards and Originless backlog item** (`f92f785`)
- AGENT.md: new Development Philosophy section (nevernesting, bug→test-first, no dead code, standalone commits, non-blocking async)
- Engineering roadmap: Originless file attachment integration added to backlog with board-key encryption requirement

**docs(skill): add profile-first rule to taskify-cli skill** (`66018b2`)
- Skill now instructs agents to check/switch profiles before any Taskify command
- Auto-sync note updated to reflect new CLI behavior

---

## Test plan
- `npm test` passes (43/43) ✅
- `npm run build` clean ✅
- CLI: `taskify-nostr@0.3.4` published to npm
- PWA: manual verification needed for cursor sync behavior on first open post-deploy