### PR TITLE
fix(pwa): iOS reload loop, broken cursor preload, AES key cache

### DIFF
--- a/taskify-core/src/boardCrypto.ts
+++ b/taskify-core/src/boardCrypto.ts
@@ -5,9 +5,21 @@ export async function boardTagHash(boardId: string): Promise<string> {
   return Array.from(digest).map((x) => x.toString(16).padStart(2, "0")).join("");
 }
 
+// Cache derived AES keys per boardId. The key material is deterministic (boardId only),
+// so one derivation per board is sufficient for the lifetime of the session.
+// Without this, every decryptFromBoard call ran SHA-256 + importKey — 2 async WebCrypto
+// ops per event × 500 events = 1000 serial operations that blocked the queue for minutes.
+const aesKeyCache = new Map<string, Promise<CryptoKey>>();
+
 async function deriveBoardAesKey(boardId: string): Promise<CryptoKey> {
-  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(boardId));
-  return crypto.subtle.importKey("raw", hash, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+  const cached = aesKeyCache.get(boardId);
+  if (cached) return cached;
+  const promise = (async () => {
+    const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(boardId));
+    return crypto.subtle.importKey("raw", hash, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+  })();
+  aesKeyCache.set(boardId, promise);
+  return promise;
 }
 
 export async function encryptToBoard(boardId: string, plaintext: string): Promise<string> {

--- a/taskify-pwa/src/main.tsx
+++ b/taskify-pwa/src/main.tsx
@@ -45,7 +45,10 @@ async function bootstrapApp(): Promise<void> {
   let storageTimedOut = false;
   try {
     // Guard against occasional startup hangs in storage bootstrap.
-    await withTimeout(storagePromise, 1500);
+    // 10s gives large backups (1000s of tasks) enough time to read from IDB on
+    // slow mobile devices. Fast devices still boot instantly since the await
+    // resolves as soon as IDB is ready — the timeout is only the upper bound.
+    await withTimeout(storagePromise, 10_000);
   } catch (err) {
     console.warn('Storage bootstrap fallback (continuing with in-memory behavior)', err);
     storageTimedOut = true;
@@ -83,14 +86,18 @@ async function bootstrapApp(): Promise<void> {
 
   // If IDB timed out but eventually succeeds, reload once so components pick up
   // the real data instead of showing empty state for the entire session.
+  // NOTE: use localStorage (not sessionStorage) — on iOS, the PWA process can be
+  // terminated and relaunched by the OS, which clears sessionStorage and causes an
+  // infinite reload loop when IDB is slow (e.g. after a large backup restore).
+  // A 60-second guard prevents rapid repeated reloads on slow devices.
   if (storageTimedOut) {
     storagePromise
       .then(() => {
         const RELOAD_KEY = 'taskify_storage_late_reload';
         try {
-          const last = Number(sessionStorage.getItem(RELOAD_KEY) || '0');
-          if (Date.now() - last > 10_000) {
-            sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+          const last = Number(localStorage.getItem(RELOAD_KEY) || '0');
+          if (Date.now() - last > 60_000) {
+            localStorage.setItem(RELOAD_KEY, String(Date.now()));
             window.location.reload();
           }
         } catch {}

--- a/taskify-pwa/src/storage/storageBootstrap.ts
+++ b/taskify-pwa/src/storage/storageBootstrap.ts
@@ -23,6 +23,7 @@ const TASKS_KEY = "taskify_tasks_v5";
 const BOARDS_KEY = "taskify_boards_v2";
 const EVENTS_KEY = "taskify_calendar_events_v1";
 const EXTERNAL_EVENTS_KEY = "taskify_calendar_external_events_v1";
+const BOARD_SYNC_CURSORS_KEY = "taskify_board_sync_cursors_v1";
 
 const CASHU_PROOFS_KEY = "cashu_proofs_v1";
 const CASHU_ACTIVE_MINT_KEY = "cashu_active_mint_v1";
@@ -55,6 +56,7 @@ export async function initializeStorageBoundaries(): Promise<void> {
       LS_BACKGROUND_IMAGE,
       AGENT_IDEMPOTENCY_STORAGE_KEY,
       AGENT_SECURITY_STORAGE_KEY,
+      BOARD_SYNC_CURSORS_KEY, // relay sync cursors — must preload so repeat opens skip limit:500
     ]),
     idbKeyValue.initStore(TASKIFY_STORE_WALLET, [
       CASHU_PROOFS_KEY,


### PR DESCRIPTION
## Summary

2 commits on top of merged PR #51.

### fix(pwa): stop iOS reload loop + fix broken cursor preload — `e69f981`
- **iOS reload loop:** reload guard used `sessionStorage` which iOS clears when it terminates the PWA process. Every relaunch after an OS memory kill → guard gone → reload → kill → repeat. Fixed: switched to `localStorage` + extended guard to 60 seconds.
- **Broken cursor preload:** `LS_BOARD_SYNC_CURSORS` was never added to `idbKeyValue.initStore()` so `getItem()` always returned null — the cursor optimization was silently not running, every open was still doing `limit:500`. Fixed: added to preload list.
- **Storage timeout too tight:** 1500ms was too short for large backups on mobile. Increased to 10s.

### perf(core): cache derived AES key per board to unblock event queue — `cdd1aae`
- `decryptFromBoard` was calling `SHA-256` + `importKey` (2 async WebCrypto ops) on every event with no caching — 500 events × N boards = 1000+ serial WebCrypto calls. This was the minutes-long hang during initial sync.
- Fixed: cache `CryptoKey` promise per boardId. One derivation per board per session; all 500 events share it.

---

## Test plan
- `npm test` passes (43/43) ✅
- `npm run build` clean ✅