### PR TITLE
fix(pwa): cursor key mismatch causing limit:500 on every reload

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -12891,10 +12891,11 @@ export default function App() {
     if (ev.created_at === last && isPending) return;
     // Accept equal timestamps so rapid consecutive updates still apply
     m.set(taskId, ev.created_at);
-    // Advance the in-memory cursor for this board so we know the high-water mark
+    // Advance the in-memory cursor for this board so we know the high-water mark.
+    // Key by lb.id (board UUID) — must match the lookup in the subscription setup.
     if (typeof ev.created_at === "number" && Number.isFinite(ev.created_at)) {
-      const prev = boardSyncCursorsRef.current[bTag] ?? 0;
-      if (ev.created_at > prev) boardSyncCursorsRef.current = { ...boardSyncCursorsRef.current, [bTag]: ev.created_at };
+      const prev = boardSyncCursorsRef.current[lb.id] ?? 0;
+      if (ev.created_at > prev) boardSyncCursorsRef.current = { ...boardSyncCursorsRef.current, [lb.id]: ev.created_at };
     }
 
     let payload: any = {};


### PR DESCRIPTION
## Summary

Single commit: `fe2cf82`

### The bug
The relay sync cursor was saved under `bTag` (SHA256 hash of `nostrBoardId`) but looked up under `it.id` (board UUID). These are always different values, so the cursor lookup always returned `undefined` → fell through to `limit:500` → full 500-event flood on every single app open. This is the root cause of the crash-on-reload.

### The fix
Save cursor under `lb.id` (board UUID) to match the subscription lookup key. First sync after restore now correctly builds the cursor; every subsequent open fetches only `since:(cursor - 300s)` instead of 500 events.

---

- `npm test` passes ✅
- `npm run build` clean ✅