### PR TITLE
fix(runtime-nostr): drain buffered events before EOSE to eliminate old-task flicker

### DIFF
--- a/taskify-runtime-nostr/src/SubscriptionManager.ts
+++ b/taskify-runtime-nostr/src/SubscriptionManager.ts
@@ -210,6 +210,23 @@ export class SubscriptionManager {
     });
 
     sub.on("eose", () => {
+      // Drain all buffered events synchronously before notifying EOSE handlers.
+      // Events are queued in pendingEvents and delivered via requestAnimationFrame
+      // (FLUSH_BATCH_SIZE at a time). Without this drain, EOSE fires while
+      // hundreds of events are still pending — the batch flush happens on partial
+      // data, and the remaining events arrive post-flush as "live" individual
+      // updates. This causes old tasks to temporarily appear (out-of-order CREATE
+      // events without their DELETE counterparts) before being corrected, producing
+      // the ~15-30 second flicker of stale state.
+      if (state.pendingEvents.length > 0) {
+        state.flushScheduled = false;
+        const remaining = state.pendingEvents.splice(0);
+        for (const { raw, relayUrl } of remaining) {
+          state.handlers.forEach((h) => {
+            try { h.onEvent?.(raw, relayUrl); } catch {}
+          });
+        }
+      }
       state.handlers.forEach((h) => {
         try { h.onEose?.(); } catch {}
       });


### PR DESCRIPTION
## Summary

Single commit: `d2a2401` — in `taskify-runtime-nostr/SubscriptionManager.ts`

### The bug

`SubscriptionManager` batches incoming relay events via `requestAnimationFrame` (64 events per frame). With 500 events from a relay, ~8 animation frames are needed to deliver them all. The `eose` callback on the NDK subscription fired **synchronously and immediately** — before most of those frames had run.

So the EOSE flush in `App.tsx` executed with a partially-delivered batch (maybe 64-128 events). The remaining ~400 events then arrived as post-flush **live individual updates**, bypassing the batch Map entirely.

Because relays return events newest-first for `limit:500`, those remaining live events were out of order: old CREATE events arrived without their corresponding DELETE events → deleted/completed tasks temporarily reappeared on screen. Then 10-15 seconds later the DELETE events arrived → tasks disappeared. The total effect was a 15-30 second window of stale state.

### The fix

At EOSE, synchronously drain all remaining `pendingEvents` before notifying `onEose` handlers. The `onEvent` handler is a synchronous enqueue operation (no crypto, no async work), so draining 500 events synchronously takes microseconds. The per-board queue then processes them asynchronously as before.

### Safety

This only changes the _delivery timing_ of already-received events — no events are dropped or reordered. Events that were already delivered via RAF frames are not re-delivered (they were already spliced from `pendingEvents`). The fix is minimal and isolated to the EOSE path.

---

- `npm test` passes ✅
- `npm run build` (runtime-nostr + pwa) clean ✅