### PR TITLE
fix(pwa): correct cursor key + time-based sync window to eliminate reload flicker

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1739,7 +1739,8 @@ function applyBackupDataToStorage(data: Partial<TaskifyBackupPayload>): void {
   // uses since:(max_task_time - lookback) and only fetches events newer than the
   // backup, which are exactly the changes the user missed while offline.
   const RESTORE_LOOKBACK_SECS = 3600; // 1 hour buffer for clock skew / in-flight events
-  const boardMaxSecs = new Map<string, number>();
+  // Build a map from local boardId → max task timestamp (to avoid iterating boards twice)
+  const boardLocalMaxSecs = new Map<string, number>();
   if (Array.isArray(data.tasks)) {
     for (const task of data.tasks as Array<{ boardId?: string; createdAt?: number; updatedAt?: string }>) {
       if (!task.boardId) continue;
@@ -1751,12 +1752,23 @@ function applyBackupDataToStorage(data: Partial<TaskifyBackupPayload>): void {
         const ms = Date.parse(task.updatedAt);
         if (!isNaN(ms) && ms > 0) secs = Math.max(secs, Math.floor(ms / 1000));
       }
-      boardMaxSecs.set(task.boardId, Math.max(boardMaxSecs.get(task.boardId) ?? 0, secs));
+      boardLocalMaxSecs.set(task.boardId, Math.max(boardLocalMaxSecs.get(task.boardId) ?? 0, secs));
     }
   }
+  // Cursors must be keyed by bTag = boardTag(b.nostr!.boardId) — this is how the
+  // subscription loop reads them (it.id = boardTag(b.nostr!.boardId)).
   const cursors: Record<string, number> = {};
-  for (const [boardId, maxSecs] of boardMaxSecs) {
-    if (maxSecs > 0) cursors[boardId] = Math.max(0, maxSecs - RESTORE_LOOKBACK_SECS);
+  if (Array.isArray(data.boards)) {
+    for (const board of data.boards as Array<{ id?: string; nostr?: { boardId?: string } }>) {
+      const localId = board.id;
+      const nostrBoardId = board.nostr?.boardId;
+      if (!localId || !nostrBoardId) continue;
+      const maxSecs = boardLocalMaxSecs.get(localId) ?? 0;
+      if (maxSecs > 0) {
+        const bTag = boardTag(nostrBoardId);
+        cursors[bTag] = Math.max(0, maxSecs - RESTORE_LOOKBACK_SECS);
+      }
+    }
   }
   idbKeyValue.setItem(TASKIFY_STORE_TASKS, LS_BOARD_SYNC_CURSORS, JSON.stringify(cursors));
   if ("tasks" in data && data.tasks !== undefined) {
@@ -12949,13 +12961,14 @@ export default function App() {
     // Accept equal timestamps so rapid consecutive updates still apply
     m.set(taskId, ev.created_at);
     // Advance the in-memory cursor for this board so we know the high-water mark.
-    // Key by lb.id (board UUID) — must match the lookup in the subscription setup.
+    // Key by bTag (SHA256 of nostrBoardId) — must match the lookup in the
+    // subscription setup where it.id = boardTag(b.nostr!.boardId) = bTag.
     // Also persist incrementally every 100 events: if the app crashes before EOSE
     // the cursor survives and the next open re-fetches only unprocessed events.
     if (typeof ev.created_at === "number" && Number.isFinite(ev.created_at)) {
-      const prev = boardSyncCursorsRef.current[lb.id] ?? 0;
+      const prev = boardSyncCursorsRef.current[bTag] ?? 0;
       if (ev.created_at > prev) {
-        boardSyncCursorsRef.current = { ...boardSyncCursorsRef.current, [lb.id]: ev.created_at };
+        boardSyncCursorsRef.current = { ...boardSyncCursorsRef.current, [bTag]: ev.created_at };
         const clock = nostrIdxRef.current.taskClock.get(bTag);
         if (clock && clock.size % 100 === 0) {
           try {

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1730,9 +1730,35 @@ function applyBackupDataToStorage(data: Partial<TaskifyBackupPayload>): void {
   if (!data || typeof data !== "object") {
     throw new Error("Invalid backup data");
   }
-  // Clear sync cursors on restore so the first post-restore open re-fetches all
-  // events from relays and builds a fresh cursor, rather than skipping history.
-  idbKeyValue.setItem(TASKIFY_STORE_TASKS, LS_BOARD_SYNC_CURSORS, JSON.stringify({}));
+  // Derive per-board sync cursors from the max task timestamp in the backup instead
+  // of clearing them to {}. Clearing to {} caused limit:500 on the next open which
+  // fetched all recent events including old CREATE events whose DELETE events were
+  // beyond the 500 limit — those old tasks would reappear temporarily.
+  //
+  // By seeding the cursor from the backup's task timestamps, the post-restore sync
+  // uses since:(max_task_time - lookback) and only fetches events newer than the
+  // backup, which are exactly the changes the user missed while offline.
+  const RESTORE_LOOKBACK_SECS = 3600; // 1 hour buffer for clock skew / in-flight events
+  const boardMaxSecs = new Map<string, number>();
+  if (Array.isArray(data.tasks)) {
+    for (const task of data.tasks as Array<{ boardId?: string; createdAt?: number; updatedAt?: string }>) {
+      if (!task.boardId) continue;
+      let secs = 0;
+      if (typeof task.createdAt === "number" && task.createdAt > 0) {
+        secs = Math.max(secs, Math.floor(task.createdAt / 1000));
+      }
+      if (typeof task.updatedAt === "string") {
+        const ms = Date.parse(task.updatedAt);
+        if (!isNaN(ms) && ms > 0) secs = Math.max(secs, Math.floor(ms / 1000));
+      }
+      boardMaxSecs.set(task.boardId, Math.max(boardMaxSecs.get(task.boardId) ?? 0, secs));
+    }
+  }
+  const cursors: Record<string, number> = {};
+  for (const [boardId, maxSecs] of boardMaxSecs) {
+    if (maxSecs > 0) cursors[boardId] = Math.max(0, maxSecs - RESTORE_LOOKBACK_SECS);
+  }
+  idbKeyValue.setItem(TASKIFY_STORE_TASKS, LS_BOARD_SYNC_CURSORS, JSON.stringify(cursors));
   if ("tasks" in data && data.tasks !== undefined) {
     idbKeyValue.setItem(TASKIFY_STORE_TASKS, LS_TASKS, JSON.stringify(data.tasks));
   }
@@ -17253,10 +17279,19 @@ export default function App() {
       // events newer than our last high-water mark. This avoids re-fetching hundreds
       // of old events on every app open, which was the cause of a ~60 second flicker
       // where completed/deleted tasks would appear then disappear as old events were processed.
-      // First-time sync (no cursor): use limit:500 to bootstrap.
-      // Subsequent syncs: use since:(cursor - lookback) with no hard limit.
+      //
+      // After a backup restore, applyBackupDataToStorage seeds per-board cursors from
+      // the max task timestamp so this path is taken immediately (no limit:500).
+      //
+      // For a true first-time sync (new user, no backup, no tasks), fall back to a
+      // 30-day time window instead of limit:500. A time-based window is safer than an
+      // event-count limit: limit:500 can include old CREATE events whose DELETE events
+      // are beyond the limit and will never arrive, causing deleted tasks to reappear.
+      const INITIAL_SYNC_FALLBACK_DAYS = 30;
       const cursor = boardSyncCursorsRef.current[it.id];
-      const sinceFilter = cursor ? { since: Math.max(0, cursor - NOSTR_CURSOR_LOOKBACK_SECS) } : { limit: 500 };
+      const sinceFilter = cursor
+        ? { since: Math.max(0, cursor - NOSTR_CURSOR_LOOKBACK_SECS) }
+        : { since: Math.floor(Date.now() / 1000) - INITIAL_SYNC_FALLBACK_DAYS * 24 * 3600 };
       const filters = [
         { kinds: [30300, 30301], "#b": [it.id], ...sinceFilter },
         { kinds: [30300], "#d": [it.id], limit: 1 },


### PR DESCRIPTION
## Summary

2 commits targeting the root cause of old-task flicker on every app reload.

### `08fd6b4` — Time-based sync window replaces `limit:500`
- **Restore:** `applyBackupDataToStorage` now seeds per-board cursors from the backup's max task timestamp instead of clearing to `{}`. Post-restore sync uses `since:(backup_time - 1h)` and only fetches events newer than the backup.
- **New user fallback:** Replaced `limit:500` with `since:(now - 30d)`. A time-based window is safer — `limit:500` can include CREATE events for tasks whose DELETE events are beyond the limit and never arrive, causing deleted tasks to permanently reappear.

### `b20a5a6` — Correct cursor key (root cause of every-reload flicker)
PR #55 introduced a new key mismatch: it changed the cursor **save** key from `bTag` to `lb.id` (local board UUID), but the subscription **reads** cursors under `it.id = boardTag(b.nostr!.boardId) = bTag`. These are always different values → cursor was always null on every reload → fell through to the 30-day fallback → fetched weeks of events with stale creates/deletes → flicker every time.

The original save key (`bTag`) already matched the read. This commit reverts that and also fixes `applyBackupDataToStorage` to key cursors under `boardTag(b.nostr!.boardId)` (same `bTag`) so the restore path is consistent.

---

- `npm test` passes ✅
- `npm run build` clean ✅