### PR TITLE
fix(pwa): event invite picker + time picker position

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -19830,7 +19830,7 @@ export default function App() {
             });
           }}
           boards={boards}
-          contacts={shareContacts}
+          contacts={shareableContacts}
           rsvps={activeEventRsvps}
           nostrPK={nostrPK}
           nostrSkHex={nostrSkHex}

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -19830,7 +19830,7 @@ export default function App() {
             });
           }}
           boards={boards}
-          contacts={shareableContacts}
+          contacts={shareContacts}
           rsvps={activeEventRsvps}
           nostrPK={nostrPK}
           nostrSkHex={nostrSkHex}

--- a/taskify-pwa/src/ui/calendar/EventEditModal.tsx
+++ b/taskify-pwa/src/ui/calendar/EventEditModal.tsx
@@ -215,7 +215,9 @@ function EventEditModal({
   const contactByPubkey = useMemo(() => {
     const map = new Map<string, Contact>();
     (contacts || []).forEach((contact) => {
-      const pubkey = normalizeNostrPubkeyHex(contact?.npub);
+      // Use normalizeNostrPubkey first to handle bech32 (npub1...) format
+      const compressed = normalizeNostrPubkey(contact?.npub ?? "");
+      const pubkey = compressed ? normalizeNostrPubkeyHex(compressed) : normalizeNostrPubkeyHex(contact?.npub ?? "");
       if (pubkey) map.set(pubkey, contact);
     });
     return map;
@@ -1003,7 +1005,7 @@ function EventEditModal({
 
   const handleToggleInviteContact = (contact: Contact) => {
     if (isReadOnly) return;
-    const pubkey = normalizeNostrPubkeyHex(contact?.npub);
+    const pubkey = resolveInviteInput(contact?.npub ?? "");
     if (!pubkey) return;
     setParticipants((prev) => {
       const existing = prev.some((participant) => normalizeNostrPubkeyHex(participant.pubkey) === pubkey);
@@ -2010,7 +2012,7 @@ function EventEditModal({
           {filteredInviteContacts.length ? (
             <div className="space-y-2">
               {filteredInviteContacts.map((contact) => {
-                const pubkey = normalizeNostrPubkeyHex(contact?.npub);
+                const pubkey = resolveInviteInput(contact?.npub ?? "");
                 if (!pubkey) return null;
                 const label = contactPrimaryName(contact);
                 const subtitle = formatContactNpub(contact.npub);

--- a/taskify-pwa/src/ui/calendar/EventEditModal.tsx
+++ b/taskify-pwa/src/ui/calendar/EventEditModal.tsx
@@ -206,6 +206,7 @@ function EventEditModal({
 
   const [invitePickerOpen, setInvitePickerOpen] = useState(false);
   const [inviteSearch, setInviteSearch] = useState("");
+  const [manualInviteNpub, setManualInviteNpub] = useState("");
   const invitedPubkeys = useMemo(
     () => new Set(participantValidation.normalized.map((participant) => participant.pubkey)),
     [participantValidation.normalized],
@@ -971,7 +972,21 @@ function EventEditModal({
   const handleOpenInvitePicker = () => {
     if (isReadOnly) return;
     setInviteSearch("");
+    setManualInviteNpub("");
     setInvitePickerOpen(true);
+  };
+
+  const handleAddManualInvitee = () => {
+    if (isReadOnly) return;
+    const raw = manualInviteNpub.trim();
+    if (!raw) return;
+    const pubkey = normalizeNostrPubkeyHex(raw);
+    if (!pubkey) return;
+    setParticipants((prev) => {
+      if (prev.some((p) => normalizeNostrPubkeyHex(p.pubkey) === pubkey)) return prev;
+      return [...prev, { pubkey: raw, relay: "", role: "attendee" }];
+    });
+    setManualInviteNpub("");
   };
 
   const handleToggleInviteContact = (contact: Contact) => {
@@ -1537,10 +1552,7 @@ function EventEditModal({
               <button
                 type="button"
                 className="ghost-button button-sm pressable"
-                onClick={() => {
-                  handleAddParticipant();
-                  setShowAdvanced(true);
-                }}
+                onClick={handleOpenInvitePicker}
                 disabled={isReadOnly}
               >
                 Add invitee
@@ -1987,18 +1999,19 @@ function EventEditModal({
             <div className="space-y-2">
               {filteredInviteContacts.map((contact) => {
                 const pubkey = normalizeNostrPubkeyHex(contact?.npub);
-                if (!pubkey) return null;
+                const hasNostr = !!pubkey;
                 const label = contactPrimaryName(contact);
-                const subtitle = formatContactNpub(contact.npub);
-                const selected = invitedPubkeys.has(pubkey);
+                const subtitle = hasNostr ? formatContactNpub(contact.npub) : "No Nostr identity";
+                const selected = hasNostr && invitedPubkeys.has(pubkey);
                 return (
                   <button
                     key={contact.id}
                     type="button"
-                    className="contact-row pressable"
-                    onClick={() => handleToggleInviteContact(contact)}
+                    className={`contact-row${hasNostr ? " pressable" : " opacity-40 cursor-not-allowed"}`}
+                    onClick={() => hasNostr && handleToggleInviteContact(contact)}
                     aria-pressed={selected}
-                    disabled={isReadOnly}
+                    disabled={isReadOnly || !hasNostr}
+                    title={hasNostr ? undefined : "This contact has no Nostr identity and cannot be invited"}
                   >
                     <div className="contact-avatar">{contactInitials(label)}</div>
                     <div className="contact-row__text">
@@ -2010,11 +2023,9 @@ function EventEditModal({
                           </span>
                         ) : null}
                       </div>
-                      {subtitle ? (
-                        <div className="contact-row__meta">
-                          <span className="contact-row__meta-text">{subtitle}</span>
-                        </div>
-                      ) : null}
+                      <div className="contact-row__meta">
+                        <span className="contact-row__meta-text">{subtitle}</span>
+                      </div>
                     </div>
                   </button>
                 );
@@ -2023,6 +2034,28 @@ function EventEditModal({
           ) : (
             <div className="text-sm text-secondary">No contacts found.</div>
           )}
+          {/* Manual npub entry for contacts not in the list */}
+          <div className="space-y-1">
+            <div className="text-xs text-secondary">Or invite by npub / hex pubkey</div>
+            <div className="flex gap-2">
+              <input
+                value={manualInviteNpub}
+                onChange={(e) => setManualInviteNpub(e.target.value)}
+                className="edit-field-input flex-1"
+                placeholder="npub1... or hex pubkey"
+                readOnly={isReadOnly}
+                onKeyDown={(e) => { if (e.key === "Enter") handleAddManualInvitee(); }}
+              />
+              <button
+                type="button"
+                className="ghost-button button-sm pressable"
+                onClick={handleAddManualInvitee}
+                disabled={isReadOnly || !normalizeNostrPubkeyHex(manualInviteNpub.trim())}
+              >
+                Add
+              </button>
+            </div>
+          </div>
           <div className="flex gap-2">
             <button
               type="button"
@@ -2030,6 +2063,7 @@ function EventEditModal({
               onClick={() => {
                 setInvitePickerOpen(false);
                 setInviteSearch("");
+                setManualInviteNpub("");
               }}
             >
               Done

--- a/taskify-pwa/src/ui/calendar/EventEditModal.tsx
+++ b/taskify-pwa/src/ui/calendar/EventEditModal.tsx
@@ -79,6 +79,7 @@ import {
 // Nostr key utilities
 import { deriveBoardNostrKeys } from "../../domains/nostr/nostrKeyUtils";
 import { hexToBytes } from "../../domains/nostr/nostrCrypto";
+import { normalizeNostrPubkey } from "../../lib/nostr";
 
 // Share / inbox utilities
 import {
@@ -976,15 +977,26 @@ function EventEditModal({
     setInvitePickerOpen(true);
   };
 
+  // Resolves npub1 bech32, nostr: URIs, and raw hex to a 64-char hex pubkey.
+  const resolveInviteInput = (input: string): string | null => {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    // Try bech32 / nostr: URI first (normalizeNostrPubkey handles these)
+    const compressed = normalizeNostrPubkey(trimmed);
+    if (compressed) return normalizeNostrPubkeyHex(compressed);
+    // Fall back to straight hex
+    return normalizeNostrPubkeyHex(trimmed);
+  };
+
   const handleAddManualInvitee = () => {
     if (isReadOnly) return;
     const raw = manualInviteNpub.trim();
     if (!raw) return;
-    const pubkey = normalizeNostrPubkeyHex(raw);
+    const pubkey = resolveInviteInput(raw);
     if (!pubkey) return;
     setParticipants((prev) => {
       if (prev.some((p) => normalizeNostrPubkeyHex(p.pubkey) === pubkey)) return prev;
-      return [...prev, { pubkey: raw, relay: "", role: "attendee" }];
+      return [...prev, { pubkey, relay: "", role: "attendee" }];
     });
     setManualInviteNpub("");
   };
@@ -2051,7 +2063,7 @@ function EventEditModal({
                 type="button"
                 className="ghost-button button-sm pressable"
                 onClick={handleAddManualInvitee}
-                disabled={isReadOnly || !normalizeNostrPubkeyHex(manualInviteNpub.trim())}
+                disabled={isReadOnly || !resolveInviteInput(manualInviteNpub)}
               >
                 Add
               </button>

--- a/taskify-pwa/src/ui/calendar/EventEditModal.tsx
+++ b/taskify-pwa/src/ui/calendar/EventEditModal.tsx
@@ -1999,19 +1999,18 @@ function EventEditModal({
             <div className="space-y-2">
               {filteredInviteContacts.map((contact) => {
                 const pubkey = normalizeNostrPubkeyHex(contact?.npub);
-                const hasNostr = !!pubkey;
+                if (!pubkey) return null;
                 const label = contactPrimaryName(contact);
-                const subtitle = hasNostr ? formatContactNpub(contact.npub) : "No Nostr identity";
-                const selected = hasNostr && invitedPubkeys.has(pubkey);
+                const subtitle = formatContactNpub(contact.npub);
+                const selected = invitedPubkeys.has(pubkey);
                 return (
                   <button
                     key={contact.id}
                     type="button"
-                    className={`contact-row${hasNostr ? " pressable" : " opacity-40 cursor-not-allowed"}`}
-                    onClick={() => hasNostr && handleToggleInviteContact(contact)}
+                    className="contact-row pressable"
+                    onClick={() => handleToggleInviteContact(contact)}
                     aria-pressed={selected}
-                    disabled={isReadOnly || !hasNostr}
-                    title={hasNostr ? undefined : "This contact has no Nostr identity and cannot be invited"}
+                    disabled={isReadOnly}
                   >
                     <div className="contact-avatar">{contactInitials(label)}</div>
                     <div className="contact-row__text">
@@ -2023,9 +2022,11 @@ function EventEditModal({
                           </span>
                         ) : null}
                       </div>
-                      <div className="contact-row__meta">
-                        <span className="contact-row__meta-text">{subtitle}</span>
-                      </div>
+                      {subtitle ? (
+                        <div className="contact-row__meta">
+                          <span className="contact-row__meta-text">{subtitle}</span>
+                        </div>
+                      ) : null}
                     </div>
                   </button>
                 );


### PR DESCRIPTION
## Summary

Continuation of picker fixes plus a full overhaul of the event invite flow.

---

### Time picker — correct initial scroll position

**Root cause:** `useLayoutEffect` used `behavior: smooth` for initial scroll → fired scroll events mid-animation → snap handler read position mid-scroll → re-snapped to wrong item.

**Fix:** `scrollWheelColumnToIndex()` gains optional `behavior` param; all `useLayoutEffect` init calls pass `"instant"` for atomic, correct positioning.

---

### Event invite picker overhaul

**Bug 1: No contacts shown**

`normalizeNostrPubkeyHex` (from `taskify-core`) skips bech32 decoding — contacts stored as `npub1...` passed `contactHasNpub` but rendered `null` in the picker.

**Fix:** Added `resolveInviteInput()` helper that calls `normalizeNostrPubkey` (bech32 decoder) first, then `normalizeNostrPubkeyHex`. Applied to contact row rendering, `contactByPubkey` map, and `handleToggleInviteContact`.

**Bug 2: "Add invitee" did nothing visible**

Button called `handleAddParticipant() + setShowAdvanced(true)` — added a blank row to the hidden advanced section at the bottom with no feedback.

**Fix:** Both "Invite contact" and "Add invitee" now open the same invite picker ActionSheet.

**New: Manual npub entry**

Added `manualInviteNpub` state + `handleAddManualInvitee()`. Bottom of the invite picker has an npub/hex input + Add button. Supports Enter key. Same bech32-aware resolution via `resolveInviteInput()`.

---

## Files changed
- `taskify-pwa/src/domains/dateTime/dateUtils.ts`
- `taskify-pwa/src/domains/dateTime/calendarPickerHook.tsx`
- `taskify-pwa/src/ui/task/EditModal.tsx`
- `taskify-pwa/src/ui/calendar/EventEditModal.tsx`
- `taskify-pwa/src/ui/reminders/CustomReminderSheet.tsx`
- `taskify-pwa/src/App.tsx`
