### PR TITLE
fix(cli): deleted-task sync + latest-version regressions

### DIFF
--- a/.openclaw/skills/taskify-cli/SKILL.md
+++ b/.openclaw/skills/taskify-cli/SKILL.md
@@ -1,126 +1,151 @@
 ---
 name: taskify-cli
-description: Use the Taskify CLI to manage tasks, boards, inbox triage, exports/imports, trust, and profiles over Nostr. Trigger when users ask to list/add/update/complete/delete/search tasks, manage board metadata, run inbox triage, or perform Taskify agent commands from terminal workflows (not browser UI automation).
+description: Manage tasks, boards, and calendar events via the Taskify CLI (`taskify` command). Use when: (1) listing, searching, creating, updating, or deleting tasks, (2) marking tasks done or reopening them, (3) managing boards and columns, (4) assigning tasks to users, (5) checking upcoming or overdue tasks, (6) exporting or importing tasks, (7) triage or AI-powered task creation. Taskify stores tasks on Nostr relays — the CLI is the primary interface for agents working with Taskify data.
 ---
 
 # Taskify CLI
 
-Use deterministic CLI-first workflows for Taskify.
+`taskify` manages tasks and boards stored on Nostr relays. Tasks are identified by 8-char prefix or full UUID.
 
-## Command surface
+## Installation
 
-Primary executable: `taskify`
-Repo location: `/Users/openclaw/.openclaw/workspace/Taskify_Release/taskify-cli`
+Requires **Node.js 22+**.
 
-If `taskify` is missing globally, run via local package:
-- `cd /Users/openclaw/.openclaw/workspace/Taskify_Release/taskify-cli`
-- `npm run build` (if needed)
-- `node dist/index.js <args>`
-
-## Profile rule — always do this first
-
-**Before any Taskify command**, check and switch to the correct profile:
+**Package:** [`taskify-nostr`](https://www.npmjs.com/package/taskify-nostr)  
+**Source:** [github.com/Solife-me/Taskify_Release](https://github.com/Solife-me/Taskify_Release)  
+**Maintainer:** Ink-North ([@Ink-North](https://github.com/Ink-North))
 
 ```bash
-taskify profile list               # see all profiles and which is active (marked *)
-taskify profile use <name>         # switch to the right profile
-taskify board list                 # verify expected boards are visible (auto-syncs display names)
+npm install -g taskify-nostr
 ```
 
-- Each profile has its own boards, keys, and relay config. The default profile may not have access to the user's personal boards.
-- `taskify board list` now **auto-syncs display names** for any board showing as a raw UUID — no manual `taskify board sync` needed.
-- When a user references a named board (e.g. "Personal schedule"), resolve which profile owns it by iterating profiles until that board appears by name.
-- Use `--profile <name>` for quick one-shot commands without permanently switching: `taskify list --profile ink --board "Personal schedule"`
+Verify the install:
 
-### If you still see raw UUIDs after `board list`
-Run `taskify board sync` manually — it forces a relay fetch for all boards and updates the local cache.
-
-## Safety and reliability rules
-
-1. Prefer read commands first (`list`, `show`, `search`, `boards`, `board columns`) before mutating state.
-2. For destructive commands (`delete`, `board leave`, imports without `--dry-run`), confirm exact target identity first.
-3. Use `--json` whenever machine-verifiable output is needed.
-4. For ambiguous title matches, resolve exact task ID via `taskify search <query> --status any --json`.
-5. Never claim success until exit code is 0 and output confirms expected mutation.
-
-## Fast workflows
-
-### List and filter
-- Open tasks (table): `taskify list`
-- Open tasks (JSON): `taskify list --json`
-- Include done: `taskify list --status any --json`
-- Filter by board/column: `taskify list --board "<board>" --column "<column>" --json`
-
-### Create task
-- Minimal: `taskify add "<title>"`
-- Rich: `taskify add "<title>" --board "<board>" --due "YYYY-MM-DD" --priority 2 --note "..." --subtask "..." --column "..."`
-
-### Update task
-1. Resolve ID:
-   - `taskify search "<query>" --status any --json`
-2. Update fields:
-   - `taskify update <taskId> --title "..." --due "YYYY-MM-DD" --priority 1 --note "..." --column "..."`
-
-### Complete / reopen / delete
-- Complete: `taskify done <taskId> --board "<board>"`
-- Reopen: `taskify reopen <taskId> --board "<board>"`
-- Delete: `taskify delete <taskId> --board "<board>" --force`
-
-### Recurring task instances
-Recurring tasks on week boards generate virtual instances with IDs like `recurrence:<seriesKey>:<date>`.
-These show in the table with a `~YYYY-MM-DD` display ID. **Do not use the 8-char prefix** — it will be `~2026-03` for all instances and won't resolve.
-
-**Preferred approach — resolve by title + due date:**
 ```bash
-taskify done --title "Bible plan" --due 2026-03-14 --board "Personal schedule"
-taskify reopen --title "Bible plan" --due 2026-03-14 --board "Personal schedule"
+taskify --version
 ```
 
-**Alternative — use the full recurring instance ID from `--json`:**
+If the global install fails due to permissions, use a local prefix:
+
 ```bash
-taskify list --board "Personal schedule" --json | jq '.[] | select(.title | test("Bible"; "i")) | {id, title, dueISO}'
-# Then: taskify done "<full-recurrence:...:date-id>" --board "Personal schedule"
+npm install --prefix ~/.local -g taskify-nostr
+# add ~/.local/bin to PATH if not already there
 ```
 
-### Inbox triage
-- List inbox: `taskify inbox list --board "<board>"`
-- Quick add: `taskify inbox add "<title>" --board "<board>"`
-- Triage: `taskify inbox triage <taskId> --board "<board>" --column "<column>" --priority 2 --due "YYYY-MM-DD" --yes`
+> Before installing, verify the package on [npmjs.com/package/taskify-nostr](https://www.npmjs.com/package/taskify-nostr) and review the source at the GitHub link above. Prefer user-local install (`--prefix ~/.local`) over global on shared systems.
 
-### Boards and columns
-- List boards: `taskify boards --json`
-- Joined boards: `taskify board list`
-- Board columns: `taskify board columns "<board>"`
-- Sync board metadata: `taskify board sync`
+### First-time setup
 
-### Export/import
-- Export JSON: `taskify export --board "<board>" --format json --output /tmp/tasks.json`
-- Export CSV/MD: `taskify export --board "<board>" --format csv --output /tmp/tasks.csv`
-- Import dry run: `taskify import /tmp/tasks.json --board "<board>" --dry-run`
-- Import apply: `taskify import /tmp/tasks.json --board "<board>" --yes`
+Run the onboarding wizard — it generates or imports a Nostr keypair and stores it securely in the local CLI config:
 
-### Profiles
-- List: `taskify profile list`
-- Use profile: `taskify profile use <name>`
-- One-shot profile: `taskify list --profile <name> --json`
+```bash
+taskify setup
+```
 
-## Task ID resolution pattern (required for edits/deletes)
+Join a board by its UUID:
 
-1. `taskify search "<title fragment>" --status any --json`
-2. Prefer exact title match (and board match if provided).
-3. If multiple matches remain, ask one clarification question.
-4. Execute mutation with resolved `<taskId>`.
-5. Re-read with `taskify show <taskId> --json` or `taskify list --status any --json` to verify.
+```bash
+taskify board join <board-uuid> --name "My Board"
+```
 
-## Output contract
+> **Private key handling:** The CLI manages your Nostr private key internally via `taskify setup`. This skill does not instruct agents to read, expose, or handle private keys. Do not supply private keys via environment variables on shared or multi-user systems.
 
-For agent responses, return concise structure:
-- `status`: `ok` | `failed`
-- `action`: command intent
-- `evidence`: command(s) + key output proof (ID/state)
-- `error`: present only on failure
+## Prerequisites (summary)
 
-## References
+- **`taskify` binary on PATH** — installed via `npm install -g taskify-nostr` (see above). This skill provides instructions only; it does not install or bundle the binary.
+- **Configured Nostr identity** — set up via `taskify setup`. The **npub and hex values used in commands are public keys** and are safe to pass as arguments.
+- **At least one board joined** — via `taskify board join <uuid> --name <name>`.
 
-- CLI commands and examples: `references/command-reference.md`
-- Troubleshooting and fallback execution: `references/troubleshooting.md`
+## Data & credentials
+
+- **Task data is public-key-addressed on Nostr relays** — content may be encrypted per board settings. The skill instructs read/write of task events only.
+- **`taskify agent` commands forward task text to an external AI backend** — only use if you have configured and trust that backend (`taskify agent config`). Do not use on boards containing sensitive data unless the backend is self-hosted or trusted.
+- **Profile/identity operations (`taskify profile`, `taskify contact`)** work with public Nostr keys (npub/hex) only — not private keys. The CLI stores private keys locally; this skill never instructs exposing them.
+- **Relay management** — `taskify relay add/remove` modifies which Nostr relays tasks sync to. Only add relays you control or trust.
+
+## Quick reference
+
+```
+taskify list [--board <name|id>] [--status open|done|any] [--column <name>] [--json]
+taskify add <title> [--board <name>] [--due YYYY-MM-DD] [--priority 1|2|3] [--note <text>] [--column <name>]
+taskify show <taskId> [--board <name>] [--json]
+taskify update <taskId> --board <name> [--title <t>] [--due <d>] [--priority <p>] [--note <n>] [--column <name>]
+taskify done <taskId> [--board <name>]
+taskify reopen <taskId> [--board <name>]
+taskify delete <taskId> --board <name>
+taskify search <query> [--board <name>]
+taskify upcoming [--days <n>] [--board <name>]
+taskify board list
+taskify board columns [<board>]
+taskify agent add <natural-language description>   # forwards text to configured AI backend
+```
+
+## Key behaviours
+
+- **taskId**: accepts 8-char prefix or full UUID.
+- **`--board` flag**: required for `add`, `delete`, `update` when multiple boards exist. Optional for `list`, `done`, `show` (scans all if omitted).
+- **Incremental sync**: `list` always fetches relay events since the last cursor before returning. Pass `--refresh` to force a full 30-day re-fetch.
+- **`--json` flag**: available on `list`, `show`, `add`, `update` — output machine-readable JSON.
+- **Priority**: 1 = low, 2 = medium, 3 = high.
+
+## Common agent workflows
+
+### Reading tasks
+```bash
+taskify list                          # all open tasks across boards
+taskify list --board "Personal"       # one board
+taskify list --status done            # completed tasks
+taskify upcoming --days 7             # due within 7 days
+taskify search "keyword"              # full-text search
+taskify show abc12345 --json          # full task details
+```
+
+### Creating tasks
+```bash
+taskify add "Write release notes" --board "Work" --due 2026-03-20 --priority 2
+taskify agent add "high priority bug fix due Friday"   # AI-parsed (sends text to AI backend)
+```
+
+### Updating tasks
+```bash
+taskify update abc12345 --board "Work" --due 2026-03-25 --priority 3
+taskify update abc12345 --board "Work" --column "In Progress"
+taskify done abc12345
+taskify reopen abc12345
+```
+
+### Board management
+```bash
+taskify board list                            # show configured boards and IDs
+taskify board columns                         # show all columns
+taskify board column-add "Work" "Review"
+taskify board column-rename "Work" "Review" "QA"
+```
+
+### Assigning tasks
+```bash
+taskify assign abc12345 npub1...              # assign to npub (public key — not a secret)
+taskify unassign abc12345 npub1...
+```
+
+## Output parsing
+
+Use `--json` whenever the output will be parsed programmatically:
+
+```bash
+taskify list --json | jq '.[] | {id, title, due: .dueISO, priority}'
+taskify show abc12345 --json | jq '{title, note, column}'
+```
+
+## Diagnostics
+
+```bash
+taskify board list         # boards with IDs
+taskify relay status       # check relay connectivity
+taskify cache clear        # wipe local cache (forces cold re-fetch on next list)
+```
+
+## Reference
+
+- Full command flags: see [references/commands.md](references/commands.md)
+- Board and column operations: see [references/boards.md](references/boards.md)

--- a/.openclaw/skills/taskify-cli/references/boards.md
+++ b/.openclaw/skills/taskify-cli/references/boards.md
@@ -1,0 +1,52 @@
+# Taskify Boards & Columns Reference
+
+## Board types
+
+| Type | Description |
+|---|---|
+| `lists` | Standard kanban-style board with named columns |
+| `week` | 7-day week view — columns are Mon–Sun |
+| `compound` | Aggregates tasks from child boards |
+
+## Board commands
+
+```bash
+taskify board list                             # list configured boards with IDs
+taskify board join <uuid> --name <name>        # join an existing board by ID
+taskify board sync [boardId]                   # pull latest board metadata from relay
+taskify board create <name>                    # create a new board on Nostr
+taskify board leave <boardId>                  # remove board from local config
+taskify board rename <board> <name>
+taskify board archive <board>
+taskify board unarchive <board>
+taskify board hide <board>
+taskify board unhide <board>
+taskify board sort <board> [mode] [direction]  # mode: manual|due|priority|created|alpha
+taskify board clear-completed <board>          # delete all completed tasks
+```
+
+## Column commands
+
+```bash
+taskify board columns [<board>]                        # list columns with IDs
+taskify board column-add <board> <name>
+taskify board column-rename <board> <columnRef> <name> # columnRef = id or name
+taskify board column-delete <board> <columnRef>
+taskify board column-reorder <board> <columnRef> <pos> # 1-based position
+```
+
+## Compound board commands
+
+```bash
+taskify board children <board>
+taskify board child-add <board> <child>
+taskify board child-remove <board> <child>
+taskify board child-reorder <board> <child> <position>
+```
+
+## Identifying boards and columns
+
+- Boards: use name (e.g. `"Personal"`) or UUID (`4d0f7654-...`)
+- Columns: use name (e.g. `"In Progress"`) or column UUID
+- Week boards: use day names as column refs (`Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat`, `Sun`)
+- Run `taskify board columns` to see all column names and IDs

--- a/.openclaw/skills/taskify-cli/references/commands.md
+++ b/.openclaw/skills/taskify-cli/references/commands.md
@@ -1,0 +1,157 @@
+# Taskify CLI — Full Command Reference
+
+## taskify list
+
+```
+taskify list [--board <id|name>] [--status open|done|any] [--column <id|name>] [--refresh] [--no-cache] [--json]
+```
+
+- `--status any` returns open + done tasks
+- `--refresh` forces a full 30-day cold re-fetch (bypasses cursor)
+- `--no-cache` skips the local merge base; does not fall back to stale cache if relay is empty
+
+## taskify add
+
+```
+taskify add <title> [--board <id|name>] [--due YYYY-MM-DD] [--due-time HH:MM] [--timezone <iana>]
+            [--priority 1|2|3] [--note <text>] [--column <id|name>]
+            [--subtask <text>]... [--assignee <npub|hex>]...
+            [--recurrence-json <json>] [--reminders <csv>]
+            [--hidden-until <ISO>] [--json]
+```
+
+## taskify update
+
+```
+taskify update <taskId> [--board <id|name>]
+               [--title <t>] [--due <d>] [--due-time <HH:MM>] [--timezone <iana>]
+               [--priority <p>] [--note <n>] [--column <id|name>]
+               [--assignee <npub|hex>]...    # replaces all assignees
+               [--recurrence-json <json>] [--reminders <csv>]
+               [--hidden-until <ISO>] [--json]
+```
+
+## taskify show
+
+```
+taskify show <taskId> [--board <id|name>] [--json]
+```
+
+Displays title, note, due date/time, priority, column, subtasks, assignees, reminders, recurrence.
+
+## taskify done / reopen / delete
+
+```
+taskify done   [taskId] [--board <id|name>]
+taskify reopen [taskId] [--board <id|name>]
+taskify delete <taskId> [--board <id|name>]   # publishes status=deleted to Nostr; prompts confirm
+```
+
+Both `done` and `reopen` accept recurring instance IDs.
+
+## taskify search
+
+```
+taskify search <query> [--board <id|name>] [--status open|done|any] [--json]
+```
+
+Full-text search across title and note fields.
+
+## taskify upcoming
+
+```
+taskify upcoming [--days <n>] [--board <id|name>] [--json]
+```
+
+Default: 7 days.
+
+## taskify subtask
+
+```
+taskify subtask <taskId> <subtaskRef> [--board <id|name>]
+```
+
+`subtaskRef`: 1-based index or partial title match. Toggles done/incomplete.
+
+## taskify assign / unassign
+
+```
+taskify assign   <taskId> <npubOrHex> [--board <id|name>]
+taskify unassign <taskId> <npubOrHex> [--board <id|name>]
+```
+
+## taskify remind
+
+```
+taskify remind <taskId> <presets...> [--board <id|name>]
+```
+
+Presets: `0h`, `5m`, `15m`, `30m`, `1h`, `1d`, `1w`
+
+## taskify export / import
+
+```
+taskify export [--board <id|name>] [--format json|csv|markdown] [--output <file>]
+taskify import <file> [--board <id|name>] [--format json|csv]
+```
+
+## taskify agent
+
+```
+taskify agent add <description>      # AI-powered task creation — forwards text to configured AI backend
+taskify agent triage [--board <id>]  # AI prioritization — forwards task list to AI backend
+taskify agent config                 # configure which AI backend is used
+```
+
+> `agent` subcommands send task text to an external AI service. Only use on boards that do not contain sensitive data, unless the backend is self-hosted or trusted.
+
+## taskify inbox
+
+```
+taskify inbox list
+taskify inbox capture <title>
+taskify inbox triage
+```
+
+Quick-capture tasks that bypass board selection.
+
+## taskify profile
+
+```
+taskify profile list
+taskify profile use <name>
+taskify profile add <name>
+taskify profile remove <name>
+```
+
+Named Nostr identity profiles. Switch profiles for multi-account setups.
+
+## taskify contact
+
+```
+taskify contact list
+taskify contact add <npub|hex> [--name <n>]
+taskify contact remove <npub|hex>
+```
+
+## taskify relay
+
+```
+taskify relay status                  # check connectivity to configured relays
+taskify relay list                    # list configured relay URLs
+taskify relay add <wss://...>         # add a relay you control or trust
+taskify relay remove <wss://...>
+```
+
+> Only add relay URLs you control or trust — relays receive all task sync traffic.
+
+## taskify cache
+
+```
+taskify cache clear               # wipe all cached task data
+taskify cache clear --board <id>  # wipe one board
+```
+
+## Global flags
+
+- `-P, --profile <name>` — use a specific profile for this command without switching the active profile

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -29,6 +29,8 @@ import { resolveBoardForCommand } from "./shared/commandResolution.js";
 import { parseBackupSnapshot, mergeBoardsFromBackup, mergeRelaysFromBackup } from "./shared/backupSync.js";
 import { sendShareEnvelopeNip17, fetchShareInboxNip17 } from "./shared/shareTransport.js";
 import { resolveBoardColumn, formatAvailableColumns } from "./shared/columnResolution.js";
+import { publishProfile, fetchLatestProfileEvent } from "./profileMeta.js";
+import { uploadImageToNip96 } from "./nip96Upload.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -3408,6 +3410,157 @@ profileCmd
     const newActive = config.activeProfile === oldName ? newName : config.activeProfile;
     await saveProfiles(newActive, newProfiles);
     console.log(chalk.green(`✓ Renamed profile '${oldName}' → '${newName}'`));
+    process.exit(0);
+  });
+
+profileCmd
+  .command("set-meta")
+  .description("Update your Nostr profile metadata (kind:0) — only provided fields are updated")
+  .option("--name <n>", "Username / handle (name field)")
+  .option("--display-name <n>", "Display name (display_name field)")
+  .option("--about <text>", "Bio / about")
+  .option("--picture <url-or-path>", "Profile picture — URL or local file path (uploaded via NIP-96)")
+  .option("--banner <url-or-path>", "Banner image — URL or local file path (uploaded via NIP-96)")
+  .option("--nip05 <addr>", "NIP-05 verification address (user@domain.com)")
+  .option("--website <url>", "Website URL")
+  .option("--lud16 <addr>", "Lightning address (lud16)")
+  .option("--nip96-server <url>", "NIP-96 server for image uploads (default: nostr.build)", "https://nostr.build")
+  .option("--json", "Output published event as JSON")
+  .action(async (opts: {
+    name?: string;
+    displayName?: string;
+    about?: string;
+    picture?: string;
+    banner?: string;
+    nip05?: string;
+    website?: string;
+    lud16?: string;
+    nip96Server: string;
+    json?: boolean;
+  }) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    if (!config.nsec) {
+      console.error(chalk.red("No nsec configured for this profile. Run: taskify setup"));
+      process.exit(1);
+    }
+
+    // If no fields provided, show current metadata
+    const hasChanges = [opts.name, opts.displayName, opts.about, opts.picture, opts.banner, opts.nip05, opts.website, opts.lud16].some(v => v !== undefined);
+    if (!hasChanges) {
+      console.error(chalk.yellow("No fields specified. Use --name, --display-name, --about, --picture, --banner, --nip05, --website, --lud16"));
+      console.error(chalk.dim("  Example: taskify profile set-meta --display-name \"Nathan\" --picture ./avatar.png"));
+      process.exit(1);
+    }
+
+    // Upload local files via NIP-96 if needed
+    const resolveMedia = async (value: string | undefined, label: string): Promise<string | undefined> => {
+      if (!value) return undefined;
+      if (value.startsWith("http://") || value.startsWith("https://")) return value;
+      // Treat as local file path — upload to NIP-96
+      console.log(chalk.dim(`  Uploading ${label} via NIP-96...`));
+      try {
+        const url = await uploadImageToNip96({
+          serverUrl: opts.nip96Server,
+          filePath: value,
+          nsec: config.nsec!,
+        });
+        console.log(chalk.dim(`  ✓ Uploaded: ${url}`));
+        return url;
+      } catch (err) {
+        console.error(chalk.red(`Failed to upload ${label}: ${String(err)}`));
+        process.exit(1);
+      }
+    };
+
+    const pictureUrl = await resolveMedia(opts.picture, "profile picture");
+    const bannerUrl = await resolveMedia(opts.banner, "banner");
+
+    const draft = {
+      name: opts.name,
+      displayName: opts.displayName,
+      about: opts.about,
+      picture: pictureUrl,
+      banner: bannerUrl,
+      nip05: opts.nip05,
+      website: opts.website,
+      lud16: opts.lud16,
+    };
+
+    // Strip undefined so we only update provided fields
+    const cleanDraft = Object.fromEntries(
+      Object.entries(draft).filter(([, v]) => v !== undefined)
+    ) as typeof draft;
+
+    console.log(chalk.dim("  Publishing profile metadata..."));
+
+    try {
+      const result = await publishProfile(config.nsec, cleanDraft, config.relays);
+      if (opts.json) {
+        console.log(JSON.stringify(result.event, null, 2));
+      } else {
+        console.log(chalk.green(`✓ Profile updated (event: ${result.event.id?.slice(0, 8)}...)`));
+        const content = JSON.parse(result.event.content ?? "{}");
+        if (content.name) console.log(`  name:         ${content.name}`);
+        if (content.display_name) console.log(`  display_name: ${content.display_name}`);
+        if (content.about) console.log(`  about:        ${content.about}`);
+        if (content.picture) console.log(`  picture:      ${content.picture}`);
+        if (content.banner) console.log(`  banner:       ${content.banner}`);
+        if (content.nip05) console.log(`  nip05:        ${content.nip05}`);
+        if (content.website) console.log(`  website:      ${content.website}`);
+        if (content.lud16) console.log(`  lud16:        ${content.lud16}`);
+        if (result.deletedIds.length) console.log(chalk.dim(`  (deleted superseded event: ${result.deletedIds[0]?.slice(0, 8)}...)`));
+      }
+    } catch (err) {
+      console.error(chalk.red(`Failed to publish profile: ${String(err)}`));
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+
+profileCmd
+  .command("fetch-meta [name]")
+  .description("Fetch and display current Nostr profile metadata from relays (defaults to active profile)")
+  .option("--json", "Output raw kind:0 event as JSON")
+  .action(async (name: string | undefined, opts: { json?: boolean }) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const profileName = name ?? config.activeProfile;
+    const profile = config.profiles[profileName];
+    if (!profile) {
+      console.error(chalk.red(`Profile not found: "${profileName}"`));
+      process.exit(1);
+    }
+    if (!profile.nsec) {
+      console.error(chalk.red("No nsec configured for this profile."));
+      process.exit(1);
+    }
+    const decoded = nip19.decode(profile.nsec);
+    if (decoded.type !== "nsec") { console.error(chalk.red("Invalid nsec")); process.exit(1); }
+    const pubkeyHex = getPublicKey(decoded.data as Uint8Array);
+
+    console.log(chalk.dim("  Fetching profile metadata from relays..."));
+    const { event, metadata } = await fetchLatestProfileEvent(pubkeyHex, profile.relays ?? []);
+
+    if (!event) {
+      console.log(chalk.yellow("No kind:0 profile event found on relays."));
+      process.exit(0);
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(event, null, 2));
+    } else {
+      const npub = nip19.npubEncode(pubkeyHex);
+      console.log(chalk.bold(`Profile: ${profileName}`));
+      console.log(`  npub:         ${npub}`);
+      if (metadata.name) console.log(`  name:         ${metadata.name}`);
+      if (metadata.displayName || (metadata as any).display_name) console.log(`  display_name: ${metadata.displayName ?? (metadata as any).display_name}`);
+      if (metadata.about) console.log(`  about:        ${metadata.about}`);
+      if (metadata.picture) console.log(`  picture:      ${metadata.picture}`);
+      if (metadata.banner) console.log(`  banner:       ${metadata.banner}`);
+      if (metadata.nip05) console.log(`  nip05:        ${metadata.nip05}`);
+      if (metadata.website) console.log(`  website:      ${metadata.website}`);
+      if (metadata.lud16) console.log(`  lud16:        ${metadata.lud16}`);
+      console.log(chalk.dim(`  (event id: ${event.id?.slice(0, 8)}..., created_at: ${new Date((event.created_at ?? 0) * 1000).toISOString()})`));
+    }
     process.exit(0);
   });
 

--- a/taskify-cli/src/nip96Upload.ts
+++ b/taskify-cli/src/nip96Upload.ts
@@ -1,0 +1,142 @@
+/**
+ * nip96Upload.ts — NIP-96 file upload for Taskify CLI.
+ * Ported from taskify-pwa/src/nostr/Nip96Client.ts
+ */
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+import { nip19 } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils";
+
+const NIP96_DISCOVERY_PATH = "/.well-known/nostr/nip96.json";
+
+type Nip96Info = {
+  baseUrl: string;
+  apiUrl: string;
+};
+
+async function discoverNip96Server(serverUrl: string, depth = 0): Promise<Nip96Info> {
+  const baseUrl = serverUrl.replace(/\/$/, "");
+  if (depth > 3) throw new Error("NIP-96 discovery redirected too many times.");
+  const res = await fetch(`${baseUrl}${NIP96_DISCOVERY_PATH}`);
+  if (!res.ok) throw new Error(`Failed to load NIP-96 info (${res.status})`);
+  const data = await res.json() as Record<string, unknown>;
+  if (!data || typeof data !== "object") throw new Error("Invalid NIP-96 discovery response");
+  const apiUrl = typeof data.api_url === "string" ? data.api_url.trim() : "";
+  if (!apiUrl) throw new Error("NIP-96 api_url missing from discovery response");
+  // Handle relative api_url
+  const resolved = apiUrl.startsWith("http") ? apiUrl : `${baseUrl}${apiUrl}`;
+  return { baseUrl, apiUrl: resolved };
+}
+
+function buildNip98AuthHeader(
+  url: string,
+  method: string,
+  payloadHash: string,
+  nsec: string,
+): string {
+  const decoded = nip19.decode(nsec);
+  if (decoded.type !== "nsec") throw new Error("Invalid nsec for NIP-98 auth.");
+  const sk = decoded.data as Uint8Array;
+
+  // Build a NIP-98 auth event (kind 27235) and base64-encode it
+  const { getPublicKey, finalizeEvent } = require("nostr-tools") as typeof import("nostr-tools");
+  const pubkey = getPublicKey(sk);
+  const event = finalizeEvent(
+    {
+      kind: 27235,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ["u", url],
+        ["method", method],
+        ["payload", payloadHash],
+      ],
+      content: "",
+    },
+    sk,
+  );
+  return `Nostr ${Buffer.from(JSON.stringify(event)).toString("base64")}`;
+}
+
+function mimeTypeFromPath(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  const map: Record<string, string> = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".avif": "image/avif",
+    ".svg": "image/svg+xml",
+  };
+  return map[ext] ?? "application/octet-stream";
+}
+
+/** Upload a local image file to a NIP-96 server. Returns the public URL. */
+export async function uploadImageToNip96(opts: {
+  serverUrl: string;
+  filePath: string;
+  nsec: string;
+  timeoutMs?: number;
+}): Promise<string> {
+  const info = await discoverNip96Server(opts.serverUrl);
+  const bytes = await readFile(opts.filePath);
+  const hash = createHash("sha256").update(bytes).digest("hex");
+  const contentType = mimeTypeFromPath(opts.filePath);
+  const filename = opts.filePath.split("/").pop() ?? "avatar";
+
+  const authHeader = buildNip98AuthHeader(info.apiUrl, "POST", hash, opts.nsec);
+
+  const form = new FormData();
+  const blob = new Blob([bytes], { type: contentType });
+  form.append("file", blob, filename);
+  form.append("media_type", "avatar");
+  form.append("content_type", contentType);
+  form.append("size", String(bytes.length));
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30_000);
+
+  let res: Response;
+  try {
+    res = await fetch(info.apiUrl, {
+      method: "POST",
+      headers: { Authorization: authHeader },
+      body: form,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let data: Record<string, unknown> = {};
+  try { data = await res.json() as Record<string, unknown>; } catch {}
+
+  // Handle async processing (202 + processing_url)
+  if (res.status === 202 && typeof data.processing_url === "string") {
+    const processingUrl = new URL(data.processing_url, info.apiUrl).toString();
+    const deadline = Date.now() + (opts.timeoutMs ?? 30_000);
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1_500));
+      const poll = await fetch(processingUrl, { headers: { Authorization: authHeader } });
+      let pollData: Record<string, unknown> = {};
+      try { pollData = await poll.json() as Record<string, unknown>; } catch {}
+      if (poll.status === 200 || poll.status === 201) {
+        data = pollData;
+        break;
+      }
+    }
+  } else if (!res.ok) {
+    throw new Error((data.message as string) ?? `Upload failed (${res.status})`);
+  }
+
+  // Extract URL from response
+  const url =
+    (data.url as string | undefined) ??
+    ((data.nip94_event as any)?.tags?.find((t: string[]) => t[0] === "url")?.[1] as string | undefined) ??
+    ((data.nip94 as any)?.tags?.find((t: string[]) => t[0] === "url")?.[1] as string | undefined);
+
+  if (!url) throw new Error("NIP-96 upload response did not include a file URL.");
+  return url;
+}

--- a/taskify-cli/src/nostrRuntime.ts
+++ b/taskify-cli/src/nostrRuntime.ts
@@ -85,7 +85,7 @@ function recordToCache(r: FullTaskRecord): CachedTask {
     title: r.title,
     boardId: r.boardId,
     boardName: r.boardName,
-    status: r.completed ? "done" : "open",
+    status: r.deleted ? "deleted" : r.completed ? "done" : "open",
     updatedAt: r.createdAt,
     note: r.note,
     dueISO: r.dueISO,
@@ -105,6 +105,7 @@ function recordToCache(r: FullTaskRecord): CachedTask {
     inboxItem: r.inboxItem,
     assignees: r.assignees,
     documents: r.documents,
+    deleted: r.deleted,
   };
 }
 
@@ -135,6 +136,7 @@ function cacheToRecord(t: CachedTask, boardName?: string): FullTaskRecord {
     inboxItem: t.inboxItem,
     assignees: t.assignees as TaskAssignee[] | undefined,
     documents: t.documents as Record<string, unknown>[] | undefined,
+    deleted: t.status === "deleted",
   };
 }
 
@@ -172,6 +174,7 @@ export type FullTaskRecord = {
   longestStreak?: number;
   seriesId?: string;
   images?: string[];
+  deleted?: boolean;
 };
 
 export type ExtendedCreateInput = AgentTaskCreateInput & {
@@ -273,6 +276,7 @@ async function parseDecryptedEvent(
     if (!taskId) return null;
     const statusVal = readStatusTag(event.tags, "open");
     const completed = statusVal === "done";
+    const deleted = statusVal === "deleted";
     const column = readTagValue(event.tags, "col") || undefined;
     return {
       id: taskId,
@@ -287,9 +291,11 @@ async function parseDecryptedEvent(
       completed,
       completedAt: payload.completedAt ?? undefined,
       // payload.createdAt is ms; convert to seconds for render compat
-      createdAt: payload.createdAt
-        ? Math.floor(payload.createdAt / 1000)
-        : event.created_at,
+      // Use relay event timestamp for merge ordering/version selection.
+      // payload.createdAt is the original task creation time and does NOT change
+      // on edits/completions, so using it causes stale open versions to beat
+      // newer done/updated versions during incremental sync merges.
+      createdAt: event.created_at ?? (payload.createdAt ? Math.floor(payload.createdAt / 1000) : undefined),
       updatedAt: event.created_at
         ? new Date(event.created_at * 1000).toISOString()
         : undefined,
@@ -327,6 +333,7 @@ async function parseDecryptedEvent(
       seriesId: typeof payload.seriesId === "string" ? payload.seriesId : undefined,
       completedBy: payload.completedBy ?? undefined,
       images: Array.isArray(payload.images) ? payload.images as string[] : undefined,
+      deleted,
     };
   } catch {
     return null;
@@ -755,6 +762,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
               if (seen.has(record.id)) continue;
               seen.add(record.id);
               record.sourceBoardId = childId;
+              if (record.deleted) continue;
               if (status === "open" && record.completed) continue;
               if (status === "done" && !record.completed) continue;
               if (columnId !== undefined && record.column !== columnId) continue;
@@ -778,6 +786,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
           if (isCacheFresh(boardCache)) {
             for (const t of boardCache.tasks) {
               const rec = cacheToRecord(t, board.name);
+              if (rec.deleted) continue;
               if (status === "open" && rec.completed) continue;
               if (status === "done" && !rec.completed) continue;
               if (columnId !== undefined && rec.column !== columnId) continue;
@@ -818,6 +827,8 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
           // Incremental: merge incoming over the existing cache
           const byId = new Map<string, FullTaskRecord>();
           for (const t of boardCache.tasks) byId.set(t.id, cacheToRecord(t, board.name));
+          // If the latest incoming version is deleted, keep it in the merge map so it
+          // suppresses older cached open/done versions. Filtering happens later.
           for (const r of incomingRecords) {
             const existing = byId.get(r.id);
             if (!existing || (r.createdAt ?? 0) >= (existing.createdAt ?? 0)) {
@@ -838,6 +849,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
             // A3: cache ≤ 10 min old — silently fall back
             for (const t of boardCache.tasks) {
               const rec = cacheToRecord(t, board.name);
+              if (rec.deleted) continue;
               if (status === "open" && rec.completed) continue;
               if (status === "done" && !rec.completed) continue;
               if (columnId !== undefined && rec.column !== columnId) continue;
@@ -849,6 +861,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
             process.stderr.write("⚠ Relay returned 0 tasks — keeping cached results\n");
             for (const t of boardCache.tasks) {
               const rec = cacheToRecord(t, board.name);
+              if (rec.deleted) continue;
               if (status === "open" && rec.completed) continue;
               if (status === "done" && !rec.completed) continue;
               if (columnId !== undefined && rec.column !== columnId) continue;
@@ -867,6 +880,7 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
 
         // Filter for the caller
         for (const record of mergedRecords) {
+          if (record.deleted) continue;
           if (columnId !== undefined && record.column !== columnId) continue;
           if (status === "open" && record.completed) continue;
           if (status === "done" && !record.completed) continue;
@@ -892,9 +906,17 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
       const out: FullEventRecord[] = [];
       for (const board of boards) {
         const events = await fetchBoardCalendarEvents(board.id);
+        const latestById = new Map<string, FullEventRecord>();
         for (const evt of events) {
           const parsed = await parseDecryptedCalendarEvent(evt, board.id, board.name);
-          if (!parsed || parsed.deleted) continue;
+          if (!parsed) continue;
+          const existing = latestById.get(parsed.id);
+          if (!existing || (parsed.createdAt ?? 0) >= (existing.createdAt ?? 0)) {
+            latestById.set(parsed.id, parsed);
+          }
+        }
+        for (const parsed of latestById.values()) {
+          if (parsed.deleted) continue;
           out.push(parsed);
         }
       }
@@ -918,10 +940,14 @@ export function createNostrRuntime(config: TaskifyConfig): NostrRuntime {
         if (!resolvedId) continue;
         const events = await fetchBoardCalendarEvents(board.id, resolvedId);
         if (events.size === 0) continue;
-        const [evt] = events;
-        const parsed = await parseDecryptedCalendarEvent(evt, board.id, board.name);
-        if (!parsed || parsed.deleted) continue;
-        matches.push(parsed);
+        let latest: FullEventRecord | null = null;
+        for (const evt of events) {
+          const parsed = await parseDecryptedCalendarEvent(evt, board.id, board.name);
+          if (!parsed) continue;
+          if (!latest || (parsed.createdAt ?? 0) >= (latest.createdAt ?? 0)) latest = parsed;
+        }
+        if (!latest || latest.deleted) continue;
+        matches.push(latest);
       }
 
       if (matches.length === 0) return null;

--- a/taskify-cli/src/profileMeta.ts
+++ b/taskify-cli/src/profileMeta.ts
@@ -1,0 +1,159 @@
+/**
+ * profileMeta.ts — kind:0 profile metadata publish/fetch for Taskify CLI.
+ * Ported from taskify-pwa/src/nostr/ProfilePublisher.ts
+ */
+
+import NDK, { NDKPrivateKeySigner, NDKEvent } from "@nostr-dev-kit/ndk";
+import { nip19, getPublicKey } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils";
+import { normalizeRelayUrls } from "taskify-runtime-nostr";
+import type { NostrEvent } from "nostr-tools";
+
+export type ProfileMetadataDraft = {
+  name?: string;
+  displayName?: string;
+  about?: string;
+  picture?: string;
+  banner?: string;
+  website?: string;
+  nip05?: string;
+  lud16?: string;
+};
+
+export type ProfileMetadata = ProfileMetadataDraft & {
+  [key: string]: string | undefined;
+};
+
+function buildProfileContent(
+  existing: Record<string, unknown>,
+  draft: ProfileMetadataDraft,
+): Record<string, string> {
+  // Start from existing fields so we never wipe fields we didn't touch
+  const content: Record<string, string> = {};
+  for (const [k, v] of Object.entries(existing)) {
+    if (typeof v === "string") content[k] = v;
+  }
+
+  const set = (key: string, value: string | undefined) => {
+    if (value === undefined) return;
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      delete content[key];
+    } else {
+      content[key] = trimmed;
+    }
+  };
+
+  set("name", draft.name);
+  set("display_name", draft.displayName);
+  set("about", draft.about);
+  set("picture", draft.picture);
+  set("banner", draft.banner);
+  set("website", draft.website);
+  set("nip05", draft.nip05);
+  set("lud16", draft.lud16);
+
+  return content;
+}
+
+/** Fetch the latest kind:0 event for a pubkey from relays. */
+export async function fetchLatestProfileEvent(
+  pubkeyHex: string,
+  relays: string[],
+  timeoutMs = 8_000,
+): Promise<{ event: NostrEvent | null; metadata: ProfileMetadata }> {
+  const relayList = normalizeRelayUrls(relays);
+  const ndk = new NDK({ explicitRelayUrls: relayList });
+  await Promise.race([ndk.connect(), new Promise<void>((r) => setTimeout(r, 3_000))]);
+
+  const events = await Promise.race<Set<NDKEvent>>([
+    ndk.fetchEvents({ kinds: [0], authors: [pubkeyHex], limit: 1 } as any),
+    new Promise<Set<NDKEvent>>((r) => setTimeout(() => r(new Set()), timeoutMs)),
+  ]).catch(() => new Set<NDKEvent>());
+
+  if (!events.size) return { event: null, metadata: {} };
+
+  // Pick highest created_at
+  let latest: NDKEvent | null = null;
+  for (const ev of events) {
+    if (!latest || (ev.created_at ?? 0) > (latest.created_at ?? 0)) latest = ev;
+  }
+  if (!latest) return { event: null, metadata: {} };
+
+  const raw = latest.rawEvent?.() as NostrEvent ?? (latest as unknown as NostrEvent);
+  let metadata: ProfileMetadata = {};
+  try {
+    metadata = JSON.parse(raw.content ?? "{}");
+  } catch {
+    // ignore
+  }
+  return { event: raw, metadata };
+}
+
+export type PublishProfileResult = {
+  event: NostrEvent;
+  previous: NostrEvent | null;
+  deletedIds: string[];
+};
+
+/** Publish a kind:0 profile metadata event. Deletes the previous event (kind:5). */
+export async function publishProfile(
+  nsec: string,
+  draft: ProfileMetadataDraft,
+  relays: string[],
+  opts?: { timeoutMs?: number; reason?: string },
+): Promise<PublishProfileResult> {
+  const relayList = normalizeRelayUrls(relays);
+  if (!relayList.length) throw new Error("No relays configured.");
+
+  const decoded = nip19.decode(nsec);
+  if (decoded.type !== "nsec") throw new Error("Invalid nsec.");
+  const sk = decoded.data as Uint8Array;
+  const pubkeyHex = getPublicKey(sk);
+  const skHex = bytesToHex(sk);
+
+  const ndk = new NDK({
+    explicitRelayUrls: relayList,
+    signer: new NDKPrivateKeySigner(skHex),
+  });
+  await Promise.race([ndk.connect(), new Promise<void>((r) => setTimeout(r, 3_000))]);
+
+  // Fetch current kind:0 to merge with
+  const { event: previous, metadata: existingMeta } = await fetchLatestProfileEvent(
+    pubkeyHex,
+    relayList,
+    opts?.timeoutMs ?? 8_000,
+  );
+
+  const content = buildProfileContent(existingMeta as Record<string, unknown>, draft);
+
+  const profileEvent = new NDKEvent(ndk);
+  profileEvent.kind = 0;
+  profileEvent.content = JSON.stringify(content);
+  profileEvent.tags = [];
+  profileEvent.created_at = Math.floor(Date.now() / 1000);
+  await profileEvent.sign();
+  await profileEvent.publish();
+
+  const raw = profileEvent.rawEvent?.() as NostrEvent ?? (profileEvent as unknown as NostrEvent);
+  if (!raw?.id) throw new Error("Failed to publish profile — no event id returned.");
+
+  // Delete the previous event (NIP-09 kind:5)
+  const deletedIds: string[] = [];
+  if (previous?.id && previous.id !== raw.id) {
+    try {
+      const deleteEvent = new NDKEvent(ndk);
+      deleteEvent.kind = 5;
+      deleteEvent.content = opts?.reason ?? "superseded profile metadata";
+      deleteEvent.tags = [["e", previous.id], ["k", "0"]];
+      deleteEvent.created_at = Math.floor(Date.now() / 1000);
+      await deleteEvent.sign();
+      await deleteEvent.publish();
+      deletedIds.push(previous.id);
+    } catch {
+      // Non-fatal — deletion is best-effort
+    }
+  }
+
+  return { event: raw, previous: previous ?? null, deletedIds };
+}

--- a/taskify-cli/src/taskCache.ts
+++ b/taskify-cli/src/taskCache.ts
@@ -35,6 +35,7 @@ export type CachedTask = {
   inboxItem?: boolean;
   assignees?: Array<{ pubkey: string; relay?: string; status?: "pending" | "accepted" | "declined" | "tentative"; respondedAt?: number }>;
   documents?: Record<string, unknown>[];
+  deleted?: boolean;
 };
 
 export type BoardCache = {

--- a/taskify-cli/tests/sync-regressions.test.ts
+++ b/taskify-cli/tests/sync-regressions.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const RUNTIME = readFileSync(path.resolve(import.meta.dirname, "../src/nostrRuntime.ts"), "utf8");
+
+test("task parser preserves deleted status instead of treating it as open", () => {
+  assert.match(RUNTIME, /const statusVal = readStatusTag\(event\.tags, "open"\)/);
+  assert.match(RUNTIME, /const deleted = statusVal === "deleted"/);
+  assert.match(RUNTIME, /deleted,/);
+});
+
+test("cache serialization preserves deleted task state", () => {
+  assert.match(RUNTIME, /status: r\.deleted \? "deleted" : r\.completed \? "done" : "open"/);
+  assert.match(RUNTIME, /deleted: t\.status === "deleted"/);
+});
+
+test("listTasks filters deleted tasks from merged and cached outputs", () => {
+  const deletedFilterCount = (RUNTIME.match(/if \(rec\.deleted\) continue;/g) ?? []).length + (RUNTIME.match(/if \(record\.deleted\) continue;/g) ?? []).length;
+  assert.ok(deletedFilterCount >= 4, `expected multiple deleted-task filters, got ${deletedFilterCount}`);
+});
+
+test("task merge ordering uses relay event created_at rather than payload.createdAt", () => {
+  assert.match(RUNTIME, /createdAt: event\.created_at \?\?/);
+});
+
+test("calendar list/get pick the latest event version by id", () => {
+  assert.match(RUNTIME, /const latestById = new Map<string, FullEventRecord>\(\)/);
+  assert.match(RUNTIME, /if \(!existing \|\| \(parsed\.createdAt \?\? 0\) >= \(existing\.createdAt \?\? 0\)\)/);
+  assert.match(RUNTIME, /let latest: FullEventRecord \| null = null;/);
+  assert.match(RUNTIME, /if \(!latest \|\| \(parsed\.createdAt \?\? 0\) >= \(latest\.createdAt \?\? 0\)\) latest = parsed;/);
+});


### PR DESCRIPTION
## Summary\n- suppress deleted tasks in CLI list/sync results\n- use relay event timestamps for task version ordering\n- pick latest calendar/event version by id\n- add regression tests for deleted-task and latest-version sync behavior\n\n## User-visible fix\nThis fixes Herald daily brief pulling stale deleted tasks from Taskify Personal schedule, and fixes Important dates showing older event versions (for example Nora's birthday showing Mar 16 instead of Mar 21).\n\n## Verification\n- reproduced against Herald profile + affected boards\n- confirmed raw relay events for stale tasks were \n- verified affected tasks no longer appear after cache clear + resync\n- verified Nora's birthday resolves to Mar 21\n-  => 119/119 pass\n