### PR TITLE
feat(voice): dictation flow + refined final-pass extraction

### DIFF
--- a/taskify-pwa/src/nostr/useVoiceSession.ts
+++ b/taskify-pwa/src/nostr/useVoiceSession.ts
@@ -309,26 +309,26 @@ export type UseVoiceSessionResult = {
 // Main hook
 // ─────────────────────────────────────────────────────────────────────────────
 
-const EXTRACT_DEBOUNCE_MS = 1500;
-
 export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessionResult {
   const { workerBaseUrl, npub, defaultBoardId, onSave } = options;
   const [session, dispatch] = useReducer(voiceSessionReducer, INITIAL_VOICE_SESSION);
 
   const recRef = useRef<SpeechRecognition | null>(null);
-  const extractDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sessionStartRef = useRef<number>(0);
   const inFlightRef = useRef<boolean>(false);
   const transcriptRef = useRef<string>("");
+  const interimRef = useRef<string>("");
   const candidatesRef = useRef<TaskCandidate[]>([]);
   const quotaExhaustedRef = useRef<boolean>(false);
+  const extractedOnceRef = useRef<boolean>(false);
 
   // Keep refs in sync with state for use in callbacks
   useEffect(() => {
     transcriptRef.current = session.transcript;
+    interimRef.current = session.interimTranscript;
     candidatesRef.current = session.candidates;
     quotaExhaustedRef.current = session.quotaExhausted;
-  }, [session.transcript, session.candidates, session.quotaExhausted]);
+  }, [session.transcript, session.interimTranscript, session.candidates, session.quotaExhausted]);
 
   const callExtract = useCallback(
     async (transcript: string) => {
@@ -375,15 +375,13 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     [workerBaseUrl, npub],
   );
 
-  const scheduleExtract = useCallback(
-    (transcript: string) => {
-      if (extractDebounceRef.current) clearTimeout(extractDebounceRef.current);
-      extractDebounceRef.current = setTimeout(() => {
-        callExtract(transcript);
-      }, EXTRACT_DEBOUNCE_MS);
-    },
-    [callExtract],
-  );
+  const runFinalExtractPass = useCallback(async () => {
+    if (extractedOnceRef.current) return;
+    const finalTranscript = [transcriptRef.current, interimRef.current].filter(Boolean).join(" ").trim();
+    if (!finalTranscript) return;
+    extractedOnceRef.current = true;
+    await callExtract(finalTranscript);
+  }, [callExtract]);
 
   const startListening = useCallback(() => {
     if (recRef.current) return; // already running
@@ -391,6 +389,9 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     if (!rec) return;
 
     sessionStartRef.current = Date.now();
+    extractedOnceRef.current = false;
+    transcriptRef.current = "";
+    interimRef.current = "";
     recRef.current = rec;
 
     rec.onresult = (event: SpeechRecognitionEvent) => {
@@ -400,13 +401,12 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
         const text = result[0]?.transcript ?? "";
         if (result.isFinal) {
           dispatch({ type: "COMMIT_TRANSCRIPT", text });
-          // Use the accumulated transcript for extraction
-          const full = (transcriptRef.current ? transcriptRef.current + " " : "") + text;
-          scheduleExtract(full);
+          transcriptRef.current = [transcriptRef.current, text].filter(Boolean).join(" ").trim();
         } else {
           interim += text;
         }
       }
+      interimRef.current = interim;
       dispatch({ type: "SET_INTERIM", text: interim });
     };
 
@@ -418,26 +418,26 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     rec.onend = () => {
       dispatch({ type: "SET_LISTENING", value: false });
       recRef.current = null;
+      void runFinalExtractPass();
     };
 
     rec.start();
     dispatch({ type: "SET_LISTENING", value: true });
-  }, [scheduleExtract]);
+  }, [runFinalExtractPass]);
 
   const stopListening = useCallback(() => {
-    if (extractDebounceRef.current) clearTimeout(extractDebounceRef.current);
     recRef.current?.stop();
     recRef.current = null;
     dispatch({ type: "SET_LISTENING", value: false });
     dispatch({ type: "SET_INTERIM", text: "" });
-  }, []);
+    void runFinalExtractPass();
+  }, [runFinalExtractPass]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       recRef.current?.abort();
       recRef.current = null;
-      if (extractDebounceRef.current) clearTimeout(extractDebounceRef.current);
     };
   }, []);
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -163,8 +163,8 @@ const BACKUP_CLEANUP_STATE_KEY = "backups-cleanup-state.json";
 
 const VOICE_MAX_SESSIONS_PER_DAY = 5;
 const VOICE_MAX_SECONDS_PER_DAY = 300;
-const GEMINI_EXTRACT_URL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
+const GEMINI_MODEL_PRIMARY = "gemini-3.1-flash";
+const GEMINI_MODEL_FALLBACK = "gemini-2.0-flash";
 
 type TaskCandidate = {
   id: string;
@@ -3017,35 +3017,49 @@ async function incrementVoiceQuota(db: D1Database, npub: string, date: string, a
  * text part. Returns null on any error (network, parse, unexpected shape).
  */
 async function callGemini(apiKey: string, prompt: string): Promise<unknown | null> {
-  let response: Response;
-  try {
-    response = await fetch(`${GEMINI_EXTRACT_URL}?key=${apiKey}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { temperature: 0.1, maxOutputTokens: 1024 },
-      }),
-    });
-  } catch {
-    return null;
+  const models = [GEMINI_MODEL_PRIMARY, GEMINI_MODEL_FALLBACK];
+
+  for (const model of models) {
+    let response: Response;
+    try {
+      response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: {
+              temperature: 0.1,
+              maxOutputTokens: 1024,
+              responseMimeType: "application/json",
+            },
+          }),
+        },
+      );
+    } catch {
+      continue;
+    }
+
+    if (!response.ok) continue;
+
+    let json: unknown;
+    try {
+      json = await response.json();
+    } catch {
+      continue;
+    }
+    const text = (json as any)?.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (typeof text !== "string") continue;
+    const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+    try {
+      return JSON.parse(stripped);
+    } catch {
+      continue;
+    }
   }
-  if (!response.ok) return null;
-  let json: unknown;
-  try {
-    json = await response.json();
-  } catch {
-    return null;
-  }
-  const text = (json as any)?.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (typeof text !== "string") return null;
-  // Strip markdown code fences if Gemini wraps output
-  const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
-  try {
-    return JSON.parse(stripped);
-  } catch {
-    return null;
-  }
+
+  return null;
 }
 
 async function handleVoiceExtract(request: Request, env: Env): Promise<Response> {
@@ -3084,23 +3098,27 @@ async function handleVoiceExtract(request: Request, env: Env): Promise<Response>
     );
   }
 
-  const prompt = `You are a voice task extraction assistant. Given a voice transcript, extract task operations.
+  const prompt = `You are a voice task extraction assistant. Given one full voice transcript, extract clean task operations.
 
 Current candidates: ${JSON.stringify(candidates)}
 
 Transcript: "${transcript}"
 
-Return a JSON object with shape: { "operations": Array<TaskOperation> }
+Return ONLY JSON with shape: { "operations": Array<TaskOperation> }
 
-Where TaskOperation has type: "create_task" | "update_task" | "delete_task" | "mark_uncertain"
-Fields: type (required), title (string), dueText (string, verbatim from transcript), targetRef (string, e.g. "last_task"), changes (object with title/dueText/boardId)
+TaskOperation type is one of: "create_task" | "update_task" | "delete_task" | "mark_uncertain".
+Fields allowed: type, title, dueText, targetRef, changes.
 
-Rules:
-- create_task: new task mentioned
-- update_task: correction of existing task, use targetRef "last_task" to reference most recent
-- delete_task: user says "never mind", "remove", "cancel that", "scratch that"
-- mark_uncertain: unclear/ambiguous intent
-Keep titles concise. Return ONLY valid JSON. No markdown.`;
+Critical rules:
+- Prefer fewer, higher-quality tasks over fragmented clauses.
+- Do NOT emit filler fragments like "I", "also", "then" as tasks.
+- Merge related clauses into one task when they refer to the same action.
+- Preserve useful time/date phrases in dueText (e.g. "5 PM", "tomorrow").
+- Use concise imperative titles (e.g. "Go to the store", "Categorize church transactions").
+- If a phrase is not a task, ignore it.
+- If intent is unclear, use mark_uncertain.
+
+Output JSON only. No markdown, no prose.`;
 
   const result = await callGemini(env.GEMINI_API_KEY, prompt);
   let operations: TaskOperation[];


### PR DESCRIPTION
## Summary
This PR delivers the first full voice dictation flow and the refinement pass from testing feedback.

### Voice feature
- Add Worker endpoints:
  - `POST /api/voice/extract`
  - `POST /api/voice/finalize`
- Add D1 migration for quota tracking:
  - `worker/migrations/0002_voice_quota.sql` (`voice_quota` table)
- Add complete voice session hook + reducer tests
- Add `VoiceDictationModal` review flow with selective save
- Add add-task menu action sheet (`+ New Task` / `Dictate`)

### Refinements from live testing
- Switch to Gemini model strategy:
  - primary: `gemini-3.1-flash`
  - fallback: `gemini-2.0-flash`
- Move from live snippet extraction to **single final extraction pass** at end of dictation
- Tighten extraction prompt to reduce fragmented/non-task outputs

## Validation
- Worker tests: pass
- `useVoiceSession` reducer tests: pass

## Notes
- `GEMINI_API_KEY` must be configured as Worker secret
- D1 migration required (applied via dashboard SQL console or Wrangler)
