### PR TITLE
chore(voice): follow-up retest PR

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -14420,6 +14420,7 @@ export default function App() {
     for (const ft of finalTasks) {
       if (!ft.title?.trim()) continue;
       const nextOrder = nextOrderForBoard(targetBoardId, [...tasks, ...newTasks], settings.newTaskPosition);
+      const hasExplicitVoiceDue = typeof ft.dueISO === "string" && !!ft.dueISO.trim();
       const task: Task = {
         id: crypto.randomUUID(),
         boardId: ft.boardId ?? targetBoardId,
@@ -14429,6 +14430,7 @@ export default function App() {
         createdAt: Date.now(),
         dueISO: ft.dueISO ?? dueISOBase,
         dueDateEnabled: !!(ft.dueISO || currentBoard.kind === "week"),
+        dueTimeEnabled: hasExplicitVoiceDue,
         completed: false,
         order: nextOrder,
       };

--- a/taskify-pwa/src/nostr/useVoiceSession.test.ts
+++ b/taskify-pwa/src/nostr/useVoiceSession.test.ts
@@ -63,8 +63,8 @@ test("COMMIT_TRANSCRIPT accumulates multiple final transcripts with a space sepa
   assert.equal(s.transcript, "call dentist friday also pick up groceries");
 });
 
-// Test 5: APPLY_OPERATIONS create_task appends a draft candidate
-test("APPLY_OPERATIONS create_task appends new draft candidate", () => {
+// Test 5: APPLY_OPERATIONS create_task appends a pre-selected candidate
+test("APPLY_OPERATIONS create_task appends new confirmed candidate", () => {
   const state = dispatch(INITIAL_VOICE_SESSION, {
     type: "APPLY_OPERATIONS",
     operations: [{ type: "create_task", title: "Call dentist", dueText: "friday 2pm" }],
@@ -72,7 +72,7 @@ test("APPLY_OPERATIONS create_task appends new draft candidate", () => {
   assert.equal(state.candidates.length, 1);
   assert.equal(state.candidates[0].title, "Call dentist");
   assert.equal(state.candidates[0].dueText, "friday 2pm");
-  assert.equal(state.candidates[0].status, "draft");
+  assert.equal(state.candidates[0].status, "confirmed");
   assert.ok(typeof state.candidates[0].id === "string", "id should be assigned");
   assert.ok(state.candidates[0].id.length > 0);
 });
@@ -151,7 +151,7 @@ test("DISMISS_CANDIDATE sets the target candidate status to dismissed", () => {
   const idB = s.candidates[1].id;
   s = dispatch(s, { type: "DISMISS_CANDIDATE", id: idA });
   assert.equal(s.candidates[0].status, "dismissed");
-  assert.equal(s.candidates[1].status, "draft", "other candidates unaffected");
+  assert.equal(s.candidates[1].status, "confirmed", "other candidates unaffected");
   assert.equal(s.candidates[1].id, idB);
 });
 
@@ -214,9 +214,9 @@ test("APPLY_OPERATIONS applies multiple operations in sequence within one action
   });
   assert.equal(state.candidates.length, 3);
   assert.equal(state.candidates[0].title, "Task A");
-  assert.equal(state.candidates[0].status, "draft");
+  assert.equal(state.candidates[0].status, "confirmed");
   assert.equal(state.candidates[1].title, "Task B");
-  assert.equal(state.candidates[1].status, "draft");
+  assert.equal(state.candidates[1].status, "confirmed");
   assert.equal(state.candidates[2].title, "Task C");
   assert.equal(state.candidates[2].status, "dismissed");
 });

--- a/taskify-pwa/src/nostr/useVoiceSession.ts
+++ b/taskify-pwa/src/nostr/useVoiceSession.ts
@@ -96,7 +96,7 @@ function applyOperation(candidates: TaskCandidate[], op: TaskOperation): TaskCan
         dueText: op.dueText,
         subtasks: op.subtasks,
         boardId: op.changes?.boardId,
-        status: "draft",
+        status: "confirmed",
       };
       return [...candidates, newCandidate];
     }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3012,7 +3012,7 @@ function isGarbageTaskTitle(title: string): boolean {
 function cleanupTaskTitle(raw: string): string {
   let title = raw.trim();
   title = title.replace(/^(?:and\s+then|and|then|also)\s+/i, "");
-  title = title.replace(/^(?:i\s+need\s+to|i\s+have\s+to|i(?:'| a)?m\s+going\s+to)\s+/i, "");
+  title = title.replace(/^(?:i\s+need\s+to|i\s+have\s+to|i(?:'| a)?m\s+going\s+to|i\s+can(?:not|'?t)\s+forget\s+to)\s+/i, "");
   title = title.replace(/\s+/g, " ").trim();
   return title;
 }
@@ -3024,7 +3024,7 @@ function extractPickupItems(title: string): string[] {
   if (!raw) return [];
   const splitByDelims = raw.split(/,|\band\b/i).map((v) => v.trim()).filter(Boolean);
   if (splitByDelims.length > 1) return splitByDelims;
-  return raw.split(/\s+/).map((v) => v.trim()).filter((v) => v.length > 2);
+  return [];
 }
 
 function normalizeSubtasks(input: unknown): string[] | undefined {
@@ -3060,8 +3060,9 @@ function toOperationsFromStructuredTasks(result: unknown): TaskOperation[] {
     let dueText = typeof t?.dueText === "string" && t.dueText.trim() ? t.dueText.trim() : undefined;
     let subtasks = normalizeSubtasks(t?.subtasks);
 
+    const groceryContext = /grocery|groceries|store|shopping|supermarket/i.test(`${title} ${dueText ?? ""}`);
     const pickupItems = extractPickupItems(title);
-    if (pickupItems.length) {
+    if (groceryContext && pickupItems.length) {
       const prev = operations[operations.length - 1];
       if (prev?.type === "create_task" && /grocery|store|shopping/i.test(prev.title || "")) {
         prev.subtasks = dedupe([...(prev.subtasks || []), ...pickupItems]);
@@ -3069,6 +3070,12 @@ function toOperationsFromStructuredTasks(result: unknown): TaskOperation[] {
       }
       title = "Go to the grocery store";
       subtasks = dedupe([...(subtasks || []), ...pickupItems]);
+    }
+
+    const inlineDue = title.match(/\b(today|tomorrow|tonight|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i);
+    if (inlineDue && !dueText) {
+      dueText = inlineDue[1];
+      title = title.replace(new RegExp(`\\b${inlineDue[1]}\\b`, "i"), "").replace(/\s+/g, " ").trim();
     }
 
     const dayPrefix = title.match(/^(tomorrow|today|tonight|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b\s*(.*)$/i);
@@ -3083,6 +3090,7 @@ function toOperationsFromStructuredTasks(result: unknown): TaskOperation[] {
       title = `${who}'s birthday party`;
     }
 
+    if (isGarbageTaskTitle(title)) continue;
     operations.push({ type: "create_task", title, dueText, subtasks });
   }
 


### PR DESCRIPTION
## Summary
Fresh PR for retest pass of voice dictation improvements.

Includes the latest voice fixes from prior branch:
- Gemini primary model set to `gemini-3-flash-preview`
- Batch finalize response with full fields per candidate id
- Due time preservation improvements (`dueISO` reliability + fallback parser)
- Taskify save-path fix for due-time persistence (`dueTimeEnabled` handling)
- Candidate tasks selected by default (user deselect flow)
- Priority defaults to none unless explicit urgency language
- Settings toggle for test transcript input in voice modal

## Validation
- Worker tests pass (18/18)
- Voice reducer tests pass (17/17)
