### PR TITLE
chore(voice): Cloudflare fallback retest PR

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -658,8 +658,8 @@ test("POST /api/voice/extract increments quota after successful Gemini call", as
   }
 });
 
-// ── Test 6: POST /api/voice/extract — returns 429 + fallback when quota exceeded ─
-test("POST /api/voice/extract returns 429 with fallback operations when quota exceeded", async () => {
+// ── Test 6: POST /api/voice/extract — returns 429 when quota exceeded ─
+test("POST /api/voice/extract returns 429 when quota exceeded", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);
   const npub = "npub1overquota";
@@ -677,14 +677,11 @@ test("POST /api/voice/extract returns 429 with fallback operations when quota ex
   assert.equal(res.status, 429);
   const body = await res.json() as any;
   assert.equal(body.error, "quota_exceeded");
-  assert.ok(Array.isArray(body.operations), "should include fallback operations");
-  // Rule-based fallback: "call dentist" and "pick up groceries"
-  assert.ok(body.operations.length >= 1, "at least one fallback operation");
-  assert.ok(body.operations.every((op: any) => op.type === "create_task"));
+  assert.ok(typeof body.message === "string");
 });
 
-// ── Test 7: POST /api/voice/extract — Gemini failure → rule-based fallback (200) ─
-test("POST /api/voice/extract returns rule-based fallback operations when Gemini fails", async () => {
+// ── Test 7: POST /api/voice/extract — Gemini failure returns 503 ─
+test("POST /api/voice/extract returns 503 when Gemini fails", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);
 
@@ -703,10 +700,9 @@ test("POST /api/voice/extract returns rule-based fallback operations when Gemini
       }),
     });
     const res = await worker.fetch(req, env);
-    assert.equal(res.status, 200, "should return 200 with fallback even on Gemini failure");
+    assert.equal(res.status, 503, "should return 503 when Gemini is unavailable");
     const body = await res.json() as any;
-    assert.ok(Array.isArray(body.operations));
-    assert.ok(body.operations.length >= 1);
+    assert.equal(body.error, "gemini_unavailable");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -872,8 +868,8 @@ test("POST /api/voice/finalize returns normalized FinalTask array from confirmed
   }
 });
 
-// ── Test 11: POST /api/voice/finalize — Gemini failure returns title-only tasks ─
-test("POST /api/voice/finalize returns tasks with title-only when Gemini fails (no 500)", async () => {
+// ── Test 11: POST /api/voice/finalize — Gemini failure returns 503 ─
+test("POST /api/voice/finalize returns 503 when Gemini fails", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);
 
@@ -893,18 +889,15 @@ test("POST /api/voice/finalize returns tasks with title-only when Gemini fails (
       }),
     });
     const res = await worker.fetch(req, env);
-    assert.equal(res.status, 200, "must not 500 on Gemini failure");
+    assert.equal(res.status, 503, "must return 503 when Gemini is unavailable");
     const body = await res.json() as any;
-    assert.ok(Array.isArray(body.tasks));
-    assert.equal(body.tasks.length, 1);
-    assert.ok(body.tasks[0].title, "should still have title");
-    assert.equal(body.tasks[0].dueISO, undefined, "no dueISO when Gemini fails");
+    assert.equal(body.error, "gemini_unavailable");
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("POST /api/voice/finalize falls back to parse dueText time phrases when Gemini fails", async () => {
+test("POST /api/voice/finalize returns 503 (no local due parsing fallback) when Gemini fails", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);
 
@@ -926,12 +919,9 @@ test("POST /api/voice/finalize falls back to parse dueText time phrases when Gem
       }),
     });
     const res = await worker.fetch(req, env);
-    assert.equal(res.status, 200);
+    assert.equal(res.status, 503);
     const body = await res.json() as any;
-    assert.ok(Array.isArray(body.tasks));
-    assert.equal(body.tasks.length, 2);
-    assert.equal(body.tasks[0].dueISO, "2026-03-25T19:00:00.000Z");
-    assert.equal(body.tasks[1].dueISO, "2026-03-27T17:00:00.000Z");
+    assert.equal(body.error, "gemini_unavailable");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -708,6 +708,56 @@ test("POST /api/voice/extract returns 503 when Gemini fails", async () => {
   }
 });
 
+test("POST /api/voice/extract falls back to Cloudflare Workers AI when Gemini fails", async () => {
+  const db = new MockD1WithVoice();
+  const env = {
+    ...(await makeVoiceEnv(db)),
+    CLOUDFLARE_ACCOUNT_ID: "acc-123",
+    CLOUDFLARE_API_TOKEN: "cf-token",
+  } as any;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("generativelanguage.googleapis.com")) {
+      return new Response("gemini down", { status: 503 });
+    }
+    if (u.includes("/ai/run/@cf/zai-org/glm-4.7-flash")) {
+      return new Response(
+        JSON.stringify({
+          result: {
+            response: JSON.stringify({
+              tasks: [{ title: "Call dentist", dueText: "tomorrow", subtasks: [] }],
+            }),
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("", { status: 404 });
+  }) as any;
+
+  try {
+    const req = new Request("https://taskify-v2.solife.me/api/voice/extract", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        npub: "npub1abc",
+        transcript: "call dentist tomorrow",
+        candidates: [],
+        sessionDurationSeconds: 8,
+      }),
+    });
+    const res = await worker.fetch(req, env);
+    assert.equal(res.status, 200);
+    const body = await res.json() as any;
+    assert.ok(Array.isArray(body.operations));
+    assert.equal(body.operations[0].title, "Call dentist");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("POST /api/voice/extract applies correction phrases to prior task dueText", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);
@@ -869,6 +919,65 @@ test("POST /api/voice/finalize returns normalized FinalTask array from confirmed
 });
 
 // ── Test 11: POST /api/voice/finalize — Gemini failure returns 503 ─
+test("POST /api/voice/finalize falls back to Cloudflare Workers AI when Gemini fails", async () => {
+  const db = new MockD1WithVoice();
+  const env = {
+    ...(await makeVoiceEnv(db)),
+    CLOUDFLARE_ACCOUNT_ID: "acc-123",
+    CLOUDFLARE_API_TOKEN: "cf-token",
+  } as any;
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("generativelanguage.googleapis.com")) {
+      return new Response("error", { status: 503 });
+    }
+    if (u.includes("/ai/run/@cf/zai-org/glm-4.7-flash")) {
+      return new Response(
+        JSON.stringify({
+          result: {
+            response: JSON.stringify({
+              tasks: [
+                {
+                  id: "c1",
+                  title: "Call Dentist",
+                  dueISO: "2026-03-25T14:00:00.000Z",
+                  subtasks: [],
+                  notes: null,
+                  boardId: null,
+                  priority: null,
+                },
+              ],
+            }),
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("", { status: 404 });
+  }) as any;
+
+  try {
+    const req = new Request("https://taskify-v2.solife.me/api/voice/finalize", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        npub: "npub1abc",
+        candidates: [{ id: "c1", title: "call dentist", dueText: "tomorrow", status: "confirmed" }],
+        referenceDate: new Date().toISOString(),
+      }),
+    });
+    const res = await worker.fetch(req, env);
+    assert.equal(res.status, 200);
+    const body = await res.json() as any;
+    assert.ok(Array.isArray(body.tasks));
+    assert.equal(body.tasks[0].title, "Call Dentist");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("POST /api/voice/finalize returns 503 when Gemini fails", async () => {
   const db = new MockD1WithVoice();
   const env = await makeVoiceEnv(db);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -43,6 +43,8 @@ export interface Env {
   VAPID_SUBJECT: string;
   TASKIFY_BACKUPS?: R2Bucket;
   GEMINI_API_KEY?: string;
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  CLOUDFLARE_API_TOKEN?: string;
 }
 
 type PushPlatform = "ios" | "android";
@@ -3232,6 +3234,16 @@ async function incrementVoiceQuota(db: D1Database, npub: string, date: string, a
  * Call Gemini 2.0 Flash and parse the JSON embedded in the first candidate's
  * text part. Returns null on any error (network, parse, unexpected shape).
  */
+function parseJsonStringSafely(text: unknown): unknown | null {
+  if (typeof text !== "string") return null;
+  const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    return null;
+  }
+}
+
 async function callGemini(apiKey: string, prompt: string): Promise<unknown | null> {
   let response: Response;
   try {
@@ -3263,17 +3275,62 @@ async function callGemini(apiKey: string, prompt: string): Promise<unknown | nul
     return null;
   }
   const text = (json as any)?.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (typeof text !== "string") return null;
-  const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  return parseJsonStringSafely(text);
+}
+
+async function callCloudflareGlmFallback(env: Env, prompt: string): Promise<unknown | null> {
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID?.trim();
+  const apiToken = env.CLOUDFLARE_API_TOKEN?.trim();
+  if (!accountId || !apiToken) return null;
+
+  let response: Response;
   try {
-    return JSON.parse(stripped);
+    response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/@cf/zai-org/glm-4.7-flash`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiToken}`,
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: prompt }],
+          max_tokens: 1024,
+          temperature: 0.1,
+        }),
+      },
+    );
   } catch {
     return null;
   }
+
+  if (!response.ok) return null;
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    return null;
+  }
+
+  // Workers AI chat responses may place text in result.response or result.output_text
+  const text = (json as any)?.result?.response
+    ?? (json as any)?.result?.output_text
+    ?? (json as any)?.response;
+
+  return parseJsonStringSafely(text);
+}
+
+async function callVoiceModelWithFallback(env: Env, prompt: string): Promise<unknown | null> {
+  if (env.GEMINI_API_KEY) {
+    const gemini = await callGemini(env.GEMINI_API_KEY, prompt);
+    if (gemini) return gemini;
+  }
+  return callCloudflareGlmFallback(env, prompt);
 }
 
 async function handleVoiceExtract(request: Request, env: Env): Promise<Response> {
-  if (!env.GEMINI_API_KEY) {
+  if (!env.GEMINI_API_KEY && !(env.CLOUDFLARE_ACCOUNT_ID && env.CLOUDFLARE_API_TOKEN)) {
     return jsonResponse({ error: "Voice extraction is not configured" }, 501);
   }
 
@@ -3344,7 +3401,7 @@ Rules:
 
 Output JSON only.`;
 
-  const result = await callGemini(env.GEMINI_API_KEY, prompt);
+  const result = await callVoiceModelWithFallback(env, prompt);
   if (!result) {
     return jsonResponse({ error: "gemini_unavailable", message: "Voice extraction unavailable right now. Please try again later." }, 503);
   }
@@ -3364,7 +3421,7 @@ Output JSON only.`;
 }
 
 async function handleVoiceFinalize(request: Request, env: Env): Promise<Response> {
-  if (!env.GEMINI_API_KEY) {
+  if (!env.GEMINI_API_KEY && !(env.CLOUDFLARE_ACCOUNT_ID && env.CLOUDFLARE_API_TOKEN)) {
     return jsonResponse({ error: "Voice finalization is not configured" }, 501);
   }
 
@@ -3449,7 +3506,7 @@ Rules:
 - Preserve checklist-like nouns as subtasks.
 - No markdown, no prose.`;
 
-  const batchResult = await callGemini(env.GEMINI_API_KEY, batchPrompt);
+  const batchResult = await callVoiceModelWithFallback(env, batchPrompt);
   if (!batchResult) {
     return jsonResponse({ error: "gemini_unavailable", message: "Voice finalization unavailable right now. Please try again later." }, 503);
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -168,8 +168,7 @@ const VOICE_TEST_BYPASS_NPUBS = new Set([
   "npub13p5mg2wszus5nt7seldn8d6dnppvf3xqe5q2vsq076r2ysvh93eqwhgqdm",
   "npub1f4t6089m5zhljvrurfuc8ceymlr6yzrdljxz9yaskyj8r8s536ns6rv35g",
 ]);
-const GEMINI_MODEL_PRIMARY = "gemini-3-flash-preview";
-const GEMINI_MODEL_FALLBACK = "gemini-2.0-flash";
+const GEMINI_MODEL_PRIMARY = "gemini-3.1-flash-lite-preview";
 
 type TaskCandidate = {
   id: string;
@@ -3234,49 +3233,43 @@ async function incrementVoiceQuota(db: D1Database, npub: string, date: string, a
  * text part. Returns null on any error (network, parse, unexpected shape).
  */
 async function callGemini(apiKey: string, prompt: string): Promise<unknown | null> {
-  const models = [GEMINI_MODEL_PRIMARY, GEMINI_MODEL_FALLBACK];
-
-  for (const model of models) {
-    let response: Response;
-    try {
-      response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            contents: [{ parts: [{ text: prompt }] }],
-            generationConfig: {
-              temperature: 0.1,
-              maxOutputTokens: 1024,
-              responseMimeType: "application/json",
-            },
-          }),
-        },
-      );
-    } catch {
-      continue;
-    }
-
-    if (!response.ok) continue;
-
-    let json: unknown;
-    try {
-      json = await response.json();
-    } catch {
-      continue;
-    }
-    const text = (json as any)?.candidates?.[0]?.content?.parts?.[0]?.text;
-    if (typeof text !== "string") continue;
-    const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
-    try {
-      return JSON.parse(stripped);
-    } catch {
-      continue;
-    }
+  let response: Response;
+  try {
+    response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL_PRIMARY}:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: 0.1,
+            maxOutputTokens: 1024,
+            responseMimeType: "application/json",
+          },
+        }),
+      },
+    );
+  } catch {
+    return null;
   }
 
-  return null;
+  if (!response.ok) return null;
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    return null;
+  }
+  const text = (json as any)?.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (typeof text !== "string") return null;
+  const stripped = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    return null;
+  }
 }
 
 async function handleVoiceExtract(request: Request, env: Env): Promise<Response> {
@@ -3322,7 +3315,7 @@ async function handleVoiceExtract(request: Request, env: Env): Promise<Response>
 
   if (overQuota) {
     return jsonResponse(
-      { error: "quota_exceeded", operations: ruleBasedOperations(transcript) },
+      { error: "quota_exceeded", message: "Voice extraction unavailable right now. Please try again later." },
       429,
     );
   }
@@ -3352,15 +3345,14 @@ Rules:
 Output JSON only.`;
 
   const result = await callGemini(env.GEMINI_API_KEY, prompt);
-  let operations = toOperationsFromStructuredTasks(result);
-
-  if (!operations.length && result && Array.isArray((result as any).operations)) {
-    operations = (result as any).operations as TaskOperation[];
+  if (!result) {
+    return jsonResponse({ error: "gemini_unavailable", message: "Voice extraction unavailable right now. Please try again later." }, 503);
   }
 
-  if (!operations.length) {
-    // Gemini returned something unparseable — use rule-based fallback but still 200
-    operations = ruleBasedOperations(transcript);
+  let operations = toOperationsFromStructuredTasks(result);
+
+  if (!operations.length && Array.isArray((result as any).operations)) {
+    operations = (result as any).operations as TaskOperation[];
   }
 
   operations = applyTranscriptCorrections(operations, transcript);
@@ -3458,6 +3450,9 @@ Rules:
 - No markdown, no prose.`;
 
   const batchResult = await callGemini(env.GEMINI_API_KEY, batchPrompt);
+  if (!batchResult) {
+    return jsonResponse({ error: "gemini_unavailable", message: "Voice finalization unavailable right now. Please try again later." }, 503);
+  }
   const batchTasks = Array.isArray((batchResult as any)?.tasks) ? (batchResult as any).tasks as any[] : [];
   const batchById = new Map<string, any>();
   for (const t of batchTasks) {
@@ -3491,11 +3486,6 @@ Rules:
     }
     priority = parseTaskPriority(fromBatch?.priority);
     subtasks = normalizeSubtasks(fromBatch?.subtasks) ?? subtasks;
-
-    // Fallback safety: parse dueText locally if model omitted/failed date conversion
-    if (!dueISO && candidate.dueText) {
-      dueISO = parseDueTextFallback(candidate.dueText, referenceDate, referenceOffsetMinutes);
-    }
 
     tasks.push({
       title: normalizedTitle,


### PR DESCRIPTION
## Summary
Fresh PR for retesting voice dictation with Cloudflare Workers AI fallback enabled.

Includes latest voice stack changes:
- Gemini primary model: `gemini-3.1-flash-lite-preview`
- Fallback provider: Cloudflare Workers AI `@cf/zai-org/glm-4.7-flash`
- Explicit 503 try-again-later only when both providers fail
- Prior dictation extraction/refinement and UI task-card theming updates

## Validation
- Worker tests pass (21/21)
- Voice reducer tests pass (17/17)
