### PR TITLE
chore(voice): candidate-circle retest PR

### DIFF
--- a/taskify-pwa/src/components/VoiceDictationModal.tsx
+++ b/taskify-pwa/src/components/VoiceDictationModal.tsx
@@ -57,13 +57,10 @@ function MicButton({
 function CandidateCard({
   candidate,
   onDismiss,
-  onConfirm,
 }: {
   candidate: TaskCandidate;
   onDismiss: (id: string) => void;
-  onConfirm: (id: string) => void;
 }) {
-  const isConfirmed = candidate.status === "confirmed";
   const isDismissed = candidate.status === "dismissed";
 
   return (
@@ -73,15 +70,12 @@ function CandidateCard({
       data-state={isDismissed ? "completed" : undefined}
     >
       <div className="flex items-start gap-2">
-        <button
-          type="button"
-          onClick={() => (isDismissed ? onConfirm(candidate.id) : isConfirmed ? onDismiss(candidate.id) : onConfirm(candidate.id))}
-          aria-label={isConfirmed ? "Deselect task" : "Select task"}
-          className={`icon-button mt-0.5 ${isConfirmed ? "icon-button--accent" : ""}`}
-          data-active={isConfirmed ? "true" : "false"}
+        <span
+          aria-hidden="true"
+          className="icon-button mt-0.5"
         >
-          {isConfirmed ? "✓" : "○"}
-        </button>
+          ○
+        </span>
 
         <div className="flex-1 min-w-0">
           <div className={`task-card__title ${isDismissed ? "task-card__title--done" : ""}`}>
@@ -308,7 +302,6 @@ export function VoiceDictationModal({
                   key={candidate.id}
                   candidate={candidate}
                   onDismiss={dismissCandidate}
-                  onConfirm={confirmCandidate}
                 />
               ))}
             </ul>


### PR DESCRIPTION
## Summary
Fresh PR for retesting candidate-task rendering + voice fallback behavior.

Includes latest updates:
- Candidate rows use static unchecked-circle indicator (no checkmark toggle)
- Remove candidate via X action only
- Candidate due metadata in regular task style (no calendar emoji)
- Accent color alignment for mic/save/testing controls
- Gemini fallback chain before Cloudflare Workers AI fallback

## Validation
- Worker tests pass (21/21)
- Voice reducer tests pass (17/17)
