### PR TITLE
docs(legal): add hosted Privacy + Terms pages

### DIFF
--- a/taskify-pwa/public/privacy/index.html
+++ b/taskify-pwa/public/privacy/index.html
@@ -75,7 +75,7 @@
 
       <h2>9) Contact</h2>
       <p>
-        Questions about this policy: <a href="mailto:support@taskify.solife.me">support@taskify.solife.me</a>
+        Questions about this policy: <a href="mailto:support@solife.me">support@solife.me</a>
       </p>
     </main>
   </body>

--- a/taskify-pwa/public/privacy/index.html
+++ b/taskify-pwa/public/privacy/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taskify Privacy Policy</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; background: #0b0f14; color: #e8eef7; }
+      .wrap { max-width: 860px; margin: 0 auto; padding: 40px 20px 80px; line-height: 1.65; }
+      h1, h2 { line-height: 1.2; }
+      h1 { margin-bottom: 8px; }
+      .muted { color: #9fb0c7; }
+      a { color: #7cc4ff; }
+      code { background: #152132; padding: 1px 6px; border-radius: 6px; }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <h1>Taskify Privacy Policy</h1>
+      <p class="muted">Effective date: March 25, 2026</p>
+
+      <p>
+        Taskify (“we”, “our”, or “us”) provides task and calendar features, including optional Google Calendar integration.
+        This Privacy Policy explains what information we collect, how we use it, and your choices.
+      </p>
+
+      <h2>1) Information we collect</h2>
+      <ul>
+        <li><strong>Account/identity data:</strong> identifiers needed to operate Taskify (for example, app-specific public keys).</li>
+        <li><strong>Task and calendar data:</strong> tasks, events, and settings you create or sync.</li>
+        <li><strong>Google account data (optional):</strong> if you connect Google Calendar, we access your Google email address and read calendar/event data based on granted scopes.</li>
+        <li><strong>Technical data:</strong> basic logs required for reliability, debugging, and security.</li>
+      </ul>
+
+      <h2>2) How we use information</h2>
+      <ul>
+        <li>Provide and maintain Taskify features.</li>
+        <li>Sync connected calendar data into your Taskify Upcoming view.</li>
+        <li>Improve reliability, security, and performance.</li>
+        <li>Respond to support or abuse reports.</li>
+      </ul>
+
+      <h2>3) Google API data use</h2>
+      <p>
+        If you connect Google Calendar, Taskify only requests scopes required for the feature (for example,
+        <code>calendar.readonly</code> and <code>userinfo.email</code>).
+      </p>
+      <ul>
+        <li>Google data is used only to provide calendar integration functionality.</li>
+        <li>We do not sell Google user data.</li>
+        <li>We do not use Google Workspace APIs to develop, improve, or train generalized AI/ML models.</li>
+      </ul>
+
+      <h2>4) Data retention and deletion</h2>
+      <p>
+        We retain data as needed to operate Taskify and comply with legal obligations. You may disconnect Google Calendar at any time,
+        which stops future sync and removes active connection state for that integration.
+      </p>
+
+      <h2>5) Security</h2>
+      <p>
+        We apply reasonable technical and organizational safeguards, including encryption for sensitive credentials at rest and in transit.
+      </p>
+
+      <h2>6) Third-party services</h2>
+      <p>
+        Taskify may rely on third-party infrastructure providers (for example, hosting and OAuth providers) to deliver service functionality.
+      </p>
+
+      <h2>7) Children’s privacy</h2>
+      <p>Taskify is not directed to children under 13, and we do not knowingly collect personal data from children under 13.</p>
+
+      <h2>8) Changes to this policy</h2>
+      <p>We may update this policy from time to time. Material changes will be reflected by updating the effective date above.</p>
+
+      <h2>9) Contact</h2>
+      <p>
+        Questions about this policy: <a href="mailto:support@taskify.solife.me">support@taskify.solife.me</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/taskify-pwa/public/terms/index.html
+++ b/taskify-pwa/public/terms/index.html
@@ -75,7 +75,7 @@
 
       <h2>10) Contact</h2>
       <p>
-        Questions about these Terms: <a href="mailto:support@taskify.solife.me">support@taskify.solife.me</a>
+        Questions about these Terms: <a href="mailto:support@solife.me">support@solife.me</a>
       </p>
     </main>
   </body>

--- a/taskify-pwa/public/terms/index.html
+++ b/taskify-pwa/public/terms/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Taskify Terms of Service</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; background: #0b0f14; color: #e8eef7; }
+      .wrap { max-width: 860px; margin: 0 auto; padding: 40px 20px 80px; line-height: 1.65; }
+      h1, h2 { line-height: 1.2; }
+      h1 { margin-bottom: 8px; }
+      .muted { color: #9fb0c7; }
+      a { color: #7cc4ff; }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <h1>Taskify Terms of Service</h1>
+      <p class="muted">Effective date: March 25, 2026</p>
+
+      <p>
+        These Terms of Service (“Terms”) govern your use of Taskify (“Service”).
+        By using the Service, you agree to these Terms.
+      </p>
+
+      <h2>1) Use of the service</h2>
+      <ul>
+        <li>You may use Taskify only in compliance with applicable laws.</li>
+        <li>You are responsible for activity performed through your account and connected integrations.</li>
+        <li>You must not misuse, disrupt, reverse engineer, or attempt unauthorized access to the Service.</li>
+      </ul>
+
+      <h2>2) Integrations and third-party services</h2>
+      <p>
+        Taskify may connect to third-party services (such as Google Calendar) at your request.
+        Your use of third-party services is also governed by their terms and policies.
+      </p>
+
+      <h2>3) Data and content</h2>
+      <p>
+        You retain ownership of content you create in Taskify. You grant Taskify permission to process that content
+        solely to operate and improve the Service.
+      </p>
+
+      <h2>4) Availability and changes</h2>
+      <p>
+        We may modify, suspend, or discontinue features at any time. We do not guarantee uninterrupted availability.
+      </p>
+
+      <h2>5) Disclaimer</h2>
+      <p>
+        The Service is provided “as is” and “as available,” without warranties of any kind to the extent permitted by law.
+      </p>
+
+      <h2>6) Limitation of liability</h2>
+      <p>
+        To the maximum extent permitted by law, Taskify and its operators are not liable for indirect, incidental,
+        special, consequential, or punitive damages, or any loss of data, profits, or goodwill.
+      </p>
+
+      <h2>7) Termination</h2>
+      <p>
+        We may suspend or terminate access for violations of these Terms or to protect service integrity and security.
+      </p>
+
+      <h2>8) Governing law</h2>
+      <p>
+        These Terms are governed by applicable laws of your operating jurisdiction unless otherwise required by law.
+      </p>
+
+      <h2>9) Changes to these terms</h2>
+      <p>
+        We may revise these Terms from time to time. Continued use after updates constitutes acceptance of the revised Terms.
+      </p>
+
+      <h2>10) Contact</h2>
+      <p>
+        Questions about these Terms: <a href="mailto:support@taskify.solife.me">support@taskify.solife.me</a>
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Adds static legal pages required for Google OAuth consent publishing.

## Added
- taskify-pwa/public/privacy/index.html
- taskify-pwa/public/terms/index.html

## Resulting routes (after merge/deploy)
- /privacy
- /terms

This PR is intentionally scoped to legal pages only so it can merge directly to main.