### PR TITLE
fix(pwa): recover from blank-screen bootstrap failures

### DIFF
--- a/taskify-pwa/src/main.tsx
+++ b/taskify-pwa/src/main.tsx
@@ -118,8 +118,49 @@ async function bootstrapApp(): Promise<void> {
       .catch(() => {});
   }
 }
-void bootstrapApp().catch((err) => {
+async function recoverFromBootstrapFailure(err: unknown): Promise<boolean> {
+  const message = err instanceof Error ? err.message : String(err);
+  const isChunkOrImportFailure = /Failed to fetch dynamically imported module|Importing a module script failed|ChunkLoadError|Loading chunk/i.test(message);
+  if (!isChunkOrImportFailure) return false;
+
+  const RECOVERY_KEY = 'taskify_bootstrap_recovery_v1';
+  try {
+    const alreadyRecovered = sessionStorage.getItem(RECOVERY_KEY) === '1';
+    if (alreadyRecovered) return false;
+    sessionStorage.setItem(RECOVERY_KEY, '1');
+
+    if ('serviceWorker' in navigator) {
+      try {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map((reg) => reg.unregister()));
+      } catch {}
+    }
+
+    if (typeof caches !== 'undefined') {
+      try {
+        const keys = await caches.keys();
+        await Promise.all(keys.filter((k) => k.startsWith('taskify-cache-')).map((k) => caches.delete(k)));
+      } catch {}
+    }
+
+    const busted = new URL(window.location.href);
+    busted.searchParams.set('cache_bust', String(Date.now()));
+    window.location.replace(busted.toString());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+void bootstrapApp().catch(async (err) => {
   console.error('Taskify bootstrap failed', err);
+  const recovered = await recoverFromBootstrapFailure(err);
+  if (recovered) return;
+
+  const rootEl = document.getElementById('root');
+  if (rootEl) {
+    rootEl.innerHTML = '<div style="padding:20px;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;color:#111">Taskify failed to load. Please refresh once. If this persists, contact support@solife.me.</div>';
+  }
 });
 
 async function cleanupDevServiceWorkers() {

--- a/taskify-pwa/src/main.tsx
+++ b/taskify-pwa/src/main.tsx
@@ -1,8 +1,34 @@
-import { StrictMode } from 'react'
+import { Component, StrictMode, type ReactNode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 
 const root = createRoot(document.getElementById('root')!);
+
+class RootErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('Taskify runtime render error', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 20, fontFamily: '-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif', color: '#111' }}>
+          Taskify hit a runtime error and recovered safely. Please close and reopen once. If this repeats, contact support@solife.me.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -83,15 +109,17 @@ async function bootstrapApp(): Promise<void> {
 
   root.render(
     <StrictMode>
-      <ToastProvider>
-        <NwcProvider>
-          <P2PKProvider>
-            <CashuProvider>
-              <App />
-            </CashuProvider>
-          </P2PKProvider>
-        </NwcProvider>
-      </ToastProvider>
+      <RootErrorBoundary>
+        <ToastProvider>
+          <NwcProvider>
+            <P2PKProvider>
+              <CashuProvider>
+                <App />
+              </CashuProvider>
+            </P2PKProvider>
+          </NwcProvider>
+        </ToastProvider>
+      </RootErrorBoundary>
     </StrictMode>,
   );
 


### PR DESCRIPTION
## Summary
Creates a focused hotfix PR for installed-PWA blank screen failures after auth/deploy transitions.

## Changes
- Auto-recover from stale chunk/module bootstrap failures
  - Detects dynamic import/chunk load failures at bootstrap
  - Unregisters stale service workers
  - Clears only Taskify SW caches (taskify-cache-*)
  - One-time cache-busted reload guard (prevents loops)
- Add root React error boundary
  - Prevents full white-screen unmount on runtime render exceptions
  - Shows safe fallback message instead of blank UI

## Scope
- Touches only taskify-pwa/src/main.tsx
- No API/DB schema changes

## Expected outcome
Users should recover automatically from stale-cache deployment mismatches and avoid permanent blank screens in installed PWA sessions.