### PR TITLE
fix(gcal): make Upcoming filters honor Google calendar selections

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -9385,10 +9385,17 @@ export default function App() {
     return groups;
   }, [visibleBoards]);
 
-  const upcomingFilterOptions = useMemo(
-    () => upcomingFilterGroups.flatMap((group) => [group.boardOption, ...group.listOptions]),
-    [upcomingFilterGroups],
-  );
+  const upcomingFilterOptions = useMemo(() => {
+    const boardOptions = upcomingFilterGroups.flatMap((group) => [group.boardOption, ...group.listOptions]);
+    const gcalOptions: UpcomingFilterOption[] = gcalStatus.connected
+      ? gcalCalendars.map((cal) => ({
+          id: `gcal:${cal.id}`,
+          label: cal.name,
+          boardId: `gcal:${cal.id}`,
+        }))
+      : [];
+    return [...boardOptions, ...gcalOptions];
+  }, [upcomingFilterGroups, gcalCalendars, gcalStatus.connected]);
   const upcomingFilterOptionMap = useMemo(() => {
     const map = new Map<string, UpcomingFilterOption>();
     upcomingFilterOptions.forEach((option) => {


### PR DESCRIPTION
Summary: Fixes two linked issues where Google calendars were visible in Settings but not reliably selectable in Upcoming filters, and Google events were hidden from Upcoming.

Root cause: Upcoming filter sanitization only allowed IDs from board/list options. Google calendar IDs (gcal:<id>) were not part of that option set, so selections were stripped and gcal events were filtered out.

Change:
- Include connected Google calendars in upcomingFilterOptions so they are first-class filter option IDs.

Result:
- Select/deselect for Google calendars is stable.
- Google events appear in Upcoming when selected (or when filter is All).

Validation:
- taskify-pwa production build passes.