### PR TITLE
fix(gcal): follow-up for event rendering and settings UX

### DIFF
--- a/taskify-pwa/src/hooks/useGoogleCalendar.ts
+++ b/taskify-pwa/src/hooks/useGoogleCalendar.ts
@@ -18,6 +18,49 @@ const LS_GCAL_STATUS = "taskify_gcal_status_v1";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+function normalizeExternalEvents(input: unknown): GcalExternalEvent[] {
+  if (!Array.isArray(input)) return [];
+  const out: GcalExternalEvent[] = [];
+  for (const item of input) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as Record<string, unknown>;
+    const id = typeof raw.id === "string" ? raw.id : "";
+    const calendarId = typeof raw.calendarId === "string" ? raw.calendarId : "";
+    const title = typeof raw.title === "string" ? raw.title : "";
+    const startISO = typeof raw.startISO === "string"
+      ? raw.startISO
+      : (typeof raw.startIso === "string" ? raw.startIso : "");
+    const endISO = typeof raw.endISO === "string"
+      ? raw.endISO
+      : (typeof raw.endIso === "string" ? raw.endIso : undefined);
+    if (!id || !calendarId || !title || !startISO) continue;
+
+    out.push({
+      id,
+      calendarId,
+      providerEventId: typeof raw.providerEventId === "string" ? raw.providerEventId : id,
+      calendarName:
+        typeof raw.calendarName === "string" && raw.calendarName.trim().length > 0
+          ? raw.calendarName
+          : calendarId,
+      calendarColor: typeof raw.calendarColor === "string" ? raw.calendarColor : undefined,
+      title,
+      description: typeof raw.description === "string" ? raw.description : undefined,
+      location: typeof raw.location === "string" ? raw.location : undefined,
+      startISO,
+      endISO,
+      allDay: typeof raw.allDay === "boolean" ? raw.allDay : false,
+      status: raw.status === "tentative" || raw.status === "cancelled" ? raw.status : "confirmed",
+      htmlLink: typeof raw.htmlLink === "string" ? raw.htmlLink : undefined,
+      isRecurring: Boolean(raw.isRecurring),
+      readonly: true,
+      source: "google",
+      kind: "calendar_event",
+    });
+  }
+  return out;
+}
+
 export type { GcalCalendar, GcalConnectionStatus };
 
 function normalizeExternalEvents(input: unknown): GcalExternalEvent[] {

--- a/taskify-pwa/src/ui/settings/GoogleCalendarSection.tsx
+++ b/taskify-pwa/src/ui/settings/GoogleCalendarSection.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { GcalCalendar, GcalConnectionStatus } from "../../hooks/useGoogleCalendar";
-import { pillButtonClass } from "./settingsConstants";
 
 type Props = {
   connectionStatus: GcalConnectionStatus;
@@ -8,7 +7,6 @@ type Props = {
   loading: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
-  onToggleCalendar: (id: string, selected: boolean) => void;
   onSync: () => void;
 };
 
@@ -18,7 +16,6 @@ export function GoogleCalendarSection({
   loading,
   onConnect,
   onDisconnect,
-  onToggleCalendar,
   onSync,
 }: Props) {
   const connected = connectionStatus.connected;
@@ -77,33 +74,9 @@ export function GoogleCalendarSection({
             )}
           </div>
 
-          {/* Calendar toggles */}
           {calendars.length > 0 && (
-            <div className="space-y-1">
-              <div className="text-xs text-secondary mb-1">Calendars</div>
-              {calendars.map((cal) => (
-                <label
-                  key={cal.id}
-                  className="flex items-center gap-2 cursor-pointer py-0.5"
-                >
-                  <input
-                    type="checkbox"
-                    checked={cal.selected === 1}
-                    onChange={(e) => onToggleCalendar(cal.id, e.target.checked)}
-                    className="rounded"
-                  />
-                  {cal.color && (
-                    <span
-                      className="w-2.5 h-2.5 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: cal.color }}
-                    />
-                  )}
-                  <span className="text-sm truncate">{cal.name}</span>
-                  {cal.primary_cal === 1 && (
-                    <span className="text-xs text-secondary ml-auto flex-shrink-0">Primary</span>
-                  )}
-                </label>
-              ))}
+            <div className="text-xs text-secondary">
+              {calendars.length} calendar{calendars.length === 1 ? "" : "s"} connected. Manage visibility from Upcoming filters.
             </div>
           )}
 
@@ -112,7 +85,7 @@ export function GoogleCalendarSection({
             {needsReauth ? (
               <button
                 type="button"
-                className={pillButtonClass}
+                className="ghost-button button-sm pressable"
                 onClick={onConnect}
                 disabled={loading}
               >
@@ -121,7 +94,7 @@ export function GoogleCalendarSection({
             ) : (
               <button
                 type="button"
-                className={pillButtonClass}
+                className="ghost-button button-sm pressable"
                 onClick={onSync}
                 disabled={loading}
               >
@@ -130,7 +103,7 @@ export function GoogleCalendarSection({
             )}
             <button
               type="button"
-              className={`${pillButtonClass} text-red-400`}
+              className="ghost-button button-sm pressable text-rose-400"
               onClick={onDisconnect}
               disabled={loading}
             >

--- a/taskify-pwa/src/ui/settings/SettingsModal.tsx
+++ b/taskify-pwa/src/ui/settings/SettingsModal.tsx
@@ -411,7 +411,6 @@ export function SettingsModal({
           loading={gcalLoading}
           onConnect={onGcalConnect}
           onDisconnect={onGcalDisconnect}
-          onToggleCalendar={onGcalToggleCalendar}
           onSync={onGcalSync}
         />
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4019,6 +4019,8 @@ type GcalEventRow = {
   all_day: number;
   status: string;
   html_link: string | null;
+  calendar_name?: string | null;
+  calendar_color?: string | null;
 };
 
 // --- Token helpers -----------------------------------------------------------
@@ -4584,14 +4586,14 @@ async function handleGcalEvents(request: Request, env: Env): Promise<Response> {
     .prepare<GcalEventRow>(
       `SELECT e.id, e.npub, e.calendar_id, e.provider_event_id,
               e.title, e.description, e.location,
-              e.start_iso, e.end_iso, e.all_day, e.status, e.html_link
+              e.start_iso, e.end_iso, e.all_day, e.status, e.html_link,
+              c.name AS calendar_name, c.color AS calendar_color
          FROM gcal_events e
          JOIN gcal_calendars c ON c.id = e.calendar_id AND c.npub = e.npub
         WHERE e.npub = ?
           AND e.start_iso >= ?
           AND e.start_iso <= ?
           AND e.status != 'cancelled'
-          AND c.selected = 1
         ORDER BY e.start_iso ASC`,
     )
     .bind(auth.npub, from, to)
@@ -4601,15 +4603,18 @@ async function handleGcalEvents(request: Request, env: Env): Promise<Response> {
     id: r.id,
     calendarId: r.calendar_id,
     providerEventId: r.provider_event_id,
+    calendarName: r.calendar_name ?? r.calendar_id,
+    calendarColor: r.calendar_color ?? undefined,
     title: r.title,
     description: r.description,
     location: r.location,
-    startIso: r.start_iso,
-    endIso: r.end_iso,
+    startISO: r.start_iso,
+    endISO: r.end_iso,
     allDay: r.all_day === 1,
     status: r.status,
     htmlLink: r.html_link,
     source: "google" as const,
+    kind: "calendar_event" as const,
   }));
 
   return jsonResponse(events);
@@ -4636,7 +4641,7 @@ async function handleGcalSync(request: Request, env: Env): Promise<Response> {
 
   const calendarsResult = await db
     .prepare<GcalCalendarRow>(
-      `SELECT * FROM gcal_calendars WHERE npub = ? AND selected = 1`,
+      `SELECT * FROM gcal_calendars WHERE npub = ?`,
     )
     .bind(auth.npub)
     .all<GcalCalendarRow>();


### PR DESCRIPTION
Follow-up PR after #110 merge.

Includes:
- Worker gcal events response shape aligned with frontend expectations (startISO/endISO/calendarName/calendarColor/kind).
- Event query no longer suppressed by calendar selected flag, so connected calendar events are available for Upcoming filtering.
- Sync operates across connected calendars.
- Settings Google Calendar section no longer owns per-calendar visibility toggles; users manage visibility from Upcoming filters only.
- Sync/Reconnect/Disconnect buttons restyled to match standard settings button patterns.

Files:
- worker/src/index.ts
- taskify-pwa/src/hooks/useGoogleCalendar.ts
- taskify-pwa/src/ui/settings/GoogleCalendarSection.tsx
- taskify-pwa/src/ui/settings/SettingsModal.tsx