### PR TITLE
fix(ios): open Google OAuth outside WKWebView

### DIFF
--- a/taskify-ios/Sources/TaskifyApp/TaskifyApp.swift
+++ b/taskify-ios/Sources/TaskifyApp/TaskifyApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import WebKit
+#if os(iOS)
+import UIKit
+#endif
 
 // MARK: - App
 
@@ -80,8 +83,26 @@ extension TaskifyWebWrapperView {
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
                      decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            #if os(iOS)
+            if let url = navigationAction.request.url, shouldOpenExternallyForOAuth(url: url) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                decisionHandler(.cancel)
+                return
+            }
+            #endif
             decisionHandler(.allow)
         }
+
+        #if os(iOS)
+        private func shouldOpenExternallyForOAuth(url: URL) -> Bool {
+            guard let host = url.host?.lowercased() else { return false }
+            let path = url.path.lowercased()
+            if host == "accounts.google.com" && path.contains("/oauth") { return true }
+            if host == "accounts.google.com" && path.contains("/o/oauth2") { return true }
+            if host == "oauth2.googleapis.com" { return true }
+            return false
+        }
+        #endif
 
         @available(iOS 15.0, *)
         func webView(


### PR DESCRIPTION
Implements iOS patch for Google Calendar connect flow failing with 403 disallowed_useragent.

Root cause:
- Google blocks OAuth sign-in inside embedded user agents (WKWebView).

Change:
- In iOS WKNavigationDelegate, detect Google OAuth navigation URLs.
- Cancel in-webview navigation and open URL via UIApplication.shared.open (system browser).
- Keep normal in-app navigation for non-OAuth URLs.

File:
- taskify-ios/Sources/TaskifyApp/TaskifyApp.swift

Result:
- Google auth runs in allowed browser context instead of embedded WKWebView, avoiding disallowed_useragent.