### PR TITLE
fix(undo): raise snackbar above bottom nav pill

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -19856,7 +19856,10 @@ export default function App() {
 
       {/* Undo Snackbar */}
       {undoTask && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-surface-muted border border-surface text-sm px-4 py-2 rounded-xl shadow-lg flex items-center gap-3">
+        <div
+          className="fixed left-1/2 -translate-x-1/2 bg-surface-muted border border-surface text-sm px-4 py-2 rounded-xl shadow-lg flex items-center gap-3 z-[9999]"
+          style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + var(--app-tab-pill-offset) + 0.75rem)" }}
+        >
           Task deleted
           <button onClick={undoDelete} className="accent-button button-sm pressable">Undo</button>
         </div>


### PR DESCRIPTION
Fixes undo toast being obscured by the bottom navigation pill on iOS.

Root cause:
Snackbar used fixed bottom-4 (16px) which placed it behind the nav pill.

Fix:
Replace static bottom-4 with calc(env(safe-area-inset-bottom, 0px) + var(--app-tab-pill-offset) + 0.75rem) matching the pattern used elsewhere in the app to clear the nav pill. Also adds z-[9999] so it renders above all other fixed elements.

File: taskify-pwa/src/App.tsx