### PR TITLE
fix(contacts): render emoji correctly in contact avatar initials

### DIFF
--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -13054,11 +13054,13 @@ export default function CashuWalletModal({
   }
 
   const contactInitials = (value: string) => {
-    const trimmed = (value || "").trim();
-    if (!trimmed) return "?";
-    const parts = trimmed.split(/\s+/).filter(Boolean);
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    const parts = (value || "").trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    const cp = parts[0].codePointAt(0) ?? 0;
+    const isEmoji = (cp >= 0x2600 && cp <= 0x27bf) || (cp >= 0x1f300 && cp <= 0x1faff) || (cp >= 0x1f900 && cp <= 0x1f9ff);
+    if (isEmoji) return [...parts[0]][0] ?? "?";
+    if (parts.length === 1) return [...parts[0]].slice(0, 2).join("").toUpperCase();
+    return ([...parts[0]][0] ?? "" + ([...parts[parts.length - 1]][0] ?? "")).toUpperCase();
   };
 
   const contactSubtitle = useCallback(

--- a/taskify-pwa/src/ui/bounty/LockToNpubSheet.tsx
+++ b/taskify-pwa/src/ui/bounty/LockToNpubSheet.tsx
@@ -34,14 +34,20 @@ function contactVerifiedNip05(contact: Contact, cache: Record<string, Nip05Check
   return entry.nip05 || null;
 }
 
+function startsWithEmoji(str: string): boolean {
+  const cp = str.codePointAt(0);
+  if (cp === undefined) return false;
+  return (cp >= 0x2600 && cp <= 0x27bf) || (cp >= 0x1f300 && cp <= 0x1faff) || (cp >= 0x1f900 && cp <= 0x1f9ff);
+}
+
 function contactInitials(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "?";
-  const words = trimmed.split(/\s+/);
-  if (words.length >= 2) {
-    return `${words[0]![0]}${words[1]![0]}`.toUpperCase();
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (startsWithEmoji(parts[0])) return [...parts[0]][0] ?? "?";
+  if (parts.length >= 2) {
+    return `${[...parts[0]][0] ?? ""}${[...parts[parts.length - 1]][0] ?? ""}`.toUpperCase();
   }
-  return trimmed.slice(0, 2).toUpperCase();
+  return [...parts[0]].slice(0, 2).join("").toUpperCase();
 }
 
 function LockToNpubSheet({

--- a/taskify-pwa/src/ui/settings/settingsConstants.ts
+++ b/taskify-pwa/src/ui/settings/settingsConstants.ts
@@ -26,11 +26,38 @@ export function isSameLocalDate(aMs: number, bMs: number): boolean {
   );
 }
 
+/** Returns the first Unicode codepoint (handles emoji and multi-byte chars). */
+function firstCodepoint(str: string): string {
+  return [...str][0] ?? "";
+}
+
+/** True when a string starts with an emoji character. */
+function startsWithEmoji(str: string): boolean {
+  const cp = str.codePointAt(0);
+  if (cp === undefined) return false;
+  // Emoji ranges: Misc Symbols, Dingbats, Supplemental Symbols, Emoticons, etc.
+  return (
+    (cp >= 0x2600 && cp <= 0x27bf) ||  // Misc symbols + dingbats
+    (cp >= 0x1f300 && cp <= 0x1faff) || // Emoji block (emoticons, transport, etc.)
+    (cp >= 0x1f900 && cp <= 0x1f9ff) || // Supplemental symbols
+    (cp >= 0x2700 && cp <= 0x27bf) ||   // Dingbats
+    (cp >= 0xfe00 && cp <= 0xfe0f) ||   // Variation selectors
+    cp === 0x200d                         // ZWJ
+  );
+}
+
 export function contactInitials(value: string): string {
   const parts = value.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  const first = firstCodepoint(parts[0]);
+  // If the display name starts with an emoji, use it as the avatar glyph
+  if (startsWithEmoji(parts[0])) return first;
+  if (parts.length === 1) {
+    const chars = [...parts[0]];
+    return chars.slice(0, 2).join("").toUpperCase();
+  }
+  const last = firstCodepoint(parts[parts.length - 1]);
+  return (first + last).toUpperCase();
 }
 
 export function hexToBytes(hex: string): Uint8Array {


### PR DESCRIPTION
Fixes contact avatar showing broken horizontal lines when a display name starts with an emoji.

Root cause:
contactInitials() used .slice(0,2) and [0] on emoji strings — these operate on UTF-16 code units, not Unicode codepoints. Emoji are multi-unit so the result was garbage bytes rendered as replacement characters.

Fix:
- Use [...str] spread (iterates by Unicode codepoint) instead of .slice/.charAt
- Added startsWithEmoji() detector covering Misc Symbols, Dingbats, Emoticons, Supplemental Symbols ranges
- When first word is an emoji, return just the emoji codepoint as the avatar glyph (no uppercase)
- Applied to all three contactInitials copies: settingsConstants.ts, LockToNpubSheet.tsx, CashuWalletModal.tsx

Build: passes