### PR TITLE
fix(contacts): show npub QR on own contact card for new accounts

### DIFF
--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -6317,9 +6317,11 @@ export default function CashuWalletModal({
 
   const profileShareValue = useMemo(() => {
     if (profileSharePayload) return profileSharePayload;
-    const identity = nostrIdentityRef.current;
+    // Read identity directly — not gated by paymentRequestsEnabled so new accounts
+    // without payment requests still get a QR on their contact card.
+    const identity = readNostrIdentity().identity ?? nostrIdentityRef.current;
     return identity ? formatNpub(identity.pubkey) : null;
-  }, [formatNpub, profileSharePayload]);
+  }, [formatNpub, profileSharePayload, readNostrIdentity]);
   const nwcFundInProgress = nwcFundState === "creating" || nwcFundState === "paying" || nwcFundState === "waiting" || nwcFundState === "claiming";
   const nwcWithdrawInProgress = nwcWithdrawState === "requesting" || nwcWithdrawState === "paying";
 
@@ -13092,7 +13094,11 @@ export default function CashuWalletModal({
   const myCardUsername = formatContactUsername(profileForm.username);
   const myCardName = profileForm.displayName.trim() || myCardUsername || "My Card";
   const myCardLightning = profileForm.lud16.trim() || deriveDefaultLightningAddress();
-  const myCardNpub = nostrIdentityRef.current ? formatNpub(nostrIdentityRef.current.pubkey) : "";
+  const myCardNpub = useMemo(() => {
+    const identity = readNostrIdentity().identity ?? nostrIdentityRef.current;
+    return identity ? formatNpub(identity.pubkey) : "";
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formatNpub, readNostrIdentity, profileSharePayload]);
   const myCardSubtitle =
     myCardLightning || profileForm.nip05.trim() || myCardNpub || "My Card";
   const profileCard = {


### PR DESCRIPTION
Fixes the own contact card showing no QR code for new accounts that haven't enabled payment requests.

Root cause:
nostrIdentityRef is only populated when paymentRequestsEnabled is true (gated in nostrIdentityInfo useMemo). profileShareValue and myCardNpub both read from nostrIdentityRef — so new accounts without payment requests get null/empty and no QR is rendered.

Fix:
profileShareValue and myCardNpub now call readNostrIdentity() directly, bypassing the paymentRequestsEnabled gate. readNostrIdentity() reads the stored nsec regardless, so any account with a key gets a valid npub QR on their contact card.