### PR TITLE
feat(tasks): tap image to open fullscreen preview

### DIFF
--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { ImagePreviewModal } from "./ImagePreviewModal";
 import { nip19 } from "nostr-tools";
 import { normalizeTaskAssignmentStatus } from "taskify-core";
 
@@ -240,6 +241,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
   const [prioritySheetOpen, setPrioritySheetOpen] = useState(false);
   const [note, setNote] = useState(task.note || "");
   const [images, setImages] = useState<string[]>(task.images || []);
+  const [previewImageSrc, setPreviewImageSrc] = useState<string | null>(null);
   const [documents, setDocuments] = useState<TaskDocument[]>(task.documents || []);
   const [subtasks, setSubtasks] = useState<Subtask[]>(task.subtasks || []);
   const [newSubtask, setNewSubtask] = useState("");
@@ -1680,11 +1682,21 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
                 </button>
               </div>
             </div>
+            {previewImageSrc && (
+              <ImagePreviewModal src={previewImageSrc} onClose={() => setPreviewImageSrc(null)} />
+            )}
             {images.length > 0 && (
               <div className="edit-media-grid">
                 {images.map((img, i) => (
                   <div key={i} className="relative">
-                    <img src={img} className="max-h-40 rounded-lg" alt="Attachment" />
+                    <img
+                      src={img}
+                      className="max-h-40 rounded-lg cursor-zoom-in"
+                      alt="Attachment"
+                      onClick={() => setPreviewImageSrc(img)}
+                      role="button"
+                      aria-label="View full image"
+                    />
                     <button
                       type="button"
                       className="absolute top-1 right-1 rounded-full bg-black/70 px-1 text-xs"

--- a/taskify-pwa/src/ui/task/ImagePreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/ImagePreviewModal.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+interface ImagePreviewModalProps {
+  src: string;
+  alt?: string;
+  onClose: () => void;
+}
+
+export function ImagePreviewModal({ src, alt, onClose }: ImagePreviewModalProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    // Prevent body scroll while open
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = prev;
+    };
+  }, [handleKeyDown]);
+
+  const portal = (
+    <div
+      className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/90"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image preview"
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        className="absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-black/60 text-white text-xl leading-none pressable"
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        aria-label="Close preview"
+      >
+        ×
+      </button>
+      {/* Image — stop propagation so tapping the image itself doesn't close */}
+      <img
+        src={src}
+        alt={alt ?? "Attachment preview"}
+        className="max-h-[90vh] max-w-[95vw] rounded-xl object-contain shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        draggable={false}
+      />
+    </div>
+  );
+
+  return typeof document !== "undefined"
+    ? createPortal(portal, document.body)
+    : null;
+}

--- a/taskify-pwa/src/ui/task/TaskMedia.tsx
+++ b/taskify-pwa/src/ui/task/TaskMedia.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import type { Task } from "../../domains/tasks/taskTypes";
 import type { CalendarEvent } from "../../domains/tasks/taskTypes";
 import type { TaskDocument } from "../../lib/documents";
@@ -7,6 +7,7 @@ import type { UrlPreviewData } from "../../lib/urlPreview";
 import { extractFirstUrl, isUrlLike } from "../../lib/urlPreview";
 import { autolink, stripUrlsFromText, fallbackTitleFromUrl, useTaskPreview } from "./TaskTitle";
 import { DocumentThumbnail } from "./DocumentPreviewModal";
+import { ImagePreviewModal } from "./ImagePreviewModal";
 
 export function UrlPreviewCard({ preview }: { preview: UrlPreviewData; indent?: boolean }) {
   const [imageFailed, setImageFailed] = useState(false);
@@ -76,6 +77,11 @@ export function TaskMedia({
   const hasDocuments = Boolean(task.documents && task.documents.length);
   const derivedPreview = useTaskPreview(task);
   const hasPreview = Boolean(derivedPreview);
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+  const openPreview = useCallback((src: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPreviewSrc(src);
+  }, []);
 
   if (!noteText && !hasImages && !hasDocuments && !hasPreview) return null;
 
@@ -84,6 +90,9 @@ export function TaskMedia({
 
   return (
     <div className={wrapperClasses}>
+      {previewSrc && (
+        <ImagePreviewModal src={previewSrc} onClose={() => setPreviewSrc(null)} />
+      )}
       {noteText && (
         <div
           className={`${noteDetailClass}text-xs text-secondary break-words`}
@@ -95,7 +104,14 @@ export function TaskMedia({
       {hasImages ? (
         <div className="space-y-2">
           {task.images!.map((img, i) => (
-            <img key={i} src={img} className="max-h-40 w-full rounded-2xl object-contain" />
+            <img
+              key={i}
+              src={img}
+              className="max-h-40 w-full rounded-2xl object-contain cursor-zoom-in"
+              onClick={(e) => openPreview(img, e)}
+              role="button"
+              aria-label="View full image"
+            />
           ))}
         </div>
       ) : null}


### PR DESCRIPTION
Adds a fullscreen image preview when tapping an attached image from the board card view or task edit view.

New file: src/ui/task/ImagePreviewModal.tsx
- Portal-based overlay (z-[99999]) rendered via ReactDOM.createPortal into document.body
- 90vh × 95vw max size, object-contain, rounded-xl
- Tap backdrop to dismiss, × button top-right, Escape key support
- Locks body scroll while open

TaskMedia.tsx (board card view):
- Images get cursor-zoom-in + onClick → opens ImagePreviewModal
- e.stopPropagation() so tap doesn't trigger card navigation

EditModal.tsx (task edit view):
- Same treatment — tapping an image opens fullscreen preview
- Remove button still works independently (stopPropagation not needed as they're separate elements)