### PR TITLE
feat(ios-native): Primal-informed relay improvements — ping keepalive, RelayPoolProtocol, ConnectionSummary

### DIFF
--- a/taskify-ios-native/Sources/TaskifyCore/Relay/RelayConnection.swift
+++ b/taskify-ios-native/Sources/TaskifyCore/Relay/RelayConnection.swift
@@ -1,19 +1,44 @@
 /// RelayConnection.swift
-/// Single Nostr relay WebSocket connection with automatic reconnection.
+/// Single Nostr relay WebSocket connection with automatic reconnection and keepalive pings.
+///
+/// Improvements over initial version (Primal-informed patterns, no GPL code):
+/// - Ping/keepalive every 10s — mirrors Primal's `socket?.ping(interval: 10.0)`.
+///   Detects silent dead connections that URLSessionWebSocketTask doesn't surface.
+/// - `pingIntervalSeconds` / `maxReconnectDelaySecs` exposed as constants for tests.
+/// - `hasPendingMessages()` exposed for test observability.
+/// - Ping failure triggers reconnect (same path as receive error).
 
 import Foundation
 
+// MARK: - RelayPoolProtocol
+
+/// Protocol for RelayPool so RelayConnection can be tested with a mock pool.
+public protocol RelayPoolProtocol: AnyObject {
+    nonisolated func dispatch(message: RelayMessage, from relayUrl: String)
+    func relayDidConnect(url: String) async
+}
+
+// MARK: - RelayConnection
+
 public actor RelayConnection {
 
+    // MARK: Constants (exposed for tests)
+
+    /// Ping interval in seconds — matches Primal's 10s keepalive.
+    public static let pingIntervalSeconds: TimeInterval = 10.0
+    /// Maximum reconnect backoff — caps exponential growth.
+    public static let maxReconnectDelaySecs: TimeInterval = 30.0
+
     public let url: String
-    private weak var pool: RelayPool?
+    private weak var pool: (any RelayPoolProtocol)?
     private var webSocketTask: URLSessionWebSocketTask?
     private var reconnectDelay: TimeInterval = 1.0
     private var shouldReconnect = true
     private var isConnected = false
     private var pendingMessages: [String] = []
+    private var pingTask: Task<Void, Never>? = nil
 
-    public init(url: String, pool: RelayPool) {
+    public init(url: String, pool: any RelayPoolProtocol) {
         self.url = url
         self.pool = pool
     }
@@ -27,6 +52,8 @@ public actor RelayConnection {
 
     public func disconnect() async {
         shouldReconnect = false
+        pingTask?.cancel()
+        pingTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
         isConnected = false
@@ -48,9 +75,14 @@ public actor RelayConnection {
         }
     }
 
+    // MARK: State queries
+
     public func connected() -> Bool { isConnected }
 
-    // MARK: Internal
+    /// Exposed for test observability.
+    public func hasPendingMessages() -> Bool { !pendingMessages.isEmpty }
+
+    // MARK: Internal — WebSocket lifecycle
 
     private func openWebSocket() async {
         guard let wsURL = URL(string: url) else { return }
@@ -61,6 +93,7 @@ public actor RelayConnection {
         isConnected = true
         reconnectDelay = 1.0
         startReceiving(task: task)
+        startPingLoop(task: task)
         Task { [weak self] in
             guard let self else { return }
             await self.finishOpenWebSocket()
@@ -93,6 +126,34 @@ public actor RelayConnection {
         }
     }
 
+    /// Sends a WebSocket ping every `pingIntervalSeconds`.
+    /// If the ping fails, it means the connection is silently dead — trigger reconnect.
+    /// Mirrors Primal's `socket?.ping(interval: 10.0)` behaviour.
+    ///
+    /// Uses the callback-based `sendPing(pongReceiveHandler:)` API wrapped in a continuation
+    /// because `URLSessionWebSocketTask` does not have an async `sendPing()` overload.
+    private func startPingLoop(task: URLSessionWebSocketTask) {
+        pingTask?.cancel()
+        pingTask = Task { [weak self] in
+            while true {
+                try? await Task.sleep(nanoseconds: UInt64(Self.pingIntervalSeconds * 1_000_000_000))
+                guard let self, !Task.isCancelled else { return }
+                let stillConnected = await self.connected()
+                guard stillConnected else { return }
+                let pingError = await withCheckedContinuation { (continuation: CheckedContinuation<(any Error)?, Never>) in
+                    task.sendPing { error in
+                        continuation.resume(returning: error)
+                    }
+                }
+                if pingError != nil {
+                    // Ping failed — connection is silently dead
+                    await self.handleDisconnect()
+                    return
+                }
+            }
+        }
+    }
+
     private func flushPendingMessages() async {
         guard let task = webSocketTask, isConnected, !pendingMessages.isEmpty else { return }
         let queued = pendingMessages
@@ -118,11 +179,13 @@ public actor RelayConnection {
     }
 
     private func handleDisconnect() async {
+        pingTask?.cancel()
+        pingTask = nil
         isConnected = false
         webSocketTask = nil
         guard shouldReconnect else { return }
         try? await Task.sleep(nanoseconds: UInt64(reconnectDelay * 1_000_000_000))
-        reconnectDelay = min(reconnectDelay * 2, 30.0) // exponential backoff, max 30s
+        reconnectDelay = min(reconnectDelay * 2, Self.maxReconnectDelaySecs)
         await openWebSocket()
     }
 }

--- a/taskify-ios-native/Sources/TaskifyCore/Relay/RelayPool.swift
+++ b/taskify-ios-native/Sources/TaskifyCore/Relay/RelayPool.swift
@@ -8,12 +8,28 @@
 /// - Event batch flush on EOSE before firing onEose (mirrors SubscriptionManager EOSE drain)
 /// - CursorStore: per-filter since cursor advanced on every received event
 /// - EventCache: deduplication ring buffer (mirrors EventCache.ts)
+///
+/// Primal-informed additions (patterns only, no GPL code):
+/// - `atLeastOneConnected()` — mirrors Primal RelayPool.atLeastOneConnected @Published
+/// - `connectionSummary()` — structured label for UI (e.g. "2/4 relays")
+/// - Conforms to RelayPoolProtocol so RelayConnection can be mock-tested
 
 import Foundation
 
+// MARK: - ConnectionSummary
+
+/// Structured relay connection state for UI consumption.
+/// Mirrors Primal's `numOfConnected` / `atLeastOneConnected` @Published pattern.
+public struct ConnectionSummary: Sendable, Equatable {
+    public let connected: Int
+    public let total: Int
+    public var label: String { "\(connected)/\(total) relays" }
+    public var hasAny: Bool { connected > 0 }
+}
+
 // MARK: - RelayPool
 
-public actor RelayPool {
+public actor RelayPool: RelayPoolProtocol {
 
     // MARK: Dependencies injected at init
 
@@ -60,7 +76,31 @@ public actor RelayPool {
         for (url, conn) in connections {
             statuses.append((url: url, connected: await conn.connected()))
         }
+        // Include configured relays that haven't connected yet (no RelayConnection created yet)
+        for url in relayURLs where connections[url] == nil {
+            statuses.append((url: url, connected: false))
+        }
         return statuses
+    }
+
+    /// Returns true if at least one relay is currently connected.
+    /// Mirrors Primal's `atLeastOneConnected` @Published property.
+    public func atLeastOneConnected() async -> Bool {
+        for (_, conn) in connections {
+            if await conn.connected() { return true }
+        }
+        return false
+    }
+
+    /// Returns a structured summary of relay connection state for UI.
+    /// e.g. `ConnectionSummary(connected: 2, total: 4)` → "2/4 relays"
+    public func connectionSummary() async -> ConnectionSummary {
+        let total = relayURLs.count
+        var connected = 0
+        for (_, conn) in connections {
+            if await conn.connected() { connected += 1 }
+        }
+        return ConnectionSummary(connected: connected, total: total)
     }
 
     public func relayDidConnect(url: String) async {
@@ -210,8 +250,13 @@ public actor RelayPool {
 
     // MARK: Internal dispatch (called from RelayConnection)
 
-    nonisolated func dispatch(message: RelayMessage, from relayUrl: String) {
+    public nonisolated func dispatch(message: RelayMessage, from relayUrl: String) {
         Task { await _dispatch(message: message, relayUrl: relayUrl) }
+    }
+
+    /// Async variant for test-only use — awaits actor isolation before dispatching.
+    public func dispatchAsync(message: RelayMessage, from relayUrl: String) {
+        _dispatch(message: message, relayUrl: relayUrl)
     }
 
     private func _dispatch(message: RelayMessage, relayUrl: String) {

--- a/taskify-ios-native/Sources/TaskifyCore/Sync/SyncEngine.swift
+++ b/taskify-ios-native/Sources/TaskifyCore/Sync/SyncEngine.swift
@@ -74,9 +74,8 @@ public final class BoardSyncManager: ObservableObject {
             ]
 
             // Absolute 25s timeout — mirrors App.tsx absoluteTimeoutSecs
-            let absoluteDeadline = Date().addingTimeInterval(absoluteTimeoutSecs)
 
-            let subKey = await relayPool.subscribe(
+            let _ = await relayPool.subscribe(
                 filters: [filter],
                 onEvent: { [weak self] event, relayUrl in
                     guard let self else { return }

--- a/taskify-ios-native/Tests/TaskifyCoreTests/RelayConnectionTests.swift
+++ b/taskify-ios-native/Tests/TaskifyCoreTests/RelayConnectionTests.swift
@@ -1,0 +1,191 @@
+/// RelayConnectionTests.swift
+/// Tests for RelayConnection ping/keepalive, reconnect, and published state.
+
+import Foundation
+import Testing
+@testable import TaskifyCore
+
+// MARK: - Mock RelayPool for testing
+
+final class MockRelayPool: RelayPoolProtocol, @unchecked Sendable {
+    var dispatchedMessages: [(RelayMessage, String)] = []
+    var connectedUrls: [String] = []
+
+    nonisolated func dispatch(message: RelayMessage, from relayUrl: String) {
+        dispatchedMessages.append((message, relayUrl))
+    }
+
+    func relayDidConnect(url: String) async {
+        connectedUrls.append(url)
+    }
+}
+
+// MARK: - RelayConnectionTests
+
+@Suite("RelayConnection")
+struct RelayConnectionTests {
+
+    @Test("connected() returns false before connect()")
+    func notConnectedInitially() async {
+        let pool = MockRelayPool()
+        let conn = RelayConnection(url: "wss://relay.example.com", pool: pool)
+        let connected = await conn.connected()
+        #expect(connected == false)
+    }
+
+    @Test("pendingMessages queued when not connected")
+    func queuesPendingMessagesWhenDisconnected() async {
+        let pool = MockRelayPool()
+        let conn = RelayConnection(url: "wss://relay.example.com", pool: pool)
+        // send without connecting — should queue, not crash
+        await conn.send("""
+        ["REQ","sub1",{"kinds":[30301]}]
+        """)
+        let hasPending = await conn.hasPendingMessages()
+        #expect(hasPending == true)
+    }
+
+    @Test("disconnect() sets connected to false")
+    func disconnectSetsNotConnected() async {
+        let pool = MockRelayPool()
+        let conn = RelayConnection(url: "wss://relay.example.com", pool: pool)
+        await conn.disconnect()
+        let connected = await conn.connected()
+        #expect(connected == false)
+    }
+
+    @Test("ping interval is 10 seconds (Primal-parity)")
+    func pingIntervalIsTenSeconds() {
+        #expect(RelayConnection.pingIntervalSeconds == 10)
+    }
+
+    @Test("exponential backoff caps at 30 seconds")
+    func backoffCapsAt30() async {
+        // Verify the constant is set correctly
+        #expect(RelayConnection.maxReconnectDelaySecs == 30.0)
+    }
+}
+
+// MARK: - RelayPoolPublishedStateTests
+
+@Suite("RelayPool published state")
+struct RelayPoolPublishedStateTests {
+
+    @Test("initial connectedCount is 0")
+    func initialConnectedCount() async {
+        let pool = RelayPool(relayURLs: [])
+        let count = await pool.connectedCount()
+        #expect(count == 0)
+    }
+
+    @Test("initial atLeastOneConnected is false")
+    func initialAtLeastOneConnected() async {
+        let pool = RelayPool(relayURLs: [])
+        let result = await pool.atLeastOneConnected()
+        #expect(result == false)
+    }
+
+    @Test("relayStatuses returns empty for empty pool")
+    func relayStatusesEmpty() async {
+        let pool = RelayPool(relayURLs: [])
+        let statuses = await pool.relayStatuses()
+        #expect(statuses.isEmpty)
+    }
+
+    @Test("relayStatuses lists all configured relay URLs")
+    func relayStatusesListsAllURLs() async {
+        let urls = ["wss://relay.a.com", "wss://relay.b.com"]
+        let pool = RelayPool(relayURLs: urls)
+        let statuses = await pool.relayStatuses()
+        #expect(statuses.count == 2)
+        let listedURLs = Set(statuses.map(\.url))
+        #expect(listedURLs == Set(urls))
+    }
+
+    @Test("connectionSummary reflects 0/N when not connected")
+    func connectionSummaryDisconnected() async {
+        let pool = RelayPool(relayURLs: ["wss://a.com", "wss://b.com"])
+        let summary = await pool.connectionSummary()
+        #expect(summary.total == 2)
+        #expect(summary.connected == 0)
+        #expect(summary.label == "0/2 relays")
+    }
+}
+
+// MARK: - RelayPool EOSE drain tests
+
+@Suite("RelayPool EOSE drain")
+struct RelayPoolEoseDrainTests {
+
+    @Test("EOSE drains pending events before firing onEose")
+    func eoseDrainsBefore() async {
+        // This tests the invariant: onEose must never fire while there are
+        // buffered events that haven't been delivered yet.
+        // Simulated via direct dispatch calls.
+
+        let pool = RelayPool(relayURLs: [])
+        var eventOrder: [String] = []
+
+        // Inject a fake subscription via subscribe()
+        let subKey = await pool.subscribe(
+            filters: [["kinds": [30301]]],
+            onEvent: { event, _ in
+                eventOrder.append("event:\(event.id)")
+            },
+            onEose: { _ in
+                eventOrder.append("eose")
+            }
+        )
+        #expect(!subKey.isEmpty)
+
+        // Simulate receiving an event then EOSE on a relay
+        let fakeEvent = NostrEvent(
+            id: "aabbcc",
+            pubkey: "pubkey1",
+            created_at: 1000,
+            kind: 30301,
+            tags: [["d", "task1"], ["b", "board1"]],
+            content: "encrypted"
+        )
+        await pool.dispatchAsync(message: .event(subscriptionId: subKey, event: fakeEvent), from: "wss://r.com")
+        await pool.dispatchAsync(message: .eose(subscriptionId: subKey), from: "wss://r.com")
+
+        // Allow actor task to flush
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        // Invariant: event must appear before eose in delivery order
+        #expect(eventOrder.first == "event:aabbcc")
+        #expect(eventOrder.last == "eose")
+        #expect(eventOrder.count == 2)
+    }
+
+    @Test("duplicate events are deduplicated by EventCache")
+    func duplicateEventsDeduped() async {
+        let pool = RelayPool(relayURLs: [])
+        var eventCount = 0
+
+        let subKey = await pool.subscribe(
+            filters: [["kinds": [30301]]],
+            onEvent: { _, _ in eventCount += 1 },
+            onEose: { _ in }
+        )
+
+        let fakeEvent = NostrEvent(
+            id: "dedup-test-id",
+            pubkey: "pubkey1",
+            created_at: 1000,
+            kind: 30301,
+            tags: [],
+            content: ""
+        )
+
+        // Dispatch same event twice (from two different relays — real-world duplicate)
+        await pool.dispatchAsync(message: .event(subscriptionId: subKey, event: fakeEvent), from: "wss://r1.com")
+        await pool.dispatchAsync(message: .event(subscriptionId: subKey, event: fakeEvent), from: "wss://r2.com")
+        await pool.dispatchAsync(message: .eose(subscriptionId: subKey), from: "wss://r1.com")
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(eventCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary
Primal-informed relay layer improvements for the native iOS app. All original code — no GPL material copied.

## Changes

### RelayConnection — ping/keepalive
- 10s ping loop using `sendPing(pongReceiveHandler:)` wrapped in `CheckedContinuation`
- Ping failure routes to same `handleDisconnect`/exponential-backoff path as receive errors
- Detects silently dead connections that `URLSessionWebSocketTask` doesn't surface
- `pingIntervalSeconds = 10`, `maxReconnectDelaySecs = 30` exposed as testable constants

### RelayPoolProtocol
- Protocol extracted so `RelayConnection` can be tested with a mock pool
- `RelayPool` conforms; `dispatch()` marked `public nonisolated`

### ConnectionSummary + published state API
- `ConnectionSummary(connected:total:)` — `.label` = "2/4 relays", `.hasAny`
- `atLeastOneConnected()` and `connectionSummary()` added to `RelayPool`
- `relayStatuses()` now includes configured relays not yet connected

### Tests
- 11 new tests across 3 suites in `RelayConnectionTests.swift`
- All 124 tests pass (0 failures)

## Test results
```
Test run with 124 tests in 28 suites passed after 0.036 seconds.
```