### PR TITLE
fix(pwa/ios): sync default relays + frosted glass backdrop-filter fix

### DIFF
--- a/taskify-ios-native/Sources/TaskifyCore/AppShell/DataController.swift
+++ b/taskify-ios-native/Sources/TaskifyCore/AppShell/DataController.swift
@@ -673,8 +673,11 @@ public final class DataController: ObservableObject {
 
     private func allRelayURLs() -> [String] {
         let profileRelays = profile?.relays ?? []
+        // Fall back to the full PWA-matching default preset when no profile relays are set.
+        // Mirrors DEFAULT_NOSTR_RELAYS in taskify-core/src/nostrPrimitives.ts.
+        let baseRelays = profileRelays.isEmpty ? AuthSessionManager.defaultRelayPreset : profileRelays
         let boardRelays = allStoredRelayHints()
-        return normalizeRelayList(profileRelays + boardRelays)
+        return normalizeRelayList(baseRelays + boardRelays)
     }
 
     private func allStoredRelayHints() -> [String] {
@@ -1687,6 +1690,8 @@ public final class DataController: ObservableObject {
     }
 
     private func buildTaskPayload(_ task: TaskifyTask) -> [String: Any] {
+        // Field set matches PWA maybePublishTask body in App.tsx.
+        // Reminders are device-specific and intentionally excluded (same as PWA).
         [
             "title": task.title,
             "priority": nullable(task.priority),
@@ -1707,6 +1712,8 @@ public final class DataController: ObservableObject {
             "dueDateEnabled": nullable(task.dueDateEnabled),
             "dueTimeEnabled": nullable(task.dueTimeEnabled),
             "dueTimeZone": nullable(task.dueTimeZone),
+            // inboxItem — included with explicit null to signal removals (mirrors PWA)
+            "inboxItem": nullable(task.inboxItem),
             "images": jsonField(task.imagesJSON),
             "documents": jsonField(task.documentsJSON),
             "subtasks": jsonField(task.subtasksJSON),

--- a/taskify-ios-native/Sources/TaskifyCore/Auth/AuthSessionManager.swift
+++ b/taskify-ios-native/Sources/TaskifyCore/Auth/AuthSessionManager.swift
@@ -11,7 +11,13 @@ public enum AuthState: Equatable {
 public final class AuthSessionManager {
     public private(set) var state: AuthState = .signedOut
 
-    public static let defaultRelayPreset = ["wss://relay.damus.io", "wss://relay.snort.social"]
+    /// Default Nostr relays — matches DEFAULT_NOSTR_RELAYS in taskify-core/src/nostrPrimitives.ts.
+    public static let defaultRelayPreset = [
+        "wss://relay.damus.io",
+        "wss://nos.lol",
+        "wss://relay.snort.social",
+        "wss://relay.primal.net",
+    ]
 
     private let loadActiveProfileFn: () throws -> TaskifyProfile?
     private let saveProfileFn: (TaskifyProfile) throws -> Void

--- a/taskify-ios-native/Tests/TaskifyCoreTests/AuthSessionManagerTests.swift
+++ b/taskify-ios-native/Tests/TaskifyCoreTests/AuthSessionManagerTests.swift
@@ -80,7 +80,8 @@ struct AuthSessionManagerTests {
 
         await manager.signIn(secretKeyInput: "nsec1...", profileName: "Nathan", relays: [])
 
-        #expect(saved?.relays == ["wss://relay.damus.io", "wss://relay.snort.social"])
+        // Should fall back to the full PWA-matching default preset (matches DEFAULT_NOSTR_RELAYS)
+        #expect(saved?.relays == AuthSessionManager.defaultRelayPreset)
     }
 
     @Test("invalid nsec/hex shows PWA-parity validation message")
@@ -138,5 +139,17 @@ struct AuthSessionManagerTests {
         await manager.signOut()
         #expect(await manager.state == .signedOut)
         #expect(cleared == true)
+    }
+
+    @Test("default relay preset matches PWA DEFAULT_NOSTR_RELAYS exactly")
+    func defaultRelayPresetMatchesPWA() {
+        // Source of truth: taskify-core/src/nostrPrimitives.ts DEFAULT_NOSTR_RELAYS
+        let pwaDefaults = [
+            "wss://relay.damus.io",
+            "wss://nos.lol",
+            "wss://relay.snort.social",
+            "wss://relay.primal.net",
+        ]
+        #expect(AuthSessionManager.defaultRelayPreset == pwaDefaults)
     }
 }

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -2160,8 +2160,11 @@ html.light .control-matrix__btn[data-hovered="true"] {
   inset: 0;
   z-index: 50;
   background: rgba(7, 10, 20, 0.56);
-  backdrop-filter: blur(26px);
-  -webkit-backdrop-filter: blur(26px);
+  /* NOTE: Do NOT apply backdrop-filter here. On iOS/WebKit, a backdrop-filter
+     on an ancestor creates a new compositing stacking context, which prevents
+     child panels (sheet-panel, modal-panel, wallet-section, etc.) from blurring
+     against the real content behind the overlay — they appear nearly opaque instead.
+     The dim effect is provided by the semi-transparent background alone. */
 }
 
 .overlay-scrim {


### PR DESCRIPTION
## Changes in this PR

### fix(ios-native): sync PWA default relays + inboxItem payload field
Relay list and inbox item payload alignment between iOS native and PWA.

---

### fix(pwa): remove backdrop-filter from overlay backdrops — fixes frosted glass on iOS

On iOS/WebKit, applying `backdrop-filter` to a parent element (like the overlay scrim) creates a new compositing stacking context. Child panels that also use `backdrop-filter` then blur against that layer instead of the real content behind the overlay — appearing opaque/white instead of frosted glass.

**Fix:** Removed `backdrop-filter` from `.modal-backdrop`, `.sheet-backdrop`, and `.drawer-backdrop`. The semi-transparent `rgba` background handles the dim scrim effect. Child panels now correctly blur against the underlying page content.

**Note:** Single-device "white panels" reports are likely caused by the iOS **Reduce Transparency** accessibility setting (`Settings → Accessibility → Display & Text Size`), which disables backdrop-filter system-wide. This compositing fix is still valid as a best-practice improvement.

## Files changed
- `taskify-pwa/src/index.css`