### PR TITLE
fix(pwa): wait for encrypted attachment upload before closing task editor

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -15721,7 +15721,7 @@ export default function App() {
     }
   }
 
-  function saveEdit(updated: Task) {
+  async function saveEdit(updated: Task) {
     let editedTask: Task | null = null;
     let previousAssignees: TaskAssignee[] | null = null;
     setTasks(prev => {
@@ -15762,7 +15762,6 @@ export default function App() {
           updatedAt: new Date().toISOString(),
         };
         const normalizedNext = normalizeTaskBounty(next);
-        maybePublishTask(normalizedNext).catch(() => {});
         editedTask = normalizedNext;
         return normalizedNext;
       });
@@ -15787,7 +15786,6 @@ export default function App() {
           };
         }
         const normalizedNext = normalizeTaskBounty(next);
-        maybePublishTask(normalizedNext).catch(() => {});
         editedTask = normalizedNext;
         const withNew = [...arr, normalizedNext];
         return settings.showFullWeekRecurring && editedTask?.recurrence
@@ -15799,6 +15797,7 @@ export default function App() {
         : arr;
     });
     if (editedTask) {
+      await maybePublishTask(editedTask);
       void maybeSendTaskAssignments(editedTask, { previousAssignees }).catch((err) => {
         console.warn("Failed to send task assignments", err);
       });

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -217,7 +217,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
   task: Task;
   onCancel: ()=>void;
   onDelete: ()=>void;
-  onSave: (t: Task)=>void;
+  onSave: (t: Task)=>void | Promise<void>;
   onSwitchToEvent?: (t: Task)=>void;
   weekStart: Weekday;
   boardKind: Board["kind"];
@@ -243,6 +243,8 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
   const [images, setImages] = useState<string[]>(task.images || []);
   const [previewImageSrc, setPreviewImageSrc] = useState<string | null>(null);
   const [documents, setDocuments] = useState<TaskDocument[]>(task.documents || []);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [subtasks, setSubtasks] = useState<Subtask[]>(task.subtasks || []);
   const [newSubtask, setNewSubtask] = useState("");
   const [selectedBoardId, setSelectedBoardId] = useState(task.boardId);
@@ -1459,8 +1461,17 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
     };
   }
 
-  function save(overrides: Partial<Task> = {}) {
-    onSave(normalizeTaskBounty(buildTask(overrides)));
+  async function save(overrides: Partial<Task> = {}) {
+    if (saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSave(normalizeTaskBounty(buildTask(overrides)));
+    } catch (err: any) {
+      console.error("Failed to save task", err);
+      setSaveError(err?.message || "Failed to save task.");
+      setSaving(false);
+    }
   }
 
   async function copyCurrent() {
@@ -1615,12 +1626,29 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
             className="edit-sheet__action edit-sheet__action--accent"
             onClick={() => save()}
             aria-label="Save task"
+            disabled={saving}
           >
-            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2}>
-              <path d="M5 12l4 4 10-10" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
+            {saving ? (
+              <span className="text-xs px-1">Uploading…</span>
+            ) : (
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path d="M5 12l4 4 10-10" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            )}
           </button>
         </div>
+
+        {saveError && (
+          <div className="px-4 pt-2 text-xs" style={{ color: "var(--color-rose, #f43f5e)" }}>
+            {saveError}
+          </div>
+        )}
+
+        {saving && (
+          <div className="px-4 pt-2 text-xs text-secondary">
+            Uploading encrypted attachments to your selected file server. Please keep Taskify open until save finishes.
+          </div>
+        )}
 
         {onSwitchToEvent && (
           <div className="mt-[-1rem] mb-[-1rem] w-full pb-[0.1rem]">


### PR DESCRIPTION
## Summary\n- waits for encrypted attachment upload before closing the task editor\n- adds visible upload/save progress state in the task editor\n- prevents users from closing/leaving before PDF/image encrypted upload finishes\n\n## Why\nPDF attachments were still ending up inline when the editor closed before the encrypted file-server upload path completed.\n\n## UX\n- save action shows **Uploading…**\n- helper text tells the user to keep Taskify open until save finishes\n- save errors stay visible in the modal instead of failing silently\n\n## Base branch\n- targets  only