### PR TITLE
chore(pwa): add attachment pipeline debug logging

### DIFF
--- a/taskify-pwa/src/lib/attachmentCrypto.ts
+++ b/taskify-pwa/src/lib/attachmentCrypto.ts
@@ -4,10 +4,15 @@ import type { FileServerEntry } from "./fileStorage";
 const aesKeyCache = new Map<string, Promise<CryptoKey>>();
 const decryptDataUrlCache = new Map<string, Promise<string>>();
 
+function attachmentDebug(event: string, detail?: Record<string, unknown>) {
+  console.info("[attachment-debug]", event, detail || {});
+}
+
 async function deriveBoardAesKey(boardId: string): Promise<CryptoKey> {
   const cached = aesKeyCache.get(boardId);
   if (cached) return cached;
   const promise = (async () => {
+    attachmentDebug("decrypt:start", { boardId: opts.boardId, url: opts.url, mimeType: opts.mimeType });
     const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(boardId));
     return crypto.subtle.importKey("raw", hash, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
   })();
@@ -45,20 +50,51 @@ export async function encryptAndUploadAttachment(opts: {
   nostrSkHex: string;
   signal?: AbortSignal;
 }): Promise<string> {
+  attachmentDebug("encrypt:start", {
+    boardId: opts.boardId,
+    filename: opts.filename,
+    mimeType: opts.mimeType,
+    plaintextBytes: opts.data.byteLength,
+    serverUrl: opts.serverEntry?.url,
+    serverType: opts.serverEntry?.type,
+  });
   const key = await deriveBoardAesKey(opts.boardId);
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ctBuf = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, opts.data);
   const combined = new Uint8Array(iv.length + ctBuf.byteLength);
+  attachmentDebug("encrypt:complete", {
+    filename: opts.filename,
+    plaintextBytes: opts.data.byteLength,
+    ciphertextBytes: combined.byteLength,
+    uploadContentType: "application/octet-stream",
+    uploadFilename: `${opts.filename}.enc`,
+    plaintextUploaded: false,
+  });
   combined.set(iv, 0);
   combined.set(new Uint8Array(ctBuf), iv.length);
   const blob = new Blob([combined], { type: "application/octet-stream" });
   const upload = await uploadFile({
+    debugMeta: {
+      source: "encryptAndUploadAttachment",
+      boardId: opts.boardId,
+      originalFilename: opts.filename,
+      originalMimeType: opts.mimeType,
+      plaintextBytes: opts.data.byteLength,
+      ciphertextBytes: combined.byteLength,
+      plaintextUploaded: false,
+    },
     serverEntry: opts.serverEntry,
     file: blob,
     filename: `${opts.filename}.enc`,
     contentType: "application/octet-stream",
     signer: opts.nostrSkHex,
     signal: opts.signal,
+  });
+  attachmentDebug("upload:complete", {
+    filename: opts.filename,
+    remoteUrl: upload.url,
+    serverUrl: opts.serverEntry?.url,
+    serverType: opts.serverEntry?.type,
   });
   return upload.url;
 }
@@ -73,13 +109,16 @@ export async function decryptAttachment(opts: {
   if (cached) return cached;
   const promise = (async () => {
     const res = await fetch(opts.url);
+    attachmentDebug("decrypt:fetch", { url: opts.url, status: res.status, ok: res.ok });
     if (!res.ok) throw new Error(`Failed to fetch attachment (${res.status})`);
     const bytes = new Uint8Array(await res.arrayBuffer());
+    attachmentDebug("decrypt:fetched-bytes", { url: opts.url, encryptedBytes: bytes.byteLength });
     if (bytes.length < 13) throw new Error("Encrypted attachment too small");
     const iv = bytes.slice(0, 12);
     const ct = bytes.slice(12);
     const key = await deriveBoardAesKey(opts.boardId);
     const ptBuf = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+    attachmentDebug("decrypt:success", { url: opts.url, plaintextBytes: ptBuf.byteLength, mimeType: opts.mimeType });
     return bytesToDataUrl(new Uint8Array(ptBuf), opts.mimeType || "application/octet-stream");
   })();
   decryptDataUrlCache.set(cacheKey, promise);
@@ -87,6 +126,7 @@ export async function decryptAttachment(opts: {
     return await promise;
   } catch (err) {
     decryptDataUrlCache.delete(cacheKey);
+    attachmentDebug("decrypt:error", { url: opts.url, message: err instanceof Error ? err.message : String(err) });
     throw err;
   }
 }

--- a/taskify-pwa/src/nostr/Nip96Client.ts
+++ b/taskify-pwa/src/nostr/Nip96Client.ts
@@ -108,6 +108,7 @@ async function pollProcessingUrl(url: string, headers: HeadersInit, timeoutMs: n
   while (Date.now() - started < timeoutMs) {
     const res = await fetch(absoluteUrl, { headers });
     const data = await parseJsonSafe(res);
+  console.info("[attachment-debug] upload:blossom:response", { status: res.status, ok: res.ok, data });
     lastData = data;
     if (res.status !== 202) {
       return { status: res.status, data };
@@ -144,7 +145,13 @@ export async function uploadFileToNip96(options: {
   signal?: AbortSignal;
 }): Promise<Nip96UploadResult> {
   const info = await discoverNip96Server(options.serverUrl);
-  console.info("[nip96] Uploading file", { server: info.baseUrl, apiUrl: info.apiUrl });
+  console.info("[attachment-debug] upload:nip96:start", {
+    server: info.baseUrl,
+    apiUrl: info.apiUrl,
+    filename: options.filename,
+    contentType: options.contentType || options.file.type || "application/octet-stream",
+    blobBytes: options.file.size,
+  });
 
   const uploadFile =
     options.file instanceof File
@@ -173,6 +180,7 @@ export async function uploadFileToNip96(options: {
   });
 
   let data = await parseJsonSafe(res);
+  console.info("[attachment-debug] upload:nip96:response", { status: res.status, ok: res.ok, data });
   if (res.status === 202 && data?.processing_url) {
     const processingUrl = new URL(data.processing_url, info.apiUrl).toString();
     const poll = await pollProcessingUrl(processingUrl, headers, options.timeoutMs ?? 12000);
@@ -190,7 +198,7 @@ export async function uploadFileToNip96(options: {
   }
 
   const nip94 = (data?.nip94_event || data?.nip94) as NostrEvent | null | undefined;
-  console.info("[nip96] Upload complete", { url: pictureUrl });
+  console.info("[attachment-debug] upload:nip96:complete", { url: pictureUrl, response: data });
 
   return {
     url: pictureUrl,
@@ -240,6 +248,20 @@ export async function uploadFileToBlossom(options: {
   const bytes = new Uint8Array(await options.file.arrayBuffer());
   const fileHash = bytesToHex(sha256(bytes));
   const uploadUrl = `${normalizeFileServerUrl(options.serverUrl) || options.serverUrl}/upload`;
+  console.info("[attachment-debug] upload:originless:start", {
+    server: options.serverUrl,
+    uploadUrl,
+    filename: options.filename,
+    blobBytes: options.file.size,
+    contentType: options.file.type || "application/octet-stream",
+  });
+  console.info("[attachment-debug] upload:blossom:start", {
+    server: options.serverUrl,
+    uploadUrl,
+    filename: options.filename,
+    contentType: options.contentType || options.file.type || "application/octet-stream",
+    blobBytes: options.file.size,
+  });
   const res = await fetch(uploadUrl, {
     method: "PUT",
     headers: {
@@ -253,6 +275,8 @@ export async function uploadFileToBlossom(options: {
   if (!res.ok) throw new Error(data?.message || `Blossom upload failed (${res.status})`);
   const url = typeof data?.url === "string" ? data.url.trim() : "";
   if (!url) throw new Error("Blossom upload response did not include a url.");
+  console.info("[attachment-debug] upload:blossom:complete", { url, response: data });
+  console.info("[attachment-debug] upload:originless:complete", { url, response: data });
   return { url, nip94: null };
 }
 
@@ -273,6 +297,7 @@ export async function uploadFileToOriginless(options: {
     signal: options.signal,
   });
   const data = await parseJsonSafe(res);
+  console.info("[attachment-debug] upload:originless:response", { status: res.status, ok: res.ok, data });
   if (!res.ok) throw new Error(data?.message || `Originless upload failed (${res.status})`);
   const url = typeof data?.url === "string" ? data.url.trim() : "";
   if (!url) throw new Error("Originless upload response did not include a url.");
@@ -288,10 +313,19 @@ export type UploadFileOptions = {
   contentType?: string;
   signer?: string | Uint8Array;
   signal?: AbortSignal;
+  debugMeta?: Record<string, unknown>;
 };
 
 export async function uploadFile(options: UploadFileOptions): Promise<{ url: string; nip94: NostrEvent | null }> {
-  const { serverEntry, file, filename, contentType, signer, signal } = options;
+  const { serverEntry, file, filename, contentType, signer, signal, debugMeta } = options;
+  console.info("[attachment-debug] upload:dispatch", {
+    serverType: serverEntry.type,
+    serverUrl: serverEntry.url,
+    filename,
+    contentType: contentType || file.type || "application/octet-stream",
+    blobBytes: file.size,
+    debugMeta,
+  });
   if (serverEntry.type === "blossom") {
     if (!signer) throw new Error("signer is required for Blossom uploads");
     const result = await uploadFileToBlossom({ serverUrl: serverEntry.url, file, filename, contentType, signer, signal });

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1139,6 +1139,16 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
   }
 
   async function uploadSharedDocument(file: File, doc: TaskDocument): Promise<TaskDocument> {
+    console.info("[attachment-debug] shared-document:start", {
+      filename: file.name,
+      fileType: file.type,
+      fileBytes: file.size,
+      docKind: doc.kind,
+      docMimeType: doc.mimeType,
+      boardId: selectedBoard?.nostr?.boardId,
+      serverUrl: selectedServerEntry?.url,
+      serverType: selectedServerEntry?.type,
+    });
     const bytes = new Uint8Array(await file.arrayBuffer());
     const remoteUrl = await encryptAndUploadAttachment({
       boardId: selectedBoard!.nostr!.boardId,


### PR DESCRIPTION
## Summary
- adds in-app attachment debug logs for encrypt, upload, and decrypt flows
- logs plaintext vs ciphertext byte counts and upload target metadata
- logs NIP-96, Blossom, and Originless response payloads to diagnose compatibility issues

## Validation
- taskify-pwa build passes