### PR TITLE
fix(pwa): use canonical board key for encrypted docs

### DIFF
--- a/taskify-pwa/src/lib/documents.ts
+++ b/taskify-pwa/src/lib/documents.ts
@@ -26,6 +26,9 @@ export type TaskDocument = {
   createdAt: string;
   preview?: TaskDocumentPreview;
   full?: TaskDocumentFull;
+  remoteUrl?: string;
+  encrypted?: boolean;
+  encryptionBoardId?: string;
 };
 
 const EXTENSION_TO_KIND: Record<string, TaskDocumentKind> = {
@@ -160,6 +163,7 @@ export function normalizeDocumentList(raw: unknown): TaskDocument[] | undefined 
     const dataUrl = typeof (entry as any).dataUrl === "string" ? (entry as any).dataUrl : "";
     const remoteUrl = typeof (entry as any).remoteUrl === "string" ? (entry as any).remoteUrl.trim() : "";
     const encrypted = (entry as any).encrypted === true;
+    const encryptionBoardId = typeof (entry as any).encryptionBoardId === "string" ? (entry as any).encryptionBoardId.trim() : "";
     // Accept legacy inline docs (dataUrl present) and remote-first docs (remoteUrl present)
     if (!name || (!dataUrl && !remoteUrl)) continue;
     const kindInput = typeof (entry as any).kind === "string" ? (entry as any).kind.toLowerCase() : "";
@@ -187,6 +191,7 @@ export function normalizeDocumentList(raw: unknown): TaskDocument[] | undefined 
       full: full || undefined,
       ...(remoteUrl ? { remoteUrl } : {}),
       ...(encrypted ? { encrypted: true } : {}),
+      ...(encryptionBoardId ? { encryptionBoardId } : {}),
     });
   }
   return normalized.length ? normalized : undefined;

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -80,6 +80,7 @@ export function DocumentPreviewModal({
   const [remoteError, setRemoteError] = useState<string | null>(null);
   const full = document.full;
   const label = document.name || "Document";
+  const decryptBoardId = document.encryptionBoardId || boardId;
 
   useEffect(() => {
     let cancelled = false;
@@ -89,10 +90,17 @@ export function DocumentPreviewModal({
       setRemoteError(null);
       return;
     }
-    if (document.encrypted && boardId) {
+    if (document.encrypted && decryptBoardId) {
+      console.info("[attachment-debug] document-preview:decrypt-context", {
+        documentId: document.id,
+        documentName: document.name,
+        boardIdProp: boardId,
+        encryptionBoardId: document.encryptionBoardId,
+        decryptBoardId,
+      });
       setLoadingRemote(true);
       setRemoteError(null);
-      decryptAttachment({ boardId, url: document.remoteUrl, mimeType: document.mimeType })
+      decryptAttachment({ boardId: decryptBoardId, url: document.remoteUrl, mimeType: document.mimeType })
         .then((dataUrl) => {
           if (cancelled) return;
           setResolvedDataUrl(dataUrl);
@@ -113,7 +121,7 @@ export function DocumentPreviewModal({
     return () => {
       cancelled = true;
     };
-  }, [document, boardId]);
+  }, [document, boardId, decryptBoardId]);
 
   const effectiveDocument = resolvedDataUrl && resolvedDataUrl !== document.dataUrl
     ? { ...document, dataUrl: resolvedDataUrl }

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1159,7 +1159,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
       nostrSkHex,
     });
     const { dataUrl, preview, full, ...rest } = doc as any;
-    return { ...rest, remoteUrl, encrypted: true };
+    return { ...rest, remoteUrl, encrypted: true, encryptionBoardId: selectedBoard!.nostr!.boardId };
   }
 
   async function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {


### PR DESCRIPTION
## Summary
- stores canonical shared board ids on encrypted remote documents
- uses that canonical board id during document decrypt instead of transient UI board ids like week-default
- logs document decrypt context for verification

## Validation
- taskify-pwa build passes