### PR TITLE
refactor(pwa): unify encrypted attachment preview cache

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -8982,13 +8982,9 @@ export default function App() {
   }, []);
 
   const openDocumentPreview = useCallback((doc: TaskDocument, boardId?: string) => {
-    if (doc.kind === "pdf") {
-      handleDownloadDocument(doc, boardId);
-      return;
-    }
     setPreviewDocument(doc);
     setPreviewDocumentBoardId(boardId);
-  }, [handleDownloadDocument]);
+  }, []);
   const handleOpenDocument = useCallback((task: Task, doc: TaskDocument) => {
     openDocumentPreview(doc, task.boardId);
   }, [openDocumentPreview]);
@@ -12248,7 +12244,7 @@ export default function App() {
           nostrSkHex,
         });
         const { dataUrl: _d, preview: _p, full: _f, ...rest } = doc as any;
-        return { ...rest, remoteUrl, encrypted: true };
+        return { ...rest, remoteUrl, encrypted: true, encryptionBoardId: params.boardId };
       } catch (err: any) {
         console.error("[attachments] Failed to encrypt/upload document", err);
         throw new Error(err?.message || `Failed to upload encrypted file attachment: ${doc?.name || "document"}`);

--- a/taskify-pwa/src/lib/documents.ts
+++ b/taskify-pwa/src/lib/documents.ts
@@ -562,19 +562,31 @@ function wrapSheetHtml(rows: Array<Array<unknown>>, maxRows: number, maxCols: nu
   return `<div class="doc-sheet"><table><tbody>${body}</tbody></table></div>`;
 }
 
-export async function createDocumentAttachment(file: File): Promise<TaskDocument> {
-  const kind = inferKind(file.name, file.type);
+export async function createDocumentFromDataUrl(input: {
+  id?: string;
+  name: string;
+  mimeType: string;
+  dataUrl: string;
+  createdAt?: string;
+  size?: number;
+  remoteUrl?: string;
+  encrypted?: boolean;
+  encryptionBoardId?: string;
+}): Promise<TaskDocument> {
+  const kind = inferKind(input.name, input.mimeType);
   if (!kind) throw new Error("Unsupported file type");
-  const dataUrl = await readFileAsDataURL(file);
-  const buffer = await file.arrayBuffer();
+  const buffer = arrayBufferFromDataUrl(input.dataUrl);
   const base: TaskDocument = {
-    id: generateId(),
-    name: file.name,
-    mimeType: guessMime(kind, file.type),
+    id: input.id || generateId(),
+    name: input.name,
+    mimeType: guessMime(kind, input.mimeType),
     kind,
-    size: typeof file.size === "number" ? file.size : undefined,
-    dataUrl,
-    createdAt: new Date().toISOString(),
+    size: typeof input.size === "number" ? input.size : undefined,
+    dataUrl: input.dataUrl,
+    createdAt: input.createdAt || new Date().toISOString(),
+    ...(input.remoteUrl ? { remoteUrl: input.remoteUrl } : {}),
+    ...(input.encrypted ? { encrypted: true } : {}),
+    ...(input.encryptionBoardId ? { encryptionBoardId: input.encryptionBoardId } : {}),
   };
 
   if (kind === "pdf") {
@@ -590,10 +602,6 @@ export async function createDocumentAttachment(file: File): Promise<TaskDocument
     const { previewText, fullText } = generateDocBinary(buffer);
     if (previewText) base.preview = { type: "text", data: previewText };
     if (fullText) base.full = { type: "text", data: fullText };
-  } else if (kind === "doc") {
-    const { previewText, fullText } = generateDocBinary(buffer);
-    if (previewText) base.preview = { type: "text", data: previewText };
-    if (fullText) base.full = { type: "text", data: fullText };
   } else if (kind === "xls" || kind === "xlsx") {
     const { previewHtml, fullHtml } = await generateSpreadsheetMarkup(buffer, kind);
     if (previewHtml) base.preview = { type: "html", data: previewHtml };
@@ -603,15 +611,25 @@ export async function createDocumentAttachment(file: File): Promise<TaskDocument
     if (previewText) base.preview = { type: "text", data: previewText };
     if (fullText) base.full = { type: "text", data: fullText };
   } else if (isImageKind(kind)) {
-    base.preview = { type: "image", data: dataUrl };
-    base.full = { type: "image", data: dataUrl };
+    base.preview = { type: "image", data: input.dataUrl };
+    base.full = { type: "image", data: input.dataUrl };
   } else if (isAudioKind(kind)) {
-    base.full = { type: "audio", data: dataUrl };
+    base.full = { type: "audio", data: input.dataUrl };
   } else if (isVideoKind(kind)) {
-    base.full = { type: "video", data: dataUrl };
+    base.full = { type: "video", data: input.dataUrl };
   }
 
   return base;
+}
+
+export async function createDocumentAttachment(file: File): Promise<TaskDocument> {
+  const dataUrl = await readFileAsDataURL(file);
+  return createDocumentFromDataUrl({
+    name: file.name,
+    mimeType: file.type,
+    dataUrl,
+    size: typeof file.size === "number" ? file.size : undefined,
+  });
 }
 
 export function ensureDocumentPreview(doc: TaskDocument): TaskDocument {
@@ -716,4 +734,12 @@ export async function readDocumentsFromFiles(list: FileList | File[]): Promise<T
     attachments.push(ensureDocumentPreview(doc));
   }
   return attachments;
+}
+
+export function documentAssetCacheKey(doc: Pick<TaskDocument, "remoteUrl" | "encrypted" | "encryptionBoardId" | "id">, boardId?: string): string {
+  if (doc.remoteUrl) {
+    const keyBoardId = doc.encrypted ? (doc.encryptionBoardId || boardId || "") : "public";
+    return `remote::${doc.remoteUrl}::${keyBoardId}`;
+  }
+  return `inline::${doc.id}`;
 }

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -1,30 +1,90 @@
 import React, { useState, useEffect } from "react";
 import type { TaskDocument, TaskDocumentPreview } from "../../lib/documents";
-import { loadDocumentPreview } from "../../lib/documents";
+import { createDocumentFromDataUrl, documentAssetCacheKey, loadDocumentPreview } from "../../lib/documents";
 import { Modal } from "../Modal";
 import { decryptAttachment } from "../../lib/attachmentCrypto";
 
-export function DocumentThumbnail({ document: doc, onClick }: { document: TaskDocument; onClick: () => void }) {
+const resolvedDocumentCache = new Map<string, Promise<TaskDocument>>();
+
+async function resolveDocumentAsset(doc: TaskDocument, boardId?: string): Promise<TaskDocument> {
+  if (!doc.remoteUrl) return doc;
+  const decryptBoardId = doc.encryptionBoardId || boardId;
+  const cacheKey = documentAssetCacheKey(doc, boardId);
+  const cached = resolvedDocumentCache.get(cacheKey);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    if (doc.encrypted && decryptBoardId) {
+      console.info("[attachment-debug] document-resolve:decrypt-context", {
+        documentId: doc.id,
+        documentName: doc.name,
+        boardIdProp: boardId,
+        encryptionBoardId: doc.encryptionBoardId,
+        decryptBoardId,
+        cacheKey,
+      });
+      const dataUrl = await decryptAttachment({ boardId: decryptBoardId, url: doc.remoteUrl, mimeType: doc.mimeType });
+      return createDocumentFromDataUrl({
+        id: doc.id,
+        name: doc.name,
+        mimeType: doc.mimeType,
+        dataUrl,
+        createdAt: doc.createdAt,
+        size: doc.size,
+        remoteUrl: doc.remoteUrl,
+        encrypted: doc.encrypted,
+        encryptionBoardId: doc.encryptionBoardId || decryptBoardId,
+      });
+    }
+
+    return createDocumentFromDataUrl({
+      id: doc.id,
+      name: doc.name,
+      mimeType: doc.mimeType,
+      dataUrl: doc.remoteUrl,
+      createdAt: doc.createdAt,
+      size: doc.size,
+      remoteUrl: doc.remoteUrl,
+      encrypted: doc.encrypted,
+      encryptionBoardId: doc.encryptionBoardId,
+    });
+  })().catch((err) => {
+    resolvedDocumentCache.delete(cacheKey);
+    throw err;
+  });
+
+  resolvedDocumentCache.set(cacheKey, promise);
+  return promise;
+}
+
+export function DocumentThumbnail({ document: doc, boardId, onClick }: { document: TaskDocument; boardId?: string; onClick: () => void }) {
   const [derivedPreview, setDerivedPreview] = useState<TaskDocumentPreview | null>(doc.preview ?? null);
 
   useEffect(() => {
     let cancelled = false;
-    if (doc.preview) {
+    if (doc.preview && !doc.remoteUrl) {
       setDerivedPreview(doc.preview);
       return () => {
         cancelled = true;
       };
     }
-    setDerivedPreview(null);
-    loadDocumentPreview(doc).then((next) => {
-      if (!cancelled) {
-        setDerivedPreview(next);
-      }
-    });
+    setDerivedPreview(doc.preview ?? null);
+    resolveDocumentAsset(doc, boardId)
+      .then((resolved) => loadDocumentPreview(resolved))
+      .then((next) => {
+        if (!cancelled) {
+          setDerivedPreview(next);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDerivedPreview(doc.preview ?? null);
+        }
+      });
     return () => {
       cancelled = true;
     };
-  }, [doc]);
+  }, [doc, boardId]);
 
   const preview = derivedPreview ?? doc.preview ?? null;
   const label = doc.name || "Document";
@@ -72,60 +132,43 @@ export function DocumentPreviewModal({
   document: TaskDocument;
   boardId?: string;
   onClose: () => void;
-  onDownloadDocument?: (doc: TaskDocument) => void;
-  onOpenExternal?: (doc: TaskDocument) => void;
+  onDownloadDocument?: (doc: TaskDocument, boardId?: string) => void;
+  onOpenExternal?: (doc: TaskDocument, boardId?: string) => void;
 }) {
-  const [resolvedDataUrl, setResolvedDataUrl] = useState<string | null>(document.dataUrl || null);
+  const [resolvedDocument, setResolvedDocument] = useState<TaskDocument>(document);
   const [loadingRemote, setLoadingRemote] = useState(false);
   const [remoteError, setRemoteError] = useState<string | null>(null);
-  const full = document.full;
   const label = document.name || "Document";
   const decryptBoardId = document.encryptionBoardId || boardId;
 
   useEffect(() => {
     let cancelled = false;
     if (!document.remoteUrl) {
-      setResolvedDataUrl(document.dataUrl || null);
+      setResolvedDocument(document);
       setLoadingRemote(false);
       setRemoteError(null);
       return;
     }
-    if (document.encrypted && decryptBoardId) {
-      console.info("[attachment-debug] document-preview:decrypt-context", {
-        documentId: document.id,
-        documentName: document.name,
-        boardIdProp: boardId,
-        encryptionBoardId: document.encryptionBoardId,
-        decryptBoardId,
-      });
-      setLoadingRemote(true);
-      setRemoteError(null);
-      decryptAttachment({ boardId: decryptBoardId, url: document.remoteUrl, mimeType: document.mimeType })
-        .then((dataUrl) => {
-          if (cancelled) return;
-          setResolvedDataUrl(dataUrl);
-          setLoadingRemote(false);
-        })
-        .catch((err: any) => {
-          if (cancelled) return;
-          setRemoteError(err?.message || "Failed to decrypt document");
-          setLoadingRemote(false);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }
-    setResolvedDataUrl(document.remoteUrl);
-    setLoadingRemote(false);
+    setLoadingRemote(true);
     setRemoteError(null);
+    resolveDocumentAsset(document, boardId)
+      .then((resolved) => {
+        if (cancelled) return;
+        setResolvedDocument(resolved);
+        setLoadingRemote(false);
+      })
+      .catch((err: any) => {
+        if (cancelled) return;
+        setRemoteError(err?.message || "Failed to decrypt document");
+        setLoadingRemote(false);
+      });
     return () => {
       cancelled = true;
     };
-  }, [document, boardId, decryptBoardId]);
+  }, [document, boardId]);
 
-  const effectiveDocument = resolvedDataUrl && resolvedDataUrl !== document.dataUrl
-    ? { ...document, dataUrl: resolvedDataUrl }
-    : document;
+  const effectiveDocument = resolvedDocument;
+  const full = effectiveDocument.full;
 
   let content: React.ReactNode;
   if (loadingRemote) {
@@ -141,7 +184,7 @@ export function DocumentPreviewModal({
             type="button"
             className="ghost-button button-sm pressable"
             style={{ marginTop: "0.75rem" }}
-            onClick={() => onOpenExternal?.(effectiveDocument)}
+            onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}
           >
             Open full screen
           </button>
@@ -196,7 +239,7 @@ export function DocumentPreviewModal({
       <button
         type="button"
         className="ghost-button button-sm pressable"
-        onClick={() => onDownloadDocument?.(effectiveDocument)}
+        onClick={() => onDownloadDocument?.(effectiveDocument, decryptBoardId)}
       >
         Download
       </button>


### PR DESCRIPTION
## Summary
- centralizes encrypted document resolution behind a shared cache keyed by attachment URL and canonical board id
- drives thumbnails and modal previews from the same resolved cached asset
- routes PDFs through the unified preview/decrypt path instead of bypassing directly to download
- preserves encryptionBoardId when remote encrypted docs are uploaded during publish

## Validation
- taskify-pwa build passes