### PR TITLE
feat(pwa): split file servers and fix attachment previews

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -178,7 +178,7 @@ import {
   MARK_HISTORY_ENTRIES_OLDER_SPENT_EVENT,
   type HistoryEntryRaw,
 } from "./lib/walletHistory";
-import { DEFAULT_FILE_STORAGE_SERVER, normalizeFileServerUrl, parseFileServers, findServerEntry, serializeFileServers, DEFAULT_FILE_SERVERS } from "./lib/fileStorage";
+import { DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER, DEFAULT_FILE_STORAGE_SERVER, normalizeFileServerUrl, parseFileServers, findServerEntry, serializeFileServers, DEFAULT_FILE_SERVERS } from "./lib/fileStorage";
 import { encryptAndUploadAttachment, parseDataUrl, decryptAttachment } from "./lib/attachmentCrypto";
 import { NostrSession } from "./nostr/NostrSession";
 import { SessionPool } from "./nostr/SessionPool";
@@ -1570,6 +1570,7 @@ type Settings = {
   walletMintBackupEnabled: boolean;
   walletContactsSyncEnabled: boolean;
   fileStorageServer: string;
+  encryptedFileStorageServer: string;
   fileServers: string; // JSON-serialized FileServerEntry[]
   npubCashLightningAddressEnabled: boolean;
   npubCashAutoClaim: boolean;
@@ -3926,6 +3927,12 @@ function useSettings() {
             ? parsed.fileStorageServer.trim()
             : DEFAULT_FILE_STORAGE_SERVER,
         ) || DEFAULT_FILE_STORAGE_SERVER;
+      const encryptedFileStorageServer =
+        normalizeFileServerUrl(
+          typeof parsed?.encryptedFileStorageServer === "string" && parsed.encryptedFileStorageServer.trim()
+            ? parsed.encryptedFileStorageServer.trim()
+            : DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
+        ) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
       const fileServers = (() => {
         if (typeof parsed?.fileServers === "string" && parsed.fileServers.trim()) {
           return parsed.fileServers.trim();
@@ -4034,6 +4041,7 @@ function useSettings() {
           : false,
         walletContactsSyncEnabled,
         fileStorageServer,
+        encryptedFileStorageServer,
         fileServers: typeof parsed?.fileServers === "string" && parsed.fileServers.trim()
           ? parsed.fileServers.trim()
           : serializeFileServers(DEFAULT_FILE_SERVERS),
@@ -4071,6 +4079,7 @@ function useSettings() {
         walletPaymentRequestsBackgroundChecksEnabled: true,
         walletContactsSyncEnabled: true,
         fileStorageServer: DEFAULT_FILE_STORAGE_SERVER,
+        encryptedFileStorageServer: DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
         fileServers: serializeFileServers(DEFAULT_FILE_SERVERS),
         npubCashLightningAddressEnabled: true,
         npubCashAutoClaim: true,
@@ -4121,6 +4130,19 @@ function useSettings() {
       } else {
         next.fileStorageServer =
           normalizeFileServerUrl(next.fileStorageServer) || DEFAULT_FILE_STORAGE_SERVER;
+      }
+      if (Object.prototype.hasOwnProperty.call(s, "encryptedFileStorageServer")) {
+        const rawServer = (s as any).encryptedFileStorageServer;
+        const normalizedServer =
+          typeof rawServer === "string" && rawServer.trim()
+            ? normalizeFileServerUrl(rawServer) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER
+            : DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
+        next.encryptedFileStorageServer = normalizedServer;
+      } else if (!next.encryptedFileStorageServer) {
+        next.encryptedFileStorageServer = DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
+      } else {
+        next.encryptedFileStorageServer =
+          normalizeFileServerUrl(next.encryptedFileStorageServer) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
       }
       if (Object.prototype.hasOwnProperty.call(s, "fileServers")) {
         // fileServers changed: validate and keep in sync
@@ -12203,7 +12225,7 @@ export default function App() {
     const servers = parseFileServers(settings.fileServers);
     const serverEntry = findServerEntry(servers, settings.fileStorageServer)
       ?? servers[0]
-      ?? { url: settings.fileStorageServer, type: "nip96" as const };
+      ?? { url: settings.encryptedFileStorageServer, type: "nip96" as const };
 
     const nextImages = typeof params.images === "undefined" ? null : await Promise.all((params.images || []).map(async (img, index) => {
       if (!img || !img.startsWith("data:")) return img; // already a remote URL

--- a/taskify-pwa/src/domains/tasks/settingsHook.ts
+++ b/taskify-pwa/src/domains/tasks/settingsHook.ts
@@ -8,7 +8,7 @@ import { LS_MINT_BACKUP_ENABLED } from "../../localStorageKeys";
 import { idbKeyValue } from "../../storage/idbKeyValue";
 import { TASKIFY_STORE_TASKS } from "../../storage/taskifyDb";
 import { normalizeAccentPalette, normalizeAccentPaletteList } from "../../theme/palette";
-import { DEFAULT_FILE_STORAGE_SERVER, normalizeFileServerUrl } from "../../lib/fileStorage";
+import { DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER, DEFAULT_FILE_STORAGE_SERVER, normalizeFileServerUrl } from "../../lib/fileStorage";
 import { detectPushPlatformFromNavigator, INFERRED_PUSH_PLATFORM } from "../push/pushUtils";
 import type { PushPreferences } from "../push/pushUtils";
 import { SCRIPTURE_MEMORY_FREQUENCIES, SCRIPTURE_MEMORY_SORTS } from "../scripture/scriptureUtils";
@@ -89,6 +89,12 @@ function useSettings() {
             ? parsed.fileStorageServer.trim()
             : DEFAULT_FILE_STORAGE_SERVER,
         ) || DEFAULT_FILE_STORAGE_SERVER;
+      const encryptedFileStorageServer =
+        normalizeFileServerUrl(
+          typeof parsed?.encryptedFileStorageServer === "string" && parsed.encryptedFileStorageServer.trim()
+            ? parsed.encryptedFileStorageServer.trim()
+            : DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
+        ) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
       const nostrBackupEnabled = parsed?.nostrBackupEnabled !== false;
       const nostrBackupMetadataEnabled = nostrBackupEnabled;
 
@@ -186,6 +192,7 @@ function useSettings() {
           : false,
         walletContactsSyncEnabled,
         fileStorageServer,
+        encryptedFileStorageServer,
         walletMintBackupEnabled,
         npubCashLightningAddressEnabled,
         npubCashAutoClaim: npubCashLightningAddressEnabled ? npubCashAutoClaim : false,
@@ -221,6 +228,7 @@ function useSettings() {
         walletPaymentRequestsBackgroundChecksEnabled: true,
         walletContactsSyncEnabled: true,
         fileStorageServer: DEFAULT_FILE_STORAGE_SERVER,
+        encryptedFileStorageServer: DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
         npubCashLightningAddressEnabled: true,
         npubCashAutoClaim: true,
         cloudBackupsEnabled: false,
@@ -262,6 +270,19 @@ function useSettings() {
       } else {
         next.fileStorageServer =
           normalizeFileServerUrl(next.fileStorageServer) || DEFAULT_FILE_STORAGE_SERVER;
+      }
+      if (Object.prototype.hasOwnProperty.call(s, "encryptedFileStorageServer")) {
+        const rawServer = (s as any).encryptedFileStorageServer;
+        const normalizedServer =
+          typeof rawServer === "string" && rawServer.trim()
+            ? normalizeFileServerUrl(rawServer) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER
+            : DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
+        next.encryptedFileStorageServer = normalizedServer;
+      } else if (!next.encryptedFileStorageServer) {
+        next.encryptedFileStorageServer = DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
+      } else {
+        next.encryptedFileStorageServer =
+          normalizeFileServerUrl(next.encryptedFileStorageServer) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
       }
       if (!next.backgroundImage) {
         next.backgroundImage = null;

--- a/taskify-pwa/src/domains/tasks/settingsTypes.ts
+++ b/taskify-pwa/src/domains/tasks/settingsTypes.ts
@@ -57,6 +57,7 @@ export type Settings = {
   walletMintBackupEnabled: boolean;
   walletContactsSyncEnabled: boolean;
   fileStorageServer: string;
+  encryptedFileStorageServer: string;
   fileServers: string; // JSON-serialized FileServerEntry[]
   npubCashLightningAddressEnabled: boolean;
   npubCashAutoClaim: boolean;

--- a/taskify-pwa/src/lib/fileStorage.ts
+++ b/taskify-pwa/src/lib/fileStorage.ts
@@ -1,5 +1,3 @@
-export const DEFAULT_FILE_STORAGE_SERVER = "https://nostr.build";
-
 export type FileServerType = "nip96" | "blossom" | "originless";
 
 export type FileServerEntry = {
@@ -8,45 +6,16 @@ export type FileServerEntry = {
   label?: string;
 };
 
+export const DEFAULT_PUBLIC_FILE_STORAGE_SERVER = "https://nostr.build";
+export const DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER = "https://originless.solife.me";
+export const DEFAULT_FILE_STORAGE_SERVER = DEFAULT_PUBLIC_FILE_STORAGE_SERVER;
+
 export const DEFAULT_FILE_SERVERS: FileServerEntry[] = [
   { url: "https://nostr.build", type: "nip96", label: "nostr.build" },
-  { url: "https://originless.besoeasy.com", type: "originless", label: "originless.besoeasy.com" },
   { url: "https://blossom.band", type: "blossom", label: "blossom.band" },
+  { url: "https://originless.besoeasy.com", type: "originless", label: "originless.besoeasy.com" },
+  { url: "https://originless.solife.me", type: "originless", label: "originless.solife.me" },
 ];
-
-export function parseFileServers(raw: string | null | undefined): FileServerEntry[] {
-  if (!raw) return DEFAULT_FILE_SERVERS.slice();
-  try {
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return DEFAULT_FILE_SERVERS.slice();
-    const valid = parsed.filter(
-      (e): e is FileServerEntry =>
-        e &&
-        typeof e === "object" &&
-        typeof e.url === "string" &&
-        e.url.trim() !== "" &&
-        (e.type === "nip96" || e.type === "blossom" || e.type === "originless"),
-    );
-    return valid.length ? valid : DEFAULT_FILE_SERVERS.slice();
-  } catch {
-    return DEFAULT_FILE_SERVERS.slice();
-  }
-}
-
-export function serializeFileServers(servers: FileServerEntry[]): string {
-  return JSON.stringify(servers);
-}
-
-export function findServerEntry(
-  servers: FileServerEntry[],
-  url: string,
-): FileServerEntry | undefined {
-  const normalized = normalizeFileServerUrl(url) || url;
-  return servers.find((e) => {
-    const entryNorm = normalizeFileServerUrl(e.url) || e.url;
-    return entryNorm === normalized;
-  });
-}
 
 function trimTrailingSlash(url: string): string {
   return url.endsWith("/") ? url.replace(/\/+$/, "") : url;
@@ -59,9 +28,7 @@ export function normalizeFileServerUrl(value: string | null | undefined): string
   const tryBuild = (input: string): string | null => {
     try {
       const parsed = new URL(input);
-      if (!parsed.protocol || parsed.protocol === ":") {
-        return null;
-      }
+      if (!parsed.protocol || parsed.protocol === ":") return null;
       const base = `${parsed.protocol}//${parsed.host}`;
       const path = parsed.pathname ? trimTrailingSlash(parsed.pathname) : "";
       return `${base}${path}`;
@@ -71,4 +38,39 @@ export function normalizeFileServerUrl(value: string | null | undefined): string
   };
 
   return tryBuild(raw) ?? tryBuild(`https://${raw}`) ?? "";
+}
+
+export function inferFileServerType(url: string): FileServerType {
+  const normalized = normalizeFileServerUrl(url).toLowerCase();
+  if (normalized.includes("originless")) return "originless";
+  if (normalized.includes("blossom")) return "blossom";
+  return "nip96";
+}
+
+export function parseFileServers(raw: string | null | undefined): FileServerEntry[] {
+  if (!raw) return DEFAULT_FILE_SERVERS;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return DEFAULT_FILE_SERVERS;
+    const normalized = parsed
+      .map((entry: any): FileServerEntry | null => {
+        const url = normalizeFileServerUrl(entry?.url);
+        const type = entry?.type;
+        if (!url || (type !== "nip96" && type !== "blossom" && type !== "originless")) return null;
+        return { url, type, ...(entry?.label ? { label: String(entry.label) } : {}) };
+      })
+      .filter(Boolean) as FileServerEntry[];
+    return normalized.length ? normalized : DEFAULT_FILE_SERVERS;
+  } catch {
+    return DEFAULT_FILE_SERVERS;
+  }
+}
+
+export function serializeFileServers(servers: FileServerEntry[]): string {
+  return JSON.stringify(servers.map((entry) => ({ url: normalizeFileServerUrl(entry.url) || entry.url, type: entry.type, ...(entry.label ? { label: entry.label } : {}) })));
+}
+
+export function findServerEntry(servers: FileServerEntry[], url: string): FileServerEntry | null {
+  const normalized = normalizeFileServerUrl(url) || url;
+  return servers.find((entry) => (normalizeFileServerUrl(entry.url) || entry.url) === normalized) || null;
 }

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -178,17 +178,7 @@ export function DocumentPreviewModal({
   } else if (effectiveDocument.kind === "pdf") {
     content = (
       <div className="doc-modal__content">
-        <div className="doc-modal__placeholder">
-          <div>PDF previews open in a new tab for the best experience.</div>
-          <button
-            type="button"
-            className="ghost-button button-sm pressable"
-            style={{ marginTop: "0.75rem" }}
-            onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}
-          >
-            Open full screen
-          </button>
-        </div>
+        <iframe src={effectiveDocument.dataUrl} title={label} className="h-[70vh] w-full rounded-xl border border-surface bg-white" />
       </div>
     );
   } else if (full?.type === "html") {

--- a/taskify-pwa/src/ui/task/TaskMedia.tsx
+++ b/taskify-pwa/src/ui/task/TaskMedia.tsx
@@ -7,8 +7,21 @@ import type { UrlPreviewData } from "../../lib/urlPreview";
 import { extractFirstUrl, isUrlLike } from "../../lib/urlPreview";
 import { autolink, stripUrlsFromText, fallbackTitleFromUrl, useTaskPreview } from "./TaskTitle";
 import { DocumentThumbnail } from "./DocumentPreviewModal";
+import { decryptAttachment } from "../../lib/attachmentCrypto";
 import { ImagePreviewModal } from "./ImagePreviewModal";
 import { decryptAttachment } from "../../lib/attachmentCrypto";
+
+function ResolvedTaskImage({ src, boardId }: { src: string; boardId?: string }) {
+  const [resolvedSrc, setResolvedSrc] = useState(src);
+  useEffect(() => {
+    let cancelled = false;
+    if (!src || src.startsWith("data:")) { setResolvedSrc(src); return; }
+    if (!boardId) { setResolvedSrc(src); return; }
+    decryptAttachment({ boardId, url: src, mimeType: "image/jpeg" }).then((next) => { if (!cancelled) setResolvedSrc(next); }).catch(() => { if (!cancelled) setResolvedSrc(src); });
+    return () => { cancelled = true; };
+  }, [src, boardId]);
+  return <img src={resolvedSrc} className="max-h-40 w-full rounded-2xl object-contain" />;
+}
 
 export function UrlPreviewCard({ preview }: { preview: UrlPreviewData; indent?: boolean }) {
   const [imageFailed, setImageFailed] = useState(false);
@@ -192,6 +205,7 @@ export function TaskMedia({
             <DocumentThumbnail
               key={doc.id}
               document={doc}
+              boardId={task.boardId}
               onClick={() => onOpenDocument?.(task, doc)}
             />
           ))}


### PR DESCRIPTION
## Summary
- splits public profile-photo and encrypted attachment file server settings
- defaults encrypted uploads to originless.solife.me with warnings for non-originless servers
- renders PDFs directly from resolved decrypted assets in the preview modal
- decrypts encrypted task images for preview rendering so pasted/shared images display correctly

## Validation
- taskify-pwa build passes