### PR TITLE
fix(pwa): split file server selectors and polish previews

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -4044,7 +4044,10 @@ function useSettings() {
         encryptedFileStorageServer,
         fileServers: typeof parsed?.fileServers === "string" && parsed.fileServers.trim()
           ? parsed.fileServers.trim()
-          : serializeFileServers(DEFAULT_FILE_SERVERS),
+          : serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type !== "originless") || DEFAULT_FILE_SERVERS),
+        encryptedFileServers: typeof parsed?.encryptedFileServers === "string" && parsed.encryptedFileServers.trim()
+          ? parsed.encryptedFileServers.trim()
+          : serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type === "originless")),
         walletMintBackupEnabled,
         npubCashLightningAddressEnabled,
         npubCashAutoClaim: npubCashLightningAddressEnabled ? npubCashAutoClaim : false,
@@ -4080,7 +4083,8 @@ function useSettings() {
         walletContactsSyncEnabled: true,
         fileStorageServer: DEFAULT_FILE_STORAGE_SERVER,
         encryptedFileStorageServer: DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
-        fileServers: serializeFileServers(DEFAULT_FILE_SERVERS),
+        fileServers: serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type !== "originless") || DEFAULT_FILE_SERVERS),
+        encryptedFileServers: serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type === "originless")),
         npubCashLightningAddressEnabled: true,
         npubCashAutoClaim: true,
         cloudBackupsEnabled: false,
@@ -4145,13 +4149,20 @@ function useSettings() {
           normalizeFileServerUrl(next.encryptedFileStorageServer) || DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER;
       }
       if (Object.prototype.hasOwnProperty.call(s, "fileServers")) {
-        // fileServers changed: validate and keep in sync
         const rawServers = (s as any).fileServers;
         next.fileServers = typeof rawServers === "string" && rawServers.trim()
           ? rawServers.trim()
-          : serializeFileServers(DEFAULT_FILE_SERVERS);
+          : serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type !== "originless") || DEFAULT_FILE_SERVERS);
       } else if (!next.fileServers) {
-        next.fileServers = serializeFileServers(DEFAULT_FILE_SERVERS);
+        next.fileServers = serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type !== "originless") || DEFAULT_FILE_SERVERS);
+      }
+      if (Object.prototype.hasOwnProperty.call(s, "encryptedFileServers")) {
+        const rawServers = (s as any).encryptedFileServers;
+        next.encryptedFileServers = typeof rawServers === "string" && rawServers.trim()
+          ? rawServers.trim()
+          : serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type === "originless"));
+      } else if (!next.encryptedFileServers) {
+        next.encryptedFileServers = serializeFileServers(DEFAULT_FILE_SERVERS.filter((s) => s.type === "originless"));
       }
       if (!next.backgroundImage) {
         next.backgroundImage = null;
@@ -12222,7 +12233,7 @@ export default function App() {
   async function prepareAttachmentsForPublish(
     params: { images?: string[]; documents?: TaskDocument[]; boardId: string }
   ): Promise<{ images: string[] | null; documents: any[] | null }> {
-    const servers = parseFileServers(settings.fileServers);
+    const servers = parseFileServers(settings.encryptedFileServers || settings.fileServers);
     const serverEntry = findServerEntry(servers, settings.fileStorageServer)
       ?? servers[0]
       ?? { url: settings.encryptedFileStorageServer, type: "nip96" as const };
@@ -19891,8 +19902,8 @@ export default function App() {
           defaultRelays={defaultRelays}
           nostrPK={nostrPK}
           nostrSkHex={nostrSkHex}
-          fileServers={settings.fileServers}
-          fileStorageServer={settings.fileStorageServer}
+          fileServers={settings.encryptedFileServers || settings.fileServers}
+          fileStorageServer={settings.encryptedFileStorageServer}
         />
       )}
 

--- a/taskify-pwa/src/domains/tasks/settingsTypes.ts
+++ b/taskify-pwa/src/domains/tasks/settingsTypes.ts
@@ -59,6 +59,7 @@ export type Settings = {
   fileStorageServer: string;
   encryptedFileStorageServer: string;
   fileServers: string; // JSON-serialized FileServerEntry[]
+  encryptedFileServers: string; // JSON-serialized FileServerEntry[]
   npubCashLightningAddressEnabled: boolean;
   npubCashAutoClaim: boolean;
   cloudBackupsEnabled: boolean;

--- a/taskify-pwa/src/nostr/Nip96Client.ts
+++ b/taskify-pwa/src/nostr/Nip96Client.ts
@@ -292,6 +292,25 @@ export async function uploadFileToBlossom(options: {
   return { url, nip94: null };
 }
 
+
+function resolveOriginlessUrl(serverUrl: string, data: any): string {
+  const direct = [data?.url, data?.cidUrl, data?.gatewayUrl, data?.fileUrl, data?.ipfs];
+  for (const value of direct) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  const cid = typeof data?.cid === "string" ? data.cid.trim() : "";
+  if (cid) {
+    const base = normalizeFileServerUrl(serverUrl) || serverUrl;
+    return `${base}/ipfs/${cid}`;
+  }
+  const path = typeof data?.path === "string" ? data.path.trim() : "";
+  if (path) {
+    const base = normalizeFileServerUrl(serverUrl) || serverUrl;
+    return path.startsWith("http") ? path : `${base}${path.startsWith("/") ? "" : "/"}${path}`;
+  }
+  return "";
+}
+
 // ── Originless ────────────────────────────────────────────────────────────────
 
 export async function uploadFileToOriginless(options: {
@@ -352,8 +371,8 @@ export async function uploadFileToOriginless(options: {
         data: flattenDebugError(data),
       });
       if (!res.ok) throw new Error(data?.message || `Originless upload failed (${res.status})`);
-      const url = typeof data?.url === "string" ? data.url.trim() : "";
-      if (!url) throw new Error("Originless upload response did not include a url.");
+      const url = resolveOriginlessUrl(options.serverUrl, data);
+      if (!url) throw new Error(`Originless upload response did not include a url. Response: ${JSON.stringify(flattenDebugError(data))}`);
       return { url, nip94: null };
     } catch (err) {
       lastError = err;

--- a/taskify-pwa/src/ui/settings/FileServersSection.tsx
+++ b/taskify-pwa/src/ui/settings/FileServersSection.tsx
@@ -96,7 +96,7 @@ export function FileServersSection({ fileStorageServer, fileServers, onSelectSer
 
   return (
     <div className="space-y-2">
-      <div className="text-xs text-secondary mb-1">File storage servers</div>
+      
 
       <div className="space-y-2">
         {servers.map((entry) => {
@@ -235,9 +235,6 @@ export function FileServersSection({ fileStorageServer, fileServers, onSelectSer
         </button>
       )}
 
-      <div className="text-xs text-secondary">
-        Used for profile photo uploads. Tap a server to select it.
-      </div>
     </div>
   );
 }

--- a/taskify-pwa/src/ui/settings/NostrSection.tsx
+++ b/taskify-pwa/src/ui/settings/NostrSection.tsx
@@ -122,14 +122,26 @@ export function NostrSection({
             </div>
           </div>
 
-          {/* File storage servers */}
-          <div className="mb-3">
-            <FileServersSection
-              fileStorageServer={settings.fileStorageServer}
-              fileServers={settings.fileServers || ""}
-              onSelectServer={(url) => setSettings({ fileStorageServer: url })}
-              onUpdateServers={(serialized) => setSettings({ fileServers: serialized })}
-            />
+          <div className="mb-3 space-y-4">
+            <div>
+              <div className="text-xs text-secondary mb-1">Public file servers</div>
+              <FileServersSection
+                fileStorageServer={settings.fileStorageServer}
+                fileServers={settings.fileServers || ""}
+                onSelectServer={(url) => setSettings({ fileStorageServer: url })}
+                onUpdateServers={(serialized) => setSettings({ fileServers: serialized })}
+              />
+            </div>
+            <div>
+              <div className="text-xs text-secondary mb-1">Encrypted file servers</div>
+              <FileServersSection
+                fileStorageServer={settings.encryptedFileStorageServer}
+                fileServers={settings.encryptedFileServers || ""}
+                onSelectServer={(url) => setSettings({ encryptedFileStorageServer: url })}
+                onUpdateServers={(serialized) => setSettings({ encryptedFileServers: serialized })}
+              />
+              <div className="text-xs text-amber-400 mt-2">Warning: NIP-96 and Blossom servers may fail for encrypted uploads. Originless is recommended.</div>
+            </div>
           </div>
 
           {/* Default relays */}

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import type { TaskDocument, TaskDocumentPreview } from "../../lib/documents";
 import { createDocumentFromDataUrl, documentAssetCacheKey, loadDocumentPreview } from "../../lib/documents";
 import { Modal } from "../Modal";
@@ -122,6 +123,19 @@ export function DocumentThumbnail({ document: doc, boardId, onClick }: { documen
   );
 }
 
+function PdfFullScreenPreview({ src, label, onClose }: { src: string; label: string; onClose: () => void }) {
+  if (typeof document === "undefined") return null;
+  return createPortal(
+    <div className="fixed inset-0 z-[120] bg-black/90 p-3" onClick={onClose}>
+      <button type="button" className="ghost-button button-sm pressable" style={{ position: "absolute", top: 12, right: 12, zIndex: 2 }} onClick={onClose}>Close</button>
+      <div className="h-full w-full pt-10" onClick={(e) => e.stopPropagation()}>
+        <embed src={src} type="application/pdf" className="h-full w-full rounded-xl bg-white" />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
 export function DocumentPreviewModal({
   document,
   boardId,
@@ -138,6 +152,7 @@ export function DocumentPreviewModal({
   const [resolvedDocument, setResolvedDocument] = useState<TaskDocument>(document);
   const [loadingRemote, setLoadingRemote] = useState(false);
   const [remoteError, setRemoteError] = useState<string | null>(null);
+  const [pdfFullScreen, setPdfFullScreen] = useState(false);
   const label = document.name || "Document";
   const decryptBoardId = document.encryptionBoardId || boardId;
 
@@ -178,7 +193,10 @@ export function DocumentPreviewModal({
   } else if (effectiveDocument.kind === "pdf") {
     content = (
       <div className="doc-modal__content">
-        <iframe src={effectiveDocument.dataUrl} title={label} className="h-[70vh] w-full rounded-xl border border-surface bg-white" />
+        <embed src={effectiveDocument.dataUrl} type="application/pdf" className="h-[80vh] w-full rounded-xl border border-surface bg-white" />
+        <div style={{ marginTop: "0.75rem" }}>
+          <button type="button" className="ghost-button button-sm pressable" onClick={() => setPdfFullScreen(true)}>Open full screen</button>
+        </div>
       </div>
     );
   } else if (full?.type === "html") {
@@ -237,8 +255,13 @@ export function DocumentPreviewModal({
   );
 
   return (
-    <Modal onClose={onClose} title={label} actions={actions}>
-      {content}
-    </Modal>
+    <>
+      <Modal onClose={onClose} title={label} actions={actions}>
+        {content}
+      </Modal>
+      {pdfFullScreen && effectiveDocument.kind === "pdf" && effectiveDocument.dataUrl ? (
+        <PdfFullScreenPreview src={effectiveDocument.dataUrl} label={label} onClose={() => setPdfFullScreen(false)} />
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- adds separate public and encrypted file server selectors in settings
- improves PDF preview with a larger embedded viewer and full-screen mode
- accepts additional Originless upload response shapes including cid/path-based URLs

## Validation
- taskify-pwa build passes