### PR TITLE
fix(pwa): open attachments fullscreen with richer doc previews

### DIFF
--- a/taskify-pwa/package-lock.json
+++ b/taskify-pwa/package-lock.json
@@ -18,6 +18,8 @@
         "buffer": "^6.0.3",
         "events": "^3.3.0",
         "jszip": "^3.10.1",
+        "mammoth": "^1.12.0",
+        "markdown-it": "^14.1.1",
         "nostr-tools": "^2.16.2",
         "pdfjs-dist": "^4.7.76",
         "process": "^0.11.10",
@@ -29,7 +31,8 @@
         "stream-browserify": "^3.0.0",
         "taskify-core": "file:../taskify-core",
         "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
-        "util": "^0.12.5"
+        "util": "^0.12.5",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -2399,6 +2402,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2464,7 +2476,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/autoprefixer": {
@@ -2785,6 +2796,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2860,6 +2884,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2919,6 +2952,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3025,6 +3070,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -3042,6 +3093,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -3073,6 +3133,18 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3499,6 +3571,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -4165,6 +4246,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4188,6 +4278,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4196,6 +4297,62 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/mammoth/node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4227,6 +4384,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4559,6 +4722,12 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4642,6 +4811,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4925,6 +5103,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5308,6 +5495,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/static-browser-server": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
@@ -5658,6 +5863,18 @@
       "integrity": "sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==",
       "license": "MIT"
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -5979,6 +6196,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5987,6 +6222,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/taskify-pwa/package.json
+++ b/taskify-pwa/package.json
@@ -22,6 +22,8 @@
     "buffer": "^6.0.3",
     "events": "^3.3.0",
     "jszip": "^3.10.1",
+    "mammoth": "^1.12.0",
+    "markdown-it": "^14.1.1",
     "nostr-tools": "^2.16.2",
     "pdfjs-dist": "^4.7.76",
     "process": "^0.11.10",
@@ -33,7 +35,8 @@
     "stream-browserify": "^3.0.0",
     "taskify-core": "file:../taskify-core",
     "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
-    "util": "^0.12.5"
+    "util": "^0.12.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -9009,7 +9009,9 @@ export default function App() {
         ? await decryptAttachment({ boardId, url: doc.remoteUrl, mimeType: doc.mimeType })
         : doc.remoteUrl)
       : "");
-    if (sourceUrl) {
+    if (!sourceUrl) return;
+    const popup = window.open(sourceUrl, "_blank", "noopener,noreferrer");
+    if (!popup) {
       window.location.assign(sourceUrl);
     }
   }, []);

--- a/taskify-pwa/src/lib/documents.ts
+++ b/taskify-pwa/src/lib/documents.ts
@@ -1,5 +1,8 @@
 import JSZip from "jszip";
 import readXlsxFile from "read-excel-file/browser";
+import MarkdownIt from "markdown-it";
+import * as mammoth from "mammoth/mammoth.browser";
+import * as XLSX from "xlsx";
 
 export type TaskDocumentKind = "pdf" | "doc" | "docx" | "xls" | "xlsx" | "txt" | "md" | "json" | "csv" | "png" | "jpg" | "jpeg" | "webp" | "gif" | "mp3" | "aac" | "m4a" | "wav" | "mp4" | "mov" | "webm";
 
@@ -54,6 +57,8 @@ const EXTENSION_TO_KIND: Record<string, TaskDocumentKind> = {
   ".mov": "mov",
   ".webm": "webm",
 };
+
+const markdownRenderer = new MarkdownIt({ html: false, linkify: true, breaks: true });
 
 const MIME_TO_KIND: Record<string, TaskDocumentKind> = {
   "application/pdf": "pdf",
@@ -528,25 +533,51 @@ async function generateSpreadsheetMarkup(
   buffer: ArrayBuffer,
   kind: TaskDocumentKind
 ): Promise<{ previewHtml?: string; fullHtml?: string }> {
-  if (kind === "xls") {
-    // Legacy .xls parsing is intentionally not supported without SheetJS (xlsx).
-    return {};
-  }
-
   try {
-    const blob = new Blob([buffer]);
-    const rows = await readXlsxFile(blob);
-    const rowsArray = Array.isArray(rows) ? (rows as Array<Array<unknown>>) : [];
-    if (!rowsArray.length) return {};
-    const fullHtml = wrapSheetHtml(rowsArray, 100, 20);
-    const previewHtml = wrapSheetHtml(rowsArray, 20, 8);
-    return { previewHtml, fullHtml };
+    const workbook = XLSX.read(buffer, { type: "array", cellStyles: true, cellHTML: true, cellNF: true });
+    const sheetName = workbook.SheetNames[0];
+    const sheet = workbook.Sheets[sheetName];
+    if (!sheet) return {};
+    const fullTable = XLSX.utils.sheet_to_html(sheet, { editable: false, id: "doc-sheet-table" });
+    const fullHtml = `<div class="doc-sheet doc-sheet--rich"><div class="doc-sheet__tab">${escapeHtml(sheetName)}</div>${fullTable}</div>`;
+    try {
+      const blob = new Blob([buffer]);
+      const rows = await readXlsxFile(blob);
+      const rowsArray = Array.isArray(rows) ? (rows as Array<Array<unknown>>) : [];
+      const previewHtml = rowsArray.length ? wrapSheetHtml(rowsArray, 12, 6, sheetName) : fullHtml;
+      return { previewHtml, fullHtml };
+    } catch {
+      return { previewHtml: fullHtml, fullHtml };
+    }
   } catch {
     return {};
   }
 }
 
-function wrapSheetHtml(rows: Array<Array<unknown>>, maxRows: number, maxCols: number): string {
+async function generateDocxMarkupRich(buffer: ArrayBuffer): Promise<{ previewHtml?: string; fullHtml?: string }> {
+  try {
+    const result = await mammoth.convertToHtml({ arrayBuffer: buffer }, {
+      includeDefaultStyleMap: true,
+      styleMap: [
+        "p[style-name='Heading 1'] => h1:fresh",
+        "p[style-name='Heading 2'] => h2:fresh",
+        "p[style-name='Heading 3'] => h3:fresh",
+        "p[style-name='Title'] => h1.doc-title:fresh",
+        "p[style-name='Subtitle'] => h2.doc-subtitle:fresh"
+      ]
+    });
+    const html = (result.value || "").trim();
+    if (!html) return {};
+    return {
+      previewHtml: `<div class="doc-rich doc-rich--preview">${html}</div>`,
+      fullHtml: `<div class="doc-rich">${html}</div>`,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function wrapSheetHtml(rows: Array<Array<unknown>>, maxRows: number, maxCols: number, sheetName = "Sheet 1"): string {
   const limitedRows = rows.slice(0, maxRows);
   const body = limitedRows
     .map((row) => {
@@ -559,7 +590,7 @@ function wrapSheetHtml(rows: Array<Array<unknown>>, maxRows: number, maxCols: nu
       return `<tr>${cells.join("")}</tr>`;
     })
     .join("");
-  return `<div class="doc-sheet"><table><tbody>${body}</tbody></table></div>`;
+  return `<div class="doc-sheet"><div class="doc-sheet__tab">${escapeHtml(sheetName)}</div><table><tbody>${body}</tbody></table></div>`;
 }
 
 export async function createDocumentFromDataUrl(input: {
@@ -595,7 +626,10 @@ export async function createDocumentFromDataUrl(input: {
       base.preview = { type: "image", data: previewImage };
     }
   } else if (kind === "docx") {
-    const { previewHtml, fullHtml } = await generateDocxMarkup(buffer);
+    const rich = await generateDocxMarkupRich(buffer);
+    const fallback = !rich.fullHtml ? await generateDocxMarkup(buffer) : {};
+    const previewHtml = rich.previewHtml || fallback.previewHtml;
+    const fullHtml = rich.fullHtml || fallback.fullHtml;
     if (previewHtml) base.preview = { type: "html", data: previewHtml };
     if (fullHtml) base.full = { type: "html", data: fullHtml };
   } else if (kind === "doc") {
@@ -606,6 +640,13 @@ export async function createDocumentFromDataUrl(input: {
     const { previewHtml, fullHtml } = await generateSpreadsheetMarkup(buffer, kind);
     if (previewHtml) base.preview = { type: "html", data: previewHtml };
     if (fullHtml) base.full = { type: "html", data: fullHtml };
+  } else if (kind === "md") {
+    const { fullText } = await generateTextDocument(buffer);
+    if (fullText) {
+      const rendered = `<div class="doc-rich doc-markdown">${markdownRenderer.render(fullText)}</div>`;
+      base.preview = { type: "html", data: rendered };
+      base.full = { type: "html", data: rendered };
+    }
   } else if (isTextKind(kind)) {
     const { previewText, fullText } = await generateTextDocument(buffer);
     if (previewText) base.preview = { type: "text", data: previewText };
@@ -687,6 +728,8 @@ async function buildPreviewFromDocument(doc: TaskDocument): Promise<TaskDocument
   if (!buffer.byteLength) return null;
 
   if (ensured.kind === "docx") {
+    const rich = await generateDocxMarkupRich(buffer);
+    if (rich.previewHtml) return { type: "html", data: rich.previewHtml };
     const { previewHtml } = await generateDocxMarkup(buffer);
     if (previewHtml) return { type: "html", data: previewHtml };
     return null;
@@ -701,6 +744,12 @@ async function buildPreviewFromDocument(doc: TaskDocument): Promise<TaskDocument
   if (ensured.kind === "xls" || ensured.kind === "xlsx") {
     const { previewHtml } = await generateSpreadsheetMarkup(buffer, ensured.kind);
     if (previewHtml) return { type: "html", data: previewHtml };
+    return null;
+  }
+
+  if (ensured.kind === "md") {
+    const { fullText } = await generateTextDocument(buffer);
+    if (fullText) return { type: "html", data: `<div class="doc-rich doc-markdown">${markdownRenderer.render(fullText)}</div>` };
     return null;
   }
 

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -167,7 +167,6 @@ export function DocumentPreviewModal({
   const [resolvedDocument, setResolvedDocument] = useState<TaskDocument>(document);
   const [loadingRemote, setLoadingRemote] = useState(false);
   const [remoteError, setRemoteError] = useState<string | null>(null);
-  const [fullScreenMode, setFullScreenMode] = useState<null | "pdf" | "image" | "video" | "html" | "text">(null);
   const label = document.name || "Document";
   const decryptBoardId = document.encryptionBoardId || boardId;
 
@@ -210,25 +209,25 @@ export function DocumentPreviewModal({
   } else if (effectiveDocument.kind === "pdf") {
     content = (
       <div className="doc-modal__content">
-        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 rounded-[28px] bg-[#1b1c20] p-3 shadow-2xl"><embed src={effectiveDocument.dataUrl} type="application/pdf" className="h-full w-full rounded-[22px] bg-white" /></div><div className="flex justify-center gap-2"><button type="button" className="ghost-button button-sm pressable" onClick={() => setFullScreenMode("pdf")}>Full screen</button><button type="button" className="ghost-button button-sm pressable" onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}>Open in browser</button></div></div>
+        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 rounded-[28px] bg-[#1b1c20] p-3 shadow-2xl"><embed src={effectiveDocument.dataUrl} type="application/pdf" className="h-full w-full rounded-[22px] bg-white" /></div><div className="flex justify-center gap-2"><button type="button" className="ghost-button button-sm pressable" style={{ display: "none" }}></button><button type="button" className="ghost-button button-sm pressable" onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}>Open in browser</button></div></div>
       </div>
     );
   } else if (full?.type === "html") {
     content = (
       <div className="doc-modal__content">
-        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 overflow-auto rounded-[28px] bg-white p-6 text-black shadow-2xl"><div className="doc-modal__markup" dangerouslySetInnerHTML={{ __html: full.data }} /></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" onClick={() => setFullScreenMode("html")}>Full screen</button></div></div>
+        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 overflow-auto rounded-[28px] bg-white p-6 text-black shadow-2xl"><div className="doc-modal__markup" dangerouslySetInnerHTML={{ __html: full.data }} /></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" style={{ display: "none" }}></button></div></div>
       </div>
     );
   } else if (full?.type === "text") {
     content = (
       <div className="doc-modal__content">
-        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 overflow-auto rounded-[28px] bg-white p-6 text-black shadow-2xl"><pre className="doc-modal__text whitespace-pre-wrap">{full.data}</pre></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" onClick={() => setFullScreenMode("text")}>Full screen</button></div></div>
+        <div className="flex h-full flex-col gap-3"><div className="min-h-0 flex-1 overflow-auto rounded-[28px] bg-white p-6 text-black shadow-2xl"><pre className="doc-modal__text whitespace-pre-wrap">{full.data}</pre></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" style={{ display: "none" }}></button></div></div>
       </div>
     );
   } else if (full?.type === "image") {
     content = (
       <div className="doc-modal__content">
-        <div className="flex h-full flex-col gap-3"><div className="flex min-h-0 flex-1 items-center justify-center rounded-[28px] bg-[#1b1c20] p-4 shadow-2xl"><img src={full.data} alt={label} className="max-h-full max-w-full rounded-[22px] object-contain" /></div><div className="flex justify-center gap-2"><button type="button" className="ghost-button button-sm pressable" onClick={() => setFullScreenMode("image")}>Full screen</button><button type="button" className="ghost-button button-sm pressable" onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}>Open image</button></div></div>
+        <div className="flex h-full flex-col gap-3"><div className="flex min-h-0 flex-1 items-center justify-center rounded-[28px] bg-[#1b1c20] p-4 shadow-2xl"><img src={full.data} alt={label} className="max-h-full max-w-full rounded-[22px] object-contain" /></div><div className="flex justify-center gap-2"><button type="button" className="ghost-button button-sm pressable" style={{ display: "none" }}></button><button type="button" className="ghost-button button-sm pressable" onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}>Open image</button></div></div>
       </div>
     );
   } else if (full?.type === "audio") {
@@ -240,7 +239,7 @@ export function DocumentPreviewModal({
   } else if (full?.type === "video") {
     content = (
       <div className="doc-modal__content">
-        <div className="flex h-full flex-col gap-3"><div className="flex min-h-0 flex-1 items-center justify-center rounded-[28px] bg-black p-2 shadow-2xl"><video controls src={full.data} className="max-h-full w-full rounded-[22px] bg-black" /></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" onClick={() => setFullScreenMode("video")}>Full screen</button></div></div>
+        <div className="flex h-full flex-col gap-3"><div className="flex min-h-0 flex-1 items-center justify-center rounded-[28px] bg-black p-2 shadow-2xl"><video controls src={full.data} className="max-h-full w-full rounded-[22px] bg-black" /></div><div className="flex justify-center"><button type="button" className="ghost-button button-sm pressable" style={{ display: "none" }}></button></div></div>
       </div>
     );
   } else {
@@ -273,35 +272,8 @@ export function DocumentPreviewModal({
   );
 
   return (
-    <>
-      <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={onClose}>
-        {content}
-      </ViewerShell>
-      {fullScreenMode === "pdf" && effectiveDocument.kind === "pdf" ? (
-        <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={() => setFullScreenMode(null)}>
-          <div className="h-full rounded-[28px] bg-[#1b1c20] p-3"><embed src={effectiveDocument.dataUrl} type="application/pdf" className="h-full w-full rounded-[22px] bg-white" /></div>
-        </ViewerShell>
-      ) : null}
-      {fullScreenMode === "image" && full?.type === "image" ? (
-        <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={() => setFullScreenMode(null)}>
-          <div className="flex h-full items-center justify-center"><img src={full.data} alt={label} className="max-h-full max-w-full object-contain" /></div>
-        </ViewerShell>
-      ) : null}
-      {fullScreenMode === "video" && full?.type === "video" ? (
-        <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={() => setFullScreenMode(null)}>
-          <div className="flex h-full items-center justify-center rounded-[28px] bg-black p-2"><video controls autoPlay src={full.data} className="max-h-full w-full rounded-[22px] bg-black" /></div>
-        </ViewerShell>
-      ) : null}
-      {fullScreenMode === "html" && full?.type === "html" ? (
-        <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={() => setFullScreenMode(null)}>
-          <div className="h-full overflow-auto rounded-[28px] bg-white p-6 text-black" dangerouslySetInnerHTML={{ __html: full.data }} />
-        </ViewerShell>
-      ) : null}
-      {fullScreenMode === "text" && full?.type === "text" ? (
-        <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={() => setFullScreenMode(null)}>
-          <pre className="h-full overflow-auto rounded-[28px] bg-white p-6 text-black whitespace-pre-wrap">{full.data}</pre>
-        </ViewerShell>
-      ) : null}
-    </>
+    <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={onClose}>
+      {content}
+    </ViewerShell>
   );
 }


### PR DESCRIPTION
## Summary
- opens attachment previews directly into the fullscreen viewer
- fixes open/download behavior to use resolved assets in a new tab when possible
- improves markdown, docx, and xlsx rendering with richer client-side parsers

## Validation
- taskify-pwa build passes