### PR TITLE
feat(pwa): refactor attachment preview into dedicated viewer components

### DIFF
--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -1,8 +1,15 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import type { TaskDocument, TaskDocumentPreview } from "../../lib/documents";
-import { createDocumentFromDataUrl, documentAssetCacheKey, ensurePdfjs, loadDocumentPreview } from "../../lib/documents";
+import { createDocumentFromDataUrl, documentAssetCacheKey, loadDocumentPreview } from "../../lib/documents";
 import { decryptAttachment } from "../../lib/attachmentCrypto";
+import { PdfViewer } from "./viewers/PdfViewer";
+import { ImageViewer } from "./viewers/ImageViewer";
+import { VideoViewer } from "./viewers/VideoViewer";
+import { DocumentViewer } from "./viewers/DocumentViewer";
+import { SpreadsheetViewer } from "./viewers/SpreadsheetViewer";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 const resolvedDocumentCache = new Map<string, Promise<TaskDocument>>();
 
@@ -25,38 +32,94 @@ async function resolveDocumentAsset(doc: TaskDocument, boardId?: string): Promis
     const dataUrl = doc.encrypted && decryptBoardId
       ? await decryptAttachment({ boardId: decryptBoardId, url: doc.remoteUrl!, mimeType: doc.mimeType })
       : doc.remoteUrl!;
-    return createDocumentFromDataUrl({ id: doc.id, name: doc.name, mimeType: doc.mimeType, dataUrl, createdAt: doc.createdAt, size: doc.size, remoteUrl: doc.remoteUrl, encrypted: doc.encrypted, encryptionBoardId: doc.encryptionBoardId || decryptBoardId });
+    return createDocumentFromDataUrl({
+      id: doc.id, name: doc.name, mimeType: doc.mimeType, dataUrl,
+      createdAt: doc.createdAt, size: doc.size, remoteUrl: doc.remoteUrl,
+      encrypted: doc.encrypted, encryptionBoardId: doc.encryptionBoardId || decryptBoardId,
+    });
   })().catch((err) => { resolvedDocumentCache.delete(cacheKey); throw err; });
   resolvedDocumentCache.set(cacheKey, promise);
   return promise;
 }
 
-export function DocumentThumbnail({ document: doc, boardId, onClick }: { document: TaskDocument; boardId?: string; onClick: () => void }) {
+// ── Thumbnail ─────────────────────────────────────────────────────────────────
+
+export function DocumentThumbnail({
+  document: doc,
+  boardId,
+  onClick,
+}: {
+  document: TaskDocument;
+  boardId?: string;
+  onClick: () => void;
+}) {
   const [derivedPreview, setDerivedPreview] = useState<TaskDocumentPreview | null>(doc.preview ?? null);
+
   useEffect(() => {
     let cancelled = false;
     setDerivedPreview(doc.preview ?? null);
-    resolveDocumentAsset(doc, boardId).then((resolved) => loadDocumentPreview(resolved)).then((next) => { if (!cancelled) setDerivedPreview(next); }).catch(() => { if (!cancelled) setDerivedPreview(doc.preview ?? null); });
+    resolveDocumentAsset(doc, boardId)
+      .then((resolved) => loadDocumentPreview(resolved))
+      .then((next) => { if (!cancelled) setDerivedPreview(next); })
+      .catch(() => { if (!cancelled) setDerivedPreview(doc.preview ?? null); });
     return () => { cancelled = true; };
   }, [doc, boardId]);
+
   const preview = derivedPreview ?? doc.preview ?? null;
   const label = doc.name || "Document";
+
   let previewNode: React.ReactNode;
-  if (preview?.type === "image") previewNode = <img src={preview.data} alt="" className="doc-thumb__image" />;
-  else if (preview?.type === "html") previewNode = <div className="doc-thumb__html" dangerouslySetInnerHTML={{ __html: preview.data }} />;
-  else if (preview?.type === "text") previewNode = <pre className="doc-thumb__text">{preview.data.split(/\n+/).slice(0, 6).join("\n")}</pre>;
-  else previewNode = <div className="doc-thumb__placeholder">{doc.kind.toUpperCase()}</div>;
-  return <button type="button" className="doc-thumb" onClick={onClick}><div className="doc-thumb__preview">{previewNode}</div><div className="doc-thumb__footer"><span className="doc-thumb__name" title={label}>{label}</span><span className="doc-thumb__kind">{doc.kind.toUpperCase()}</span></div></button>;
+  if (preview?.type === "image") {
+    previewNode = <img src={preview.data} alt="" className="doc-thumb__image" />;
+  } else if (preview?.type === "html") {
+    previewNode = <div className="doc-thumb__html" dangerouslySetInnerHTML={{ __html: preview.data }} />;
+  } else if (preview?.type === "text") {
+    previewNode = <pre className="doc-thumb__text">{preview.data.split(/\n+/).slice(0, 6).join("\n")}</pre>;
+  } else {
+    previewNode = <div className="doc-thumb__placeholder">{doc.kind.toUpperCase()}</div>;
+  }
+
+  return (
+    <button type="button" className="doc-thumb" onClick={onClick}>
+      <div className="doc-thumb__preview">{previewNode}</div>
+      <div className="doc-thumb__footer">
+        <span className="doc-thumb__name" title={label}>{label}</span>
+        <span className="doc-thumb__kind">{doc.kind.toUpperCase()}</span>
+      </div>
+    </button>
+  );
 }
 
-function ViewerShell({ title, subtitle, actions, children, onClose }: { title: string; subtitle?: React.ReactNode; actions?: React.ReactNode; children: React.ReactNode; onClose: () => void }) {
+// ── Shell ─────────────────────────────────────────────────────────────────────
+
+function ViewerShell({
+  title,
+  subtitle,
+  actions,
+  children,
+  onClose,
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  onClose: () => void;
+}) {
   if (typeof document === "undefined") return null;
   return createPortal(
     <div className="fixed inset-0 z-[120] bg-[#111214]/95 text-white" onClick={onClose}>
-      <div className="mx-auto flex h-full w-full max-w-6xl flex-col px-3 pb-4 pt-[max(14px,env(safe-area-inset-top))]" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="mx-auto flex h-full w-full max-w-6xl flex-col px-3 pb-4 pt-[max(14px,env(safe-area-inset-top))]"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between gap-3 pb-3">
-          <button type="button" className="ghost-button button-sm pressable" onClick={onClose}>Close</button>
-          <div className="min-w-0 flex-1 text-center"><div className="truncate text-sm font-medium text-white">{title}</div>{subtitle ? <div className="truncate text-xs text-white/60">{subtitle}</div> : null}</div>
+          <button type="button" className="ghost-button button-sm pressable" onClick={onClose}>
+            Close
+          </button>
+          <div className="min-w-0 flex-1 text-center">
+            <div className="truncate text-sm font-medium text-white">{title}</div>
+            {subtitle ? <div className="truncate text-xs text-white/60">{subtitle}</div> : null}
+          </div>
           <div className="flex min-w-[72px] justify-end gap-2">{actions}</div>
         </div>
         <div className="min-h-0 flex-1">{children}</div>
@@ -66,109 +129,135 @@ function ViewerShell({ title, subtitle, actions, children, onClose }: { title: s
   );
 }
 
-function ZoomPane({ children, pageClassName = "", zoomable = true, baseWidth = 960 }: { children: React.ReactNode; pageClassName?: string; zoomable?: boolean; baseWidth?: number }) {
-  const [scale, setScale] = useState(1);
-  const viewportRef = useRef<HTMLDivElement | null>(null);
-  const draggingRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
-  const scaledWidth = Math.round(baseWidth * scale);
-  const applyScale = (next: number) => setScale(Math.max(1, Math.min(4, next)));
-  return (
-    <div className="relative h-full overflow-hidden">
-      {zoomable ? (
-        <div className="absolute right-3 top-3 z-[30] flex gap-2 rounded-full bg-black/45 p-1 backdrop-blur">
-          <button type="button" className="ghost-button button-sm pressable" onClick={() => applyScale(scale - 0.25)}>−</button>
-          <button type="button" className="ghost-button button-sm pressable" onClick={() => applyScale(1)}>{Math.round(scale * 100)}%</button>
-          <button type="button" className="ghost-button button-sm pressable" onClick={() => applyScale(scale + 0.25)}>+</button>
-        </div>
-      ) : null}
-      <div
-        ref={viewportRef}
-        className="h-full overflow-auto"
-        style={{ touchAction: scale > 1 ? 'none' : 'auto', cursor: scale > 1 ? 'grab' : 'auto' }}
-        onPointerDown={(e) => {
-          if (scale <= 1 || !viewportRef.current) return;
-          draggingRef.current = { x: e.clientX, y: e.clientY, left: viewportRef.current.scrollLeft, top: viewportRef.current.scrollTop };
-          (e.currentTarget as HTMLDivElement).setPointerCapture?.(e.pointerId);
-        }}
-        onPointerMove={(e) => {
-          if (!draggingRef.current || !viewportRef.current || scale <= 1) return;
-          e.preventDefault();
-          viewportRef.current.scrollLeft = draggingRef.current.left - (e.clientX - draggingRef.current.x);
-          viewportRef.current.scrollTop = draggingRef.current.top - (e.clientY - draggingRef.current.y);
-        }}
-        onPointerUp={(e) => { draggingRef.current = null; (e.currentTarget as HTMLDivElement).releasePointerCapture?.(e.pointerId); }}
-        onPointerCancel={(e) => { draggingRef.current = null; (e.currentTarget as HTMLDivElement).releasePointerCapture?.(e.pointerId); }}
-      >
-        <div className="flex min-h-full items-start justify-center p-4">
-          <div style={{ width: `${scaledWidth}px`, maxWidth: 'none' }}>
-            <div className={pageClassName} style={{ width: '100%', maxWidth: 'none' }}>
-              {children}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+// ── Orchestrator ──────────────────────────────────────────────────────────────
 
-function PdfPages({ dataUrl, scale }: { dataUrl: string; scale: number }) {
-  const [pages, setPages] = useState<string[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const pdfjs = await ensurePdfjs();
-        const bytes = await fetch(dataUrl).then((r) => r.arrayBuffer());
-        const pdf = await pdfjs.getDocument({ data: bytes }).promise;
-        const rendered: string[] = [];
-        for (let i = 1; i <= pdf.numPages; i += 1) {
-          const page = await pdf.getPage(i);
-          const viewport = page.getViewport({ scale });
-          const canvas = document.createElement("canvas");
-          canvas.width = viewport.width;
-          canvas.height = viewport.height;
-          const ctx = canvas.getContext("2d");
-          if (!ctx) continue;
-          await page.render({ canvasContext: ctx, viewport }).promise;
-          rendered.push(canvas.toDataURL("image/png"));
-        }
-        if (!cancelled) setPages(rendered);
-      } catch {
-        if (!cancelled) setPages([]);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [dataUrl, scale]);
-  return <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">{pages.map((src, i) => <img key={i} src={src} alt={`PDF page ${i + 1}`} className="w-full rounded-[22px] bg-white shadow-2xl" />)}</div>;
-}
+const IMAGE_KINDS = new Set(["jpg", "jpeg", "png", "webp", "gif"]);
+const VIDEO_KINDS = new Set(["mp4", "mov", "webm"]);
 
-export function DocumentPreviewModal({ document, boardId, onClose, onDownloadDocument, onOpenExternal }: { document: TaskDocument; boardId?: string; onClose: () => void; onDownloadDocument?: (doc: TaskDocument, boardId?: string) => void; onOpenExternal?: (doc: TaskDocument, boardId?: string) => void; }) {
+export function DocumentPreviewModal({
+  document,
+  boardId,
+  onClose,
+  onDownloadDocument,
+  onOpenExternal,
+}: {
+  document: TaskDocument;
+  boardId?: string;
+  onClose: () => void;
+  onDownloadDocument?: (doc: TaskDocument, boardId?: string) => void;
+  onOpenExternal?: (doc: TaskDocument, boardId?: string) => void;
+}) {
   const [resolvedDocument, setResolvedDocument] = useState<TaskDocument>(document);
   const [loadingRemote, setLoadingRemote] = useState(false);
   const [remoteError, setRemoteError] = useState<string | null>(null);
-  const [pdfScale, setPdfScale] = useState(1.15);
+
   const label = document.name || "Document";
   const decryptBoardId = document.encryptionBoardId || boardId;
+
   useEffect(() => {
     let cancelled = false;
-    if (!document.remoteUrl) { setResolvedDocument(document); setLoadingRemote(false); setRemoteError(null); return; }
-    setLoadingRemote(true); setRemoteError(null);
-    resolveDocumentAsset(document, boardId).then((resolved) => { if (!cancelled) { setResolvedDocument(resolved); setLoadingRemote(false); } }).catch((err: any) => { if (!cancelled) { setRemoteError(err?.message || "Failed to decrypt document"); setLoadingRemote(false); } });
+    if (!document.remoteUrl) {
+      setResolvedDocument(document);
+      setLoadingRemote(false);
+      setRemoteError(null);
+      return;
+    }
+    setLoadingRemote(true);
+    setRemoteError(null);
+    resolveDocumentAsset(document, boardId)
+      .then((resolved) => { if (!cancelled) { setResolvedDocument(resolved); setLoadingRemote(false); } })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setRemoteError((err as Error)?.message || "Failed to decrypt document");
+          setLoadingRemote(false);
+        }
+      });
     return () => { cancelled = true; };
   }, [document, boardId]);
-  const effectiveDocument = resolvedDocument;
-  const full = effectiveDocument.full;
-  const subtitle = useMemo(() => [effectiveDocument.kind.toUpperCase(), formatBytes(effectiveDocument.size), effectiveDocument.encrypted ? "Encrypted" : null].filter(Boolean).join(" • "), [effectiveDocument]);
+
+  const doc = resolvedDocument;
+  const full = doc.full;
+
+  const subtitle = useMemo(
+    () =>
+      [doc.kind.toUpperCase(), formatBytes(doc.size), doc.encrypted ? "Encrypted" : null]
+        .filter(Boolean)
+        .join(" • "),
+    [doc],
+  );
+
+  const actions = (
+    <>
+      <button
+        type="button"
+        className="ghost-button button-sm pressable"
+        onClick={() => onOpenExternal?.(doc, decryptBoardId)}
+      >
+        Open
+      </button>
+      <button
+        type="button"
+        className="ghost-button button-sm pressable"
+        onClick={() => onDownloadDocument?.(doc, decryptBoardId)}
+      >
+        Download
+      </button>
+    </>
+  );
+
   let content: React.ReactNode;
-  if (loadingRemote) content = <div className="flex h-full items-center justify-center text-white/70">Decrypting document…</div>;
-  else if (remoteError) content = <div className="flex h-full items-center justify-center text-center text-white/70">{remoteError}</div>;
-  else if (effectiveDocument.kind === "pdf") content = <div className="relative h-full overflow-auto"><div className="absolute right-3 top-3 z-[30] flex gap-2 rounded-full bg-black/45 p-1 backdrop-blur"><button type="button" className="ghost-button button-sm pressable" onClick={() => setPdfScale((s) => Math.max(0.75, s - 0.15))}>−</button><button type="button" className="ghost-button button-sm pressable" onClick={() => setPdfScale(1.15)}>{Math.round((pdfScale / 1.15) * 100)}%</button><button type="button" className="ghost-button button-sm pressable" onClick={() => setPdfScale((s) => Math.min(2.5, s + 0.15))}>+</button></div><div className="px-4 pb-6 pt-14"><PdfPages dataUrl={effectiveDocument.dataUrl} scale={pdfScale} /></div></div>;
-  else if (full?.type === "image") content = <ZoomPane baseWidth={1200}><img src={full.data} alt={label} className="h-auto w-full object-contain" /></ZoomPane>;
-  else if (full?.type === "video") content = <div className="flex h-full items-center justify-center rounded-[28px] bg-black p-2 shadow-2xl"><video controls autoPlay poster={effectiveDocument.preview?.type === "image" ? effectiveDocument.preview.data : undefined} src={full.data} className="max-h-full w-full rounded-[22px] bg-black" /></div>;
-  else if (full?.type === "audio") content = <div className="flex h-full items-center justify-center"><div className="w-full max-w-xl rounded-[28px] bg-[#1b1c20] p-6 shadow-2xl"><div className="mb-4 text-center text-sm text-white/70">Audio attachment</div><audio controls src={full.data} className="w-full" /></div></div>;
-  else if (full?.type === "html") content = <ZoomPane baseWidth={1100} pageClassName="rounded-[28px] bg-white px-6 py-8 text-[#111827] shadow-2xl"><div className="doc-modal__markup doc-modal__markup--rich" dangerouslySetInnerHTML={{ __html: full.data }} /></ZoomPane>;
-  else if (full?.type === "text") content = <ZoomPane baseWidth={1100} pageClassName="rounded-[28px] bg-white px-6 py-8 text-[#111827] shadow-2xl"><pre className="doc-modal__text whitespace-pre-wrap text-[15px] leading-7 text-[#111827]">{full.data}</pre></ZoomPane>;
-  else content = <div className="flex h-full items-center justify-center"><div className="rounded-[28px] bg-[#1b1c20] px-6 py-8 text-center text-white/70 shadow-2xl">Preview unavailable. Use Download to open the original file.</div></div>;
-  const actions = <><button type="button" className="ghost-button button-sm pressable" onClick={() => onOpenExternal?.(effectiveDocument, decryptBoardId)}>Open</button><button type="button" className="ghost-button button-sm pressable" onClick={() => onDownloadDocument?.(effectiveDocument, decryptBoardId)}>Download</button></>;
-  return <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={onClose}>{content}</ViewerShell>;
+
+  if (loadingRemote) {
+    content = (
+      <div className="flex h-full items-center justify-center text-white/70">
+        Decrypting document…
+      </div>
+    );
+  } else if (remoteError) {
+    content = (
+      <div className="flex h-full items-center justify-center text-center text-white/70">
+        {remoteError}
+      </div>
+    );
+  } else if (doc.kind === "pdf") {
+    content = <PdfViewer dataUrl={doc.dataUrl} />;
+  } else if (IMAGE_KINDS.has(doc.kind) && full?.type === "image") {
+    content = <ImageViewer src={full.data} alt={label} />;
+  } else if (VIDEO_KINDS.has(doc.kind) && full?.type === "video") {
+    content = (
+      <VideoViewer
+        src={full.data}
+        poster={doc.preview?.type === "image" ? doc.preview.data : undefined}
+      />
+    );
+  } else if (full?.type === "audio") {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <div className="w-full max-w-xl rounded-[28px] bg-[#1b1c20] p-6 shadow-2xl">
+          <div className="mb-4 text-center text-sm text-white/70">Audio attachment</div>
+          <audio controls src={full.data} className="w-full" />
+        </div>
+      </div>
+    );
+  } else if (doc.kind === "xlsx" && full?.type === "html") {
+    content = <SpreadsheetViewer html={full.data} />;
+  } else if (full?.type === "html") {
+    content = <DocumentViewer content={{ type: "html", data: full.data }} />;
+  } else if (full?.type === "text") {
+    content = <DocumentViewer content={{ type: "text", data: full.data }} />;
+  } else {
+    content = (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-[28px] bg-[#1b1c20] px-6 py-8 text-center text-white/70 shadow-2xl">
+          Preview unavailable. Use Download to open the original file.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ViewerShell title={label} subtitle={subtitle} actions={actions} onClose={onClose}>
+      {content}
+    </ViewerShell>
+  );
 }

--- a/taskify-pwa/src/ui/task/viewers/DocumentViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/DocumentViewer.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { ZoomPane } from "./ZoomPane";
+
+interface DocumentContent {
+  type: "html" | "text";
+  data: string;
+}
+
+/**
+ * Document viewer for md, docx, txt, json, csv.
+ * HTML content (md/docx) is rendered as rich markup; text (txt/json/csv)
+ * is rendered as pre-formatted monospace. Both support zoom and pan.
+ */
+export function DocumentViewer({ content }: { content: DocumentContent }) {
+  const inner =
+    content.type === "html" ? (
+      <div
+        className="doc-modal__markup doc-modal__markup--rich"
+        dangerouslySetInnerHTML={{ __html: content.data }}
+      />
+    ) : (
+      <pre className="doc-modal__text whitespace-pre-wrap text-[15px] leading-7 text-[#111827]">
+        {content.data}
+      </pre>
+    );
+
+  return (
+    <ZoomPane
+      baseWidth={1100}
+      maxScale={4}
+      pageClassName="rounded-[28px] bg-white px-6 py-8 text-[#111827] shadow-2xl"
+    >
+      {inner}
+    </ZoomPane>
+  );
+}

--- a/taskify-pwa/src/ui/task/viewers/ImageViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/ImageViewer.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { ZoomPane } from "./ZoomPane";
+
+/**
+ * Image attachment viewer with scroll-based zoom and pointer drag pan.
+ * Uses ZoomPane (width-based scaling) for predictable layout behaviour.
+ */
+export function ImageViewer({ src, alt }: { src: string; alt?: string }) {
+  return (
+    <ZoomPane baseWidth={1200} maxScale={4}>
+      <img src={src} alt={alt ?? "Image attachment"} className="h-auto w-full object-contain" />
+    </ZoomPane>
+  );
+}

--- a/taskify-pwa/src/ui/task/viewers/PdfViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/PdfViewer.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from "react";
+import { ensurePdfjs } from "../../../lib/documents";
+import { ZoomPane } from "./ZoomPane";
+
+/**
+ * Multi-page PDF viewer. Renders all pages at high resolution once, then
+ * lets ZoomPane handle display zoom + pan — no re-render on zoom.
+ */
+export function PdfViewer({ dataUrl }: { dataUrl: string }) {
+  const [pages, setPages] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  // Render resolution: 2x gives sharp text even when display-zoomed to 200%
+  const RENDER_SCALE = 2.0;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    setPages([]);
+
+    (async () => {
+      try {
+        const pdfjs = await ensurePdfjs();
+        const bytes = await fetch(dataUrl).then((r) => r.arrayBuffer());
+        const pdf = await pdfjs.getDocument({ data: bytes }).promise;
+        const rendered: string[] = [];
+        for (let i = 1; i <= pdf.numPages; i++) {
+          if (cancelled) return;
+          const page = await pdf.getPage(i);
+          const viewport = page.getViewport({ scale: RENDER_SCALE });
+          const canvas = document.createElement("canvas");
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) continue;
+          await page.render({ canvasContext: ctx, viewport }).promise;
+          rendered.push(canvas.toDataURL("image/png"));
+        }
+        if (!cancelled) {
+          setPages(rendered);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true);
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataUrl]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-white/70">
+        Rendering PDF…
+      </div>
+    );
+  }
+
+  if (error || pages.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-[28px] bg-[#1b1c20] px-6 py-8 text-center text-white/70 shadow-2xl">
+          Failed to render PDF. Use Download to open the original file.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ZoomPane baseWidth={900} maxScale={4}>
+      <div className="flex flex-col gap-4 pb-2">
+        {pages.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt={`Page ${i + 1}`}
+            className="w-full rounded-[22px] bg-white shadow-2xl"
+          />
+        ))}
+      </div>
+    </ZoomPane>
+  );
+}

--- a/taskify-pwa/src/ui/task/viewers/SpreadsheetViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/SpreadsheetViewer.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ZoomPane } from "./ZoomPane";
+
+/**
+ * Spreadsheet viewer for xlsx files. Renders the HTML table generated from
+ * the workbook with zoom/pan support. All sticky positioning is explicitly
+ * suppressed so headers scroll naturally with the content.
+ */
+export function SpreadsheetViewer({ html }: { html: string }) {
+  return (
+    <ZoomPane baseWidth={1200} maxScale={4}>
+      {/* Suppress any sticky/fixed positioning on table headers/rows */}
+      <style>{`
+        .spreadsheet-viewer th,
+        .spreadsheet-viewer td,
+        .spreadsheet-viewer tr,
+        .spreadsheet-viewer thead {
+          position: static !important;
+        }
+      `}</style>
+      <div
+        className="spreadsheet-viewer rounded-[22px] bg-white p-4 shadow-2xl"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </ZoomPane>
+  );
+}

--- a/taskify-pwa/src/ui/task/viewers/VideoViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/VideoViewer.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+/**
+ * Video attachment viewer. Renders a native <video> element with controls
+ * and optional poster thumbnail from the document's image preview.
+ */
+export function VideoViewer({ src, poster }: { src: string; poster?: string }) {
+  return (
+    <div className="flex h-full items-center justify-center rounded-[28px] bg-black p-2 shadow-2xl">
+      <video
+        controls
+        autoPlay
+        poster={poster}
+        src={src}
+        className="max-h-full w-full rounded-[22px] bg-black"
+      />
+    </div>
+  );
+}

--- a/taskify-pwa/src/ui/task/viewers/ZoomPane.tsx
+++ b/taskify-pwa/src/ui/task/viewers/ZoomPane.tsx
@@ -1,0 +1,99 @@
+import React, { useRef, useState } from "react";
+
+/**
+ * Scroll-based zoom/pan container. Zooms by resizing the inner content width,
+ * pans via pointer drag or native scroll. No CSS transform hacks.
+ */
+export function ZoomPane({
+  children,
+  pageClassName = "",
+  zoomable = true,
+  baseWidth = 960,
+  minScale = 1,
+  maxScale = 4,
+  step = 0.25,
+}: {
+  children: React.ReactNode;
+  pageClassName?: string;
+  zoomable?: boolean;
+  baseWidth?: number;
+  minScale?: number;
+  maxScale?: number;
+  step?: number;
+}) {
+  const [scale, setScale] = useState(1);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
+
+  const scaledWidth = Math.round(baseWidth * scale);
+  const applyScale = (next: number) => setScale(Math.max(minScale, Math.min(maxScale, next)));
+
+  return (
+    <div className="relative h-full overflow-hidden">
+      {zoomable ? (
+        <div className="absolute right-3 top-3 z-[30] flex gap-2 rounded-full bg-black/45 p-1 backdrop-blur">
+          <button
+            type="button"
+            className="ghost-button button-sm pressable"
+            onClick={() => applyScale(scale - step)}
+          >
+            −
+          </button>
+          <button
+            type="button"
+            className="ghost-button button-sm pressable"
+            onClick={() => applyScale(1)}
+          >
+            {Math.round(scale * 100)}%
+          </button>
+          <button
+            type="button"
+            className="ghost-button button-sm pressable"
+            onClick={() => applyScale(scale + step)}
+          >
+            +
+          </button>
+        </div>
+      ) : null}
+      <div
+        ref={viewportRef}
+        className="h-full overflow-auto"
+        style={{ touchAction: scale > 1 ? "none" : "auto", cursor: scale > 1 ? "grab" : "auto" }}
+        onPointerDown={(e) => {
+          if (scale <= 1 || !viewportRef.current) return;
+          draggingRef.current = {
+            x: e.clientX,
+            y: e.clientY,
+            left: viewportRef.current.scrollLeft,
+            top: viewportRef.current.scrollTop,
+          };
+          (e.currentTarget as HTMLDivElement).setPointerCapture?.(e.pointerId);
+        }}
+        onPointerMove={(e) => {
+          if (!draggingRef.current || !viewportRef.current || scale <= 1) return;
+          e.preventDefault();
+          viewportRef.current.scrollLeft =
+            draggingRef.current.left - (e.clientX - draggingRef.current.x);
+          viewportRef.current.scrollTop =
+            draggingRef.current.top - (e.clientY - draggingRef.current.y);
+        }}
+        onPointerUp={(e) => {
+          draggingRef.current = null;
+          (e.currentTarget as HTMLDivElement).releasePointerCapture?.(e.pointerId);
+        }}
+        onPointerCancel={(e) => {
+          draggingRef.current = null;
+          (e.currentTarget as HTMLDivElement).releasePointerCapture?.(e.pointerId);
+        }}
+      >
+        <div className="flex min-h-full items-start justify-center p-4">
+          <div style={{ width: `${scaledWidth}px`, maxWidth: "none" }}>
+            <div className={pageClassName} style={{ width: "100%", maxWidth: "none" }}>
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Dedicated viewer components** replace the monolithic `DocumentPreviewModal`: `PdfViewer`, `ImageViewer`, `VideoViewer`, `DocumentViewer`, `SpreadsheetViewer`, and a shared `ZoomPane`
- **PDF**: renders all pages once at 2× resolution (sharp at any zoom), then `ZoomPane` handles display zoom + pointer-drag pan — no re-render on zoom
- **Images** (jpg/jpeg/png/webp/gif): width-based `ZoomPane` zoom/pan — no CSS `scale()` transform hacks
- **Documents** (md/docx/txt/json/csv): `DocumentViewer` with `ZoomPane` for zoom/pan; HTML and pre-formatted text handled separately
- **Spreadsheets** (xlsx): `SpreadsheetViewer` with `ZoomPane`; sticky headers/rows explicitly suppressed via scoped CSS so the table scrolls naturally
- **Video**: clean `VideoViewer` with native `<video>` and poster thumbnail from document preview
- `DocumentPreviewModal` becomes a thin orchestrator that dispatches to the correct viewer by `kind` / `full.type`
- Open and Download actions preserved

## Test plan

- [x] Build passes (`npm run build` in taskify-pwa)
- [ ] Open a PDF attachment — all pages scroll vertically, zoom in/out with +/− buttons, drag to pan
- [ ] Open an image attachment — zoom and drag pan work correctly
- [ ] Open a video attachment — plays with controls, poster thumbnail shown
- [ ] Open a .md or .docx — rendered HTML, zoom/pan enabled
- [ ] Open a .txt, .json, or .csv — pre-formatted text, zoom/pan enabled
- [ ] Open an .xlsx — table renders without sticky headers, zoom/pan enabled
- [ ] Download and Open buttons still work for all types

🤖 Generated with [Claude Code](https://claude.com/claude-code)