### PR TITLE
fix(pwa): simplify preview controls and prevent markdown clipping

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -6610,3 +6610,24 @@ html.light .wallet-modal__unit {
   font-size: 12px;
   font-weight: 600;
 }
+
+.doc-modal__markup--mobile-safe,
+.doc-modal__markup--mobile-safe * {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.doc-modal__markup--mobile-safe pre,
+.doc-modal__markup--mobile-safe code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.doc-modal__markup--mobile-safe pre {
+  overflow-x: auto;
+}
+.doc-modal__markup--mobile-safe img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -139,13 +139,11 @@ export function DocumentPreviewModal({
   boardId,
   onClose,
   onDownloadDocument,
-  onOpenExternal,
 }: {
   document: TaskDocument;
   boardId?: string;
   onClose: () => void;
   onDownloadDocument?: (doc: TaskDocument, boardId?: string) => void;
-  onOpenExternal?: (doc: TaskDocument, boardId?: string) => void;
 }) {
   const [resolvedDocument, setResolvedDocument] = useState<TaskDocument>(document);
   const [loadingRemote, setLoadingRemote] = useState(false);
@@ -186,15 +184,8 @@ export function DocumentPreviewModal({
     [doc],
   );
 
-  const actions = (
+const actions = (
     <>
-      <button
-        type="button"
-        className="ghost-button button-sm pressable"
-        onClick={() => onOpenExternal?.(doc, decryptBoardId)}
-      >
-        Open
-      </button>
       <button
         type="button"
         className="ghost-button button-sm pressable"

--- a/taskify-pwa/src/ui/task/viewers/DocumentViewer.tsx
+++ b/taskify-pwa/src/ui/task/viewers/DocumentViewer.tsx
@@ -8,10 +8,10 @@ interface DocumentContent {
 export function DocumentViewer({ content }: { content: DocumentContent }) {
   return (
     <div className="h-full overflow-auto rounded-[28px] bg-[#15161a] [touch-action:auto]">
-      <div className="flex min-h-full items-start justify-center p-4">
-        <div className="w-full max-w-4xl rounded-[28px] bg-white px-6 py-8 text-[#111827] shadow-2xl">
+      <div className="min-h-full p-4">
+        <div className="mx-auto w-full max-w-4xl overflow-x-auto rounded-[28px] bg-white px-4 py-6 text-[#111827] shadow-2xl sm:px-6 sm:py-8">
           {content.type === "html" ? (
-            <div className="doc-modal__markup doc-modal__markup--rich" dangerouslySetInnerHTML={{ __html: content.data }} />
+            <div className="doc-modal__markup doc-modal__markup--rich doc-modal__markup--mobile-safe" dangerouslySetInnerHTML={{ __html: content.data }} />
           ) : (
             <pre className="doc-modal__text whitespace-pre-wrap break-words text-[15px] leading-7 text-[#111827]">{content.data}</pre>
           )}


### PR DESCRIPTION
## Summary
- removes the in-preview Open button so only Close and Download remain
- makes markdown/html preview content mobile-safe so long code/text wraps instead of clipping
- keeps the simplified lightweight native-pinch preview approach

## Validation
- taskify-pwa build passes