### PR TITLE
fix(pwa): preserve decrypted remote media in preview modal

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -9002,23 +9002,6 @@ export default function App() {
     }
   }, [showToast]);
 
-  const openDocumentExternally = useCallback(async (doc: TaskDocument, boardId?: string) => {
-    if (typeof window === "undefined" || typeof document === "undefined") return;
-    const sourceUrl = doc.dataUrl || (doc.remoteUrl
-      ? (doc.encrypted && boardId
-        ? await decryptAttachment({ boardId, url: doc.remoteUrl, mimeType: doc.mimeType })
-        : doc.remoteUrl)
-      : "");
-    if (!sourceUrl) return;
-    const link = document.createElement("a");
-    link.href = sourceUrl;
-    link.target = "_blank";
-    link.rel = "noopener noreferrer";
-    document.body.appendChild(link);
-    link.click();
-    requestAnimationFrame(() => link.remove());
-  }, []);
-
   const openDocumentPreview = useCallback((doc: TaskDocument, boardId?: string) => {
     setPreviewDocument(doc);
     setPreviewDocumentBoardId(boardId);
@@ -19988,7 +19971,6 @@ export default function App() {
           boardId={previewDocumentBoardId}
           onClose={() => { setPreviewDocument(null); setPreviewDocumentBoardId(undefined); }}
           onDownloadDocument={(doc) => handleDownloadDocument(doc, previewDocumentBoardId)}
-          onOpenExternal={(doc) => openDocumentExternally(doc, previewDocumentBoardId)}
         />
       )}
 

--- a/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
+++ b/taskify-pwa/src/ui/task/DocumentPreviewModal.tsx
@@ -32,11 +32,17 @@ async function resolveDocumentAsset(doc: TaskDocument, boardId?: string): Promis
     const dataUrl = doc.encrypted && decryptBoardId
       ? await decryptAttachment({ boardId: decryptBoardId, url: doc.remoteUrl!, mimeType: doc.mimeType })
       : doc.remoteUrl!;
-    return createDocumentFromDataUrl({
+    const resolved = await createDocumentFromDataUrl({
       id: doc.id, name: doc.name, mimeType: doc.mimeType, dataUrl,
       createdAt: doc.createdAt, size: doc.size, remoteUrl: doc.remoteUrl,
       encrypted: doc.encrypted, encryptionBoardId: doc.encryptionBoardId || decryptBoardId,
     });
+    return {
+      ...resolved,
+      remoteUrl: doc.remoteUrl,
+      encrypted: doc.encrypted,
+      encryptionBoardId: doc.encryptionBoardId || decryptBoardId,
+    };
   })().catch((err) => { resolvedDocumentCache.delete(cacheKey); throw err; });
   resolvedDocumentCache.set(cacheKey, promise);
   return promise;


### PR DESCRIPTION
## Summary
- preserves decrypted remote attachment metadata after rebuilding preview docs in the modal
- fixes remote media previews that could get stuck because the modal fell back to encrypted remote URLs after decryption
- also removes the now-unused external open preview wiring

## Validation
- taskify-pwa build passes