### PR TITLE
revert: remove uploading attachment row change

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -6631,32 +6631,3 @@ html.light .wallet-modal__unit {
   max-width: 100%;
   height: auto;
 }
-
-.doc-edit-row--uploading {
-  position: relative;
-  padding-bottom: 0.9rem;
-}
-.doc-edit-row__status {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--accent-primary);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
-}
-.doc-edit-row__progress {
-  position: absolute;
-  left: 0.75rem;
-  right: 0.75rem;
-  bottom: 0.35rem;
-  height: 3px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-primary) 16%, transparent);
-  overflow: hidden;
-}
-.doc-edit-row__progress-bar {
-  height: 100%;
-  border-radius: inherit;
-  background: var(--accent-primary);
-  transition: width 220ms ease;
-}

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -247,13 +247,6 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
   const [images, setImages] = useState<string[]>(task.images || []);
   const [previewImageSrc, setPreviewImageSrc] = useState<string | null>(null);
   const [documents, setDocuments] = useState<TaskDocument[]>(task.documents || []);
-  type UploadingAttachment = {
-    id: string;
-    name: string;
-    kind: string;
-    progress: number;
-  };
-  const [uploadingAttachments, setUploadingAttachments] = useState<UploadingAttachment[]>([]);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [uploadingCount, setUploadingCount] = useState(0);
@@ -1169,20 +1162,6 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
     return { ...rest, remoteUrl, encrypted: true, encryptionBoardId: selectedBoard!.nostr!.boardId };
   }
 
-  function addUploadingAttachment(doc: TaskDocument, fallbackName: string) {
-    const entry = { id: doc.id, name: doc.name || fallbackName || "attachment", kind: doc.kind.toUpperCase(), progress: 0.12 };
-    setUploadingAttachments((prev) => [...prev, entry]);
-    return entry.id;
-  }
-
-  function setUploadingAttachmentProgress(id: string, progress: number) {
-    setUploadingAttachments((prev) => prev.map((item) => item.id === id ? { ...item, progress: Math.max(item.progress, Math.min(progress, 0.94)) } : item));
-  }
-
-  function removeUploadingAttachment(id: string) {
-    setUploadingAttachments((prev) => prev.filter((item) => item.id !== id));
-  }
-
   async function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
     const items = e.clipboardData?.items;
     if (!items) return;
@@ -1209,15 +1188,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
         if (!doc) throw new Error(`Could not read ${label}.`);
         if (isSharedBoard) {
           setUploadingLabel(`Uploading ${label}…`);
-          const uploadId = addUploadingAttachment(doc, label);
-          try {
-            setUploadingAttachmentProgress(uploadId, 0.45);
-            const uploaded = await uploadSharedDocument(file, doc);
-            setUploadingAttachmentProgress(uploadId, 1);
-            nextDocs.push(uploaded);
-          } finally {
-            removeUploadingAttachment(uploadId);
-          }
+          nextDocs.push(await uploadSharedDocument(file, doc));
         } else {
           nextDocs.push(doc);
         }
@@ -1251,15 +1222,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
         }
         if (isSharedBoard) {
           setUploadingLabel(`Uploading ${label}…`);
-          const uploadId = addUploadingAttachment(doc, label);
-          try {
-            setUploadingAttachmentProgress(uploadId, 0.45);
-            const uploaded = await uploadSharedDocument(file, doc);
-            setUploadingAttachmentProgress(uploadId, 1);
-            nextDocs.push(uploaded);
-          } finally {
-            removeUploadingAttachment(uploadId);
-          }
+          nextDocs.push(await uploadSharedDocument(file, doc));
         } else {
           nextDocs.push(doc);
         }
@@ -1868,22 +1831,8 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
                 ))}
               </div>
             )}
-            {(uploadingAttachments.length > 0 || documents.length > 0) && (
+            {documents.length > 0 && (
               <ul className="space-y-1">
-                {uploadingAttachments.map((doc) => (
-                  <li key={doc.id} className="doc-edit-row doc-edit-row--uploading">
-                    <div className="doc-edit-row__info">
-                      <div className="doc-edit-row__name" title={doc.name}>{doc.name}</div>
-                      <div className="doc-edit-row__meta">{doc.kind}</div>
-                    </div>
-                    <div className="doc-edit-row__actions">
-                      <span className="doc-edit-row__status">Uploading</span>
-                    </div>
-                    <div className="doc-edit-row__progress" aria-hidden="true">
-                      <div className="doc-edit-row__progress-bar" style={{ width: `${Math.round(doc.progress * 100)}%` }} />
-                    </div>
-                  </li>
-                ))}
                 {documents.map((doc) => (
                   <li key={doc.id} className="doc-edit-row">
                     <div className="doc-edit-row__info">


### PR DESCRIPTION
## Summary
- reverts PR #171 on top of the latest New_Features_Fixes
- restores prior attachment handling behavior after the upload-row change regressed shared-board file-server uploads

## Validation
- taskify-pwa build passes