### PR TITLE
fix(pwa): remove upload helper text from editor

### DIFF
--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1723,7 +1723,7 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
             disabled={saving || uploadingCount > 0}
           >
             {saving || uploadingCount > 0 ? (
-              <span className="text-xs px-1">{uploadingLabel || "Uploading…"}</span>
+              <span className="text-xs px-1">…</span>
             ) : (
               <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth={2}>
                 <path d="M5 12l4 4 10-10" strokeLinecap="round" strokeLinejoin="round" />
@@ -1738,11 +1738,6 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
           </div>
         )}
 
-        {(saving || uploadingCount > 0) && (
-          <div className="px-4 pt-2 text-xs text-secondary">
-            {uploadingLabel || "Uploading encrypted attachments to your selected file server."} Please keep Taskify open until this finishes.
-          </div>
-        )}
 
         {onSwitchToEvent && (
           <div className="mt-[-1rem] mb-[-1rem] w-full pb-[0.1rem]">


### PR DESCRIPTION
## Summary
- removes the upload helper text below the top bar during attachment uploads
- removes the verbose uploading label from the save button, keeping the UI minimal during upload

## Validation
- taskify-pwa build passes