### PR TITLE
fix(pwa): make upload progress bar visibly animate

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -6655,14 +6655,17 @@ html.light .wallet-modal__unit {
   left: 0.75rem;
   right: 0.75rem;
   bottom: 0.35rem;
-  height: 3px;
+  height: 4px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-primary) 16%, transparent);
+  background: rgba(255,255,255,0.08);
   overflow: hidden;
 }
 .doc-edit-row__progress-bar {
+  display: block;
   height: 100%;
+  min-width: 12px;
   border-radius: inherit;
   background: var(--accent-primary);
-  transition: width 220ms ease;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-primary) 24%, transparent), 0 0 10px color-mix(in srgb, var(--accent-primary) 35%, transparent);
+  transition: width 240ms ease;
 }

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -1173,13 +1173,28 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
     const id = `${doc.id}-uploading`;
     setUploadingDocumentRows((prev) => [
       ...prev,
-      { id, name: doc.name || fallbackName || "attachment", kind: doc.kind.toUpperCase(), progress: 0.18 },
+      { id, name: doc.name || fallbackName || "attachment", kind: doc.kind.toUpperCase(), progress: 0.22 },
     ]);
     return id;
   }
 
   function advanceUploadingDocumentRow(id: string, progress: number) {
     setUploadingDocumentRows((prev) => prev.map((row) => row.id === id ? { ...row, progress: Math.max(row.progress, Math.min(progress, 0.94)) } : row));
+  }
+
+  function startUploadingDocumentRowAnimation(id: string) {
+    const steps = [0.3, 0.42, 0.54, 0.66, 0.78, 0.88, 0.94];
+    let stepIndex = 0;
+    advanceUploadingDocumentRow(id, steps[0]);
+    const interval = window.setInterval(() => {
+      stepIndex += 1;
+      if (stepIndex >= steps.length) {
+        window.clearInterval(interval);
+        return;
+      }
+      advanceUploadingDocumentRow(id, steps[stepIndex]);
+    }, 260);
+    return () => window.clearInterval(interval);
   }
 
   function completeUploadingDocumentRow(id: string) {
@@ -1213,12 +1228,14 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
         if (isSharedBoard) {
           setUploadingLabel(`Uploading ${label}…`);
           const rowId = addUploadingDocumentRow(doc, label);
+          const stopAnimating = startUploadingDocumentRowAnimation(rowId);
           try {
-            advanceUploadingDocumentRow(rowId, 0.52);
             const uploaded = await uploadSharedDocument(file, doc);
+            stopAnimating();
             advanceUploadingDocumentRow(rowId, 1);
             nextDocs.push(uploaded);
           } finally {
+            stopAnimating();
             completeUploadingDocumentRow(rowId);
           }
         } else {
@@ -1255,12 +1272,14 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
         if (isSharedBoard) {
           setUploadingLabel(`Uploading ${label}…`);
           const rowId = addUploadingDocumentRow(doc, label);
+          const stopAnimating = startUploadingDocumentRowAnimation(rowId);
           try {
-            advanceUploadingDocumentRow(rowId, 0.52);
             const uploaded = await uploadSharedDocument(file, doc);
+            stopAnimating();
             advanceUploadingDocumentRow(rowId, 1);
             nextDocs.push(uploaded);
           } finally {
+            stopAnimating();
             completeUploadingDocumentRow(rowId);
           }
         } else {


### PR DESCRIPTION
## Summary
- makes the upload progress bar visibly animate while attachment upload is in progress
- increases contrast and minimum visible fill for the accent progress segment
- keeps the implementation UX-only around the existing upload flow

## Validation
- taskify-pwa build passes