### PR TITLE
fix(pwa): restore indeterminate fallback for originless uploads

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -6668,3 +6668,15 @@ html.light .wallet-modal__unit {
   background: var(--accent);
   transition: width 220ms ease;
 }
+.doc-edit-row__progress--indeterminate {
+  position: relative;
+}
+.doc-edit-row__progress-bar--indeterminate {
+  width: 34% !important;
+  min-width: 34%;
+  animation: doc-edit-row-progress-indeterminate 1.1s ease-in-out infinite;
+}
+@keyframes doc-edit-row-progress-indeterminate {
+  0% { transform: translateX(-110%); }
+  100% { transform: translateX(320%); }
+}

--- a/taskify-pwa/src/ui/task/EditModal.tsx
+++ b/taskify-pwa/src/ui/task/EditModal.tsx
@@ -93,7 +93,7 @@ import {
   type TaskDocument,
 } from "../../lib/documents";
 import { encryptAndUploadAttachment } from "../../lib/attachmentCrypto";
-import { createUploadingDocumentRow, removeUploadingDocumentRow, setUploadingDocumentRowPhase, startUploadingDotsTimer, updateUploadingDocumentRowProgress, type UploadingDocumentRow } from "./uploadProgress";
+import { createUploadingDocumentRow, markStaleUploadingRowsIndeterminate, removeUploadingDocumentRow, setUploadingDocumentRowPhase, startUploadingDotsTimer, updateUploadingDocumentRowProgress, type UploadingDocumentRow } from "./uploadProgress";
 import { findServerEntry, parseFileServers, type FileServerEntry } from "../../lib/fileStorage";
 import {
   buildTaskShareEnvelope,
@@ -1171,6 +1171,14 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
     return startUploadingDotsTimer(uploadingDocumentRows.length, setUploadingDotPhase);
   }, [uploadingDocumentRows.length]);
 
+  useEffect(() => {
+    if (!uploadingDocumentRows.length) return;
+    const interval = window.setInterval(() => {
+      setUploadingDocumentRows((prev) => markStaleUploadingRowsIndeterminate(prev));
+    }, 300);
+    return () => window.clearInterval(interval);
+  }, [uploadingDocumentRows]);
+
 
   async function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
     const items = e.clipboardData?.items;
@@ -1876,8 +1884,8 @@ function EditModal({ task, onCancel, onDelete, onSave, onSwitchToEvent, weekStar
                     <div className="doc-edit-row__actions">
                       <span className="doc-edit-row__status">{doc.phase === "processing" ? "Processing" : "Uploading"}<span className="doc-edit-row__dots">{".".repeat(uploadingDotPhase)}</span></span>
                     </div>
-                    <div className="doc-edit-row__progress" aria-hidden="true">
-                      <div className="doc-edit-row__progress-bar" style={{ width: `${Math.round(doc.progress * 100)}%` }} />
+                    <div className={`doc-edit-row__progress${doc.indeterminate ? " doc-edit-row__progress--indeterminate" : ""}`} aria-hidden="true">
+                      <div className={`doc-edit-row__progress-bar${doc.indeterminate ? " doc-edit-row__progress-bar--indeterminate" : ""}`} style={doc.indeterminate ? undefined : { width: `${Math.max(12, Math.round(doc.progress * 100))}%` }} />
                     </div>
                   </li>
                 ))}

--- a/taskify-pwa/src/ui/task/uploadProgress.ts
+++ b/taskify-pwa/src/ui/task/uploadProgress.ts
@@ -7,6 +7,9 @@ export type UploadingDocumentRow = {
   kind: string;
   progress: number;
   phase: "uploading" | "processing";
+  indeterminate: boolean;
+  progressEventCount: number;
+  lastProgressAt: number | null;
 };
 
 export function createUploadingDocumentRow(doc: TaskDocument, fallbackName: string): UploadingDocumentRow {
@@ -16,12 +19,45 @@ export function createUploadingDocumentRow(doc: TaskDocument, fallbackName: stri
     kind: doc.kind.toUpperCase(),
     progress: 0,
     phase: "uploading",
+    indeterminate: true,
+    progressEventCount: 0,
+    lastProgressAt: null,
   };
 }
 
 export function updateUploadingDocumentRowProgress(rows: UploadingDocumentRow[], id: string, progress: number): UploadingDocumentRow[] {
+  const now = Date.now();
   const clamped = Math.max(0, Math.min(progress, 1));
-  return rows.map((row) => (row.id === id ? { ...row, progress: clamped } : row));
+  return rows.map((row) => {
+    if (row.id !== id) return row;
+    const progressEventCount = row.progressEventCount + 1;
+    const hasMeaningfulProgress = progressEventCount >= 2 || clamped >= 0.12;
+    return {
+      ...row,
+      progress: clamped,
+      indeterminate: !hasMeaningfulProgress,
+      progressEventCount,
+      lastProgressAt: now,
+    };
+  });
+}
+
+export function setUploadingDocumentRowPhase(rows: UploadingDocumentRow[], id: string, phase: "uploading" | "processing"): UploadingDocumentRow[] {
+  return rows.map((row) => (
+    row.id === id
+      ? { ...row, phase, indeterminate: phase === "uploading" ? row.indeterminate : false, progress: phase === "processing" ? Math.max(row.progress, 1) : row.progress }
+      : row
+  ));
+}
+
+export function markStaleUploadingRowsIndeterminate(rows: UploadingDocumentRow[], now = Date.now()): UploadingDocumentRow[] {
+  return rows.map((row) => {
+    if (row.phase !== "uploading") return row;
+    if (row.lastProgressAt == null) return row;
+    if (row.progress >= 1) return row;
+    if (now - row.lastProgressAt < 900) return row;
+    return { ...row, indeterminate: true };
+  });
 }
 
 export function removeUploadingDocumentRow(rows: UploadingDocumentRow[], id: string): UploadingDocumentRow[] {
@@ -40,9 +76,4 @@ export function startUploadingDotsTimer(
     setUploadingDotPhase((prev) => (prev + 1) % 4);
   }, 420);
   return () => window.clearInterval(interval);
-}
-
-
-export function setUploadingDocumentRowPhase(rows: UploadingDocumentRow[], id: string, phase: "uploading" | "processing"): UploadingDocumentRow[] {
-  return rows.map((row) => (row.id === id ? { ...row, phase, progress: phase === "processing" ? Math.max(row.progress, 1) : row.progress } : row));
 }


### PR DESCRIPTION
## Summary
- restores the indeterminate upload fallback for weak/stalled originless progress events
- verifies stale-progress detection is wired from helper to modal render path
- adds/retains animated indeterminate upload styling

## Validation
- taskify-pwa build passes
- verified helper symbols, render classes, and CSS animation are present on the branch