### PR TITLE
fix(pwa): seed fresh installs with shared week board

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -4397,8 +4397,16 @@ function useBoards() {
       const migrated = migrateBoards(JSON.parse(raw));
       if (migrated && migrated.length) return migrated;
     }
-    // default: one Week board
-    return [{ id: "week-default", name: "Week", kind: "week", archived: false, hidden: false, clearCompletedDisabled: false }];
+    // default: one shared Week board for fresh installs
+    return [{
+      id: "week-default",
+      name: "Week",
+      kind: "week",
+      nostr: { boardId: crypto.randomUUID(), relays: Array.from(DEFAULT_NOSTR_RELAYS) },
+      archived: false,
+      hidden: false,
+      clearCompletedDisabled: false,
+    }];
   });
   const boardsFirstRun = useRef(true);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- updates the fresh-install default board seed to create a shared Week board
- preserves existing stored boards as-is (no local->shared migration)
- aligns bootstrap behavior with shared-by-default board creation flows

## Validation
- taskify-pwa build passes