### PR TITLE
feat(cli): add attachment parity and publishable runtime deps

### DIFF
--- a/taskify-cli/build.mjs
+++ b/taskify-cli/build.mjs
@@ -23,6 +23,10 @@ await esbuild.build({
   external: [
     ...NODE_BUILTINS,
     ...NODE_BUILTINS.map((b) => `node:${b}`),
+    "@nostr-dev-kit/ndk",
+    "nostr-tools",
+    "@noble/hashes/sha256",
+    "@noble/hashes/utils",
   ],
   // Provide a require() shim so bundled CJS deps (commander etc.) work in ESM context
   banner: {

--- a/taskify-cli/package.json
+++ b/taskify-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskify-nostr",
-  "version": "0.3.4",
+  "version": "0.3.6",
   "description": "Nostr-powered task management CLI",
   "type": "module",
   "bin": {
@@ -32,17 +32,18 @@
     "type": "git",
     "url": "git+https://github.com/Solife-me/Taskify_Release.git"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "@noble/hashes": "^1.4.0",
     "@nostr-dev-kit/ndk": "^2.18.1",
-    "@types/node": "^25.4.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
-    "esbuild": "^0.27.4",
     "nostr-tools": "^2.16.2",
     "taskify-core": "file:../taskify-core",
-    "taskify-runtime-nostr": "file:../taskify-runtime-nostr",
+    "taskify-runtime-nostr": "file:../taskify-runtime-nostr"
+  },
+  "devDependencies": {
+    "@types/node": "^25.4.0",
+    "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   }
 }

--- a/taskify-cli/src/attachmentCrypto.ts
+++ b/taskify-cli/src/attachmentCrypto.ts
@@ -1,0 +1,164 @@
+import { createHash, randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import { uploadImageToNip96 } from "./nip96Upload.js";
+import type { TaskifyConfig } from "./config.js";
+
+export type CliTaskDocument = {
+  id: string;
+  name: string;
+  mimeType: string;
+  kind: string;
+  size?: number;
+  dataUrl: string;
+  createdAt: string;
+  remoteUrl?: string;
+  encrypted?: boolean;
+  encryptionBoardId?: string;
+};
+
+
+function inferServerType(url: string): "nip96" | "originless" | "blossom" {
+  const lower = (url || "").toLowerCase();
+  if (lower.includes("originless")) return "originless";
+  if (lower.includes("blossom")) return "blossom";
+  return "nip96";
+}
+
+async function uploadBlobToOriginless(serverUrl: string, bytes: Uint8Array, filename: string, mimeType: string): Promise<string> {
+  const base = serverUrl.replace(/\/+$/, "");
+  const uploadUrl = `${base}/upload`;
+  const attempts: RequestInit[] = [
+    { method: "POST", body: (() => { const form = new FormData(); form.append("file", new Blob([bytes], { type: mimeType || "application/octet-stream" }), filename); return form; })() },
+    { method: "POST", headers: { "Content-Type": "application/octet-stream" }, body: new Blob([bytes], { type: "application/octet-stream" }) },
+  ];
+  let lastErr: unknown = null;
+  for (const init of attempts) {
+    try {
+      const res = await fetch(uploadUrl, init);
+      const data = await res.json().catch(() => ({} as any));
+      if (!res.ok) throw new Error(data?.message || `Originless upload failed (${res.status})`);
+      const direct = [data?.url, data?.cidUrl, data?.gatewayUrl, data?.fileUrl, data?.ipfs];
+      for (const value of direct) {
+        if (typeof value === "string" && value.trim()) return value.trim();
+      }
+      const cid = typeof data?.cid === "string" ? data.cid.trim() : "";
+      if (cid) return `${base}/ipfs/${cid}`;
+      const path = typeof data?.path === "string" ? data.path.trim() : "";
+      if (path) return path.startsWith('http') ? path : `${base}${path.startsWith('/') ? '' : '/'}${path}`
+      throw new Error("Originless upload response did not include a url.");
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error("Originless upload failed");
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".json": "application/json",
+  ".csv": "text/csv",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".mp3": "audio/mpeg",
+  ".aac": "audio/aac",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+};
+
+function inferMime(filePath: string): string {
+  return MIME_BY_EXT[extname(filePath).toLowerCase()] || "application/octet-stream";
+}
+function inferKind(filePath: string, mimeType: string): string {
+  const ext = extname(filePath).toLowerCase().replace(/^\./, "");
+  if (ext) return ext;
+  const slash = mimeType.indexOf("/");
+  return slash >= 0 ? mimeType.slice(slash + 1).toLowerCase() : "bin";
+}
+function bytesToDataUrl(bytes: Uint8Array, mimeType: string): string {
+  return `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`;
+}
+function deriveBoardKey(boardId: string): Buffer {
+  return createHash("sha256").update(boardId).digest();
+}
+function encryptAttachmentBytes(boardId: string, plaintext: Uint8Array): Uint8Array {
+  const key = deriveBoardKey(boardId);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(Buffer.from(plaintext)), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return new Uint8Array(Buffer.concat([iv, ciphertext, tag]));
+}
+export async function decryptAttachmentToDataUrl(boardId: string, url: string, mimeType: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch attachment (${res.status})`);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (bytes.length < 28) throw new Error("Encrypted attachment too small");
+  const iv = bytes.slice(0, 12);
+  const tag = bytes.slice(bytes.length - 16);
+  const ct = bytes.slice(12, bytes.length - 16);
+  const decipher = createDecipheriv("aes-256-gcm", deriveBoardKey(boardId), Buffer.from(iv));
+  decipher.setAuthTag(Buffer.from(tag));
+  const pt = Buffer.concat([decipher.update(Buffer.from(ct)), decipher.final()]);
+  return bytesToDataUrl(new Uint8Array(pt), mimeType || "application/octet-stream");
+}
+export async function buildAttachmentDocuments(opts: {
+  files: string[];
+  boardId: string;
+  shared: boolean;
+  config: TaskifyConfig;
+  fileServer?: string;
+}): Promise<CliTaskDocument[]> {
+  const out: CliTaskDocument[] = [];
+  for (const filePath of opts.files) {
+    const bytes = await readFile(filePath);
+    const mimeType = inferMime(filePath);
+    const kind = inferKind(filePath, mimeType);
+    const name = basename(filePath);
+    const createdAt = new Date().toISOString();
+    const base: CliTaskDocument = {
+      id: crypto.randomUUID(),
+      name,
+      mimeType,
+      kind,
+      size: bytes.length,
+      dataUrl: bytesToDataUrl(new Uint8Array(bytes), mimeType),
+      createdAt,
+    };
+    if (!opts.shared) {
+      out.push(base);
+      continue;
+    }
+    const nsec = opts.config.nsec;
+    if (!nsec) throw new Error("Shared attachment upload requires an nsec in CLI config.");
+    const serverUrl = opts.fileServer || opts.config.encryptedFileStorageServer || "https://originless.solife.me";
+    const encrypted = encryptAttachmentBytes(opts.boardId, new Uint8Array(bytes));
+    const serverType = inferServerType(serverUrl);
+    let remoteUrl = "";
+    if (serverType === "originless" || serverType === "blossom") {
+      remoteUrl = await uploadBlobToOriginless(serverUrl, encrypted, `${name}.bin`, "application/octet-stream");
+    } else {
+      const tmpPath = `/tmp/taskify-attachment-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.bin`;
+      await import('node:fs/promises').then(fs => fs.writeFile(tmpPath, Buffer.from(encrypted)));
+      try {
+        remoteUrl = await uploadImageToNip96({ serverUrl, filePath: tmpPath, nsec });
+      } finally {
+        await import('node:fs/promises').then(fs => fs.unlink(tmpPath).catch(() => {}));
+      }
+    }
+    out.push({ ...base, remoteUrl, encrypted: true, encryptionBoardId: opts.boardId });
+  }
+  return out;
+}

--- a/taskify-cli/src/config.ts
+++ b/taskify-cli/src/config.ts
@@ -4,6 +4,9 @@ import { join } from "path";
 import { homedir } from "os";
 import type { ReminderPreset } from "./shared/taskTypes.js";
 
+export const DEFAULT_PUBLIC_FILE_STORAGE_SERVER = "https://nostr.build";
+export const DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER = "https://originless.solife.me";
+
 export const CONFIG_DIR = join(homedir(), ".taskify-cli");
 export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
 
@@ -51,6 +54,8 @@ export type ProfileConfig = {
   taskReminders: Record<string, ReminderPreset[]>;
   processedInboxRumorIds?: string[];
   contacts?: Contact[];
+  fileStorageServer?: string;
+  encryptedFileStorageServer?: string;
   agent?: {
     apiKey?: string;
     baseUrl?: string;   // default: https://api.openai.com/v1
@@ -86,6 +91,8 @@ const DEFAULT_PROFILE: ProfileConfig = {
   boards: [],
   taskReminders: {},
   processedInboxRumorIds: [],
+  fileStorageServer: DEFAULT_PUBLIC_FILE_STORAGE_SERVER,
+  encryptedFileStorageServer: DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
 };
 
 function profileDefaults(partial: Partial<ProfileConfig>): ProfileConfig {
@@ -98,6 +105,8 @@ function profileDefaults(partial: Partial<ProfileConfig>): ProfileConfig {
     trustedNpubs: partial.trustedNpubs ?? [],
     boards: partial.boards ?? [],
     contacts: partial.contacts ?? [],
+    fileStorageServer: partial.fileStorageServer ?? DEFAULT_PUBLIC_FILE_STORAGE_SERVER,
+    encryptedFileStorageServer: partial.encryptedFileStorageServer ?? DEFAULT_ENCRYPTED_FILE_STORAGE_SERVER,
   };
 }
 
@@ -174,6 +183,8 @@ export async function saveConfig(cfg: TaskifyConfig): Promise<void> {
     taskReminders: cfg.taskReminders,
     processedInboxRumorIds: cfg.processedInboxRumorIds,
     contacts: cfg.contacts,
+    fileStorageServer: cfg.fileStorageServer,
+    encryptedFileStorageServer: cfg.encryptedFileStorageServer,
     agent: cfg.agent,
   };
   const stored: StoredConfig = {

--- a/taskify-cli/src/index.ts
+++ b/taskify-cli/src/index.ts
@@ -31,6 +31,7 @@ import { sendShareEnvelopeNip17, fetchShareInboxNip17 } from "./shared/shareTran
 import { resolveBoardColumn, formatAvailableColumns } from "./shared/columnResolution.js";
 import { publishProfile, fetchLatestProfileEvent } from "./profileMeta.js";
 import { uploadImageToNip96 } from "./nip96Upload.js";
+import { buildAttachmentDocuments, decryptAttachmentToDataUrl } from "./attachmentCrypto.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -168,6 +169,78 @@ async function resolveBoardId(
     }
   }
   process.exit(resolved.exitCode);
+}
+
+
+async function mergeAttachmentDocuments(opts: {
+  existing?: Record<string, unknown>[];
+  files?: string[];
+  boardId: string;
+  config: Awaited<ReturnType<typeof loadConfig>>;
+  fileServer?: string;
+  documentsJson?: string;
+  removeRefs?: string[];
+  replace?: boolean;
+}): Promise<unknown[] | null | undefined> {
+  const base = opts.replace ? [] : [ ...((opts.existing || []) as unknown[]) ];
+  const removals = new Set((opts.removeRefs || []).map((v) => v.toLowerCase()));
+  const kept = base.filter((doc, idx) => {
+    if (removals.has(String(idx + 1))) return false;
+    const name = typeof (doc as any)?.name === "string" ? (doc as any).name.toLowerCase() : "";
+    for (const ref of removals) {
+      if (name && name.includes(ref)) return false;
+    }
+    return true;
+  });
+  const fromJson = normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson));
+  const generated = (await resolveAttachmentDocuments({ files: opts.files, boardId: opts.boardId, config: opts.config, fileServer: opts.fileServer, documentsJson: undefined })) || [];
+  const merged = [...kept, ...(fromJson || []), ...generated];
+  if (opts.replace && merged.length === 0) return null;
+  if (!opts.replace && opts.removeRefs?.length === 0 && !(opts.files || []).length && opts.documentsJson === undefined) return undefined;
+  return normalizeTaskDocuments(merged) as unknown[] | undefined;
+}
+
+async function resolveAttachmentDocuments(opts: {
+  files?: string[];
+  boardId: string;
+  config: Awaited<ReturnType<typeof loadConfig>>;
+  fileServer?: string;
+  documentsJson?: string;
+}): Promise<unknown[] | undefined> {
+  const fromJson = normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson));
+  const files = (opts.files || []).filter(Boolean);
+  if (!files.length) return fromJson as unknown[] | undefined;
+  const boardEntry = opts.config.boards.find((b) => b.id === opts.boardId);
+  const generated = await buildAttachmentDocuments({
+    files,
+    boardId: opts.boardId,
+    shared: !!boardEntry,
+    config: opts.config,
+    fileServer: opts.fileServer,
+  });
+  const merged = [...(fromJson || []), ...generated as unknown[]];
+  return normalizeTaskDocuments(merged) as unknown[] | undefined;
+}
+
+
+function extractDocumentUrl(doc: Record<string, unknown>): string | undefined {
+  if (typeof doc.remoteUrl === "string" && doc.remoteUrl.trim()) return doc.remoteUrl.trim();
+  if (typeof doc.url === "string" && doc.url.trim()) return doc.url.trim();
+  return undefined;
+}
+
+function resolveDocumentByRef(documents: Record<string, unknown>[] | undefined, ref: string): { index: number; doc: Record<string, unknown> } | null {
+  if (!Array.isArray(documents) || documents.length === 0) return null;
+  const indexNum = Number.parseInt(ref, 10);
+  if (Number.isFinite(indexNum) && indexNum >= 1 && indexNum <= documents.length) {
+    return { index: indexNum - 1, doc: documents[indexNum - 1] as Record<string, unknown> };
+  }
+  const lowered = ref.toLowerCase();
+  const idx = documents.findIndex((doc) => {
+    const name = typeof doc.name === "string" ? doc.name.toLowerCase() : "";
+    return name.includes(lowered);
+  });
+  return idx >= 0 ? { index: idx, doc: documents[idx] as Record<string, unknown> } : null;
 }
 
 // ---- board command group ----
@@ -707,6 +780,8 @@ eventCmd
   .option("--reminders <csv>", "Reminder presets csv (e.g. 15m,1h)")
   .option("--invitee <npubOrHex>", "Invitee pubkey/npub (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
   .option("--documents-json <json>", "Documents/attachments array JSON")
+  .option("--attach <path>", "Attach local file/image (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--file-server <url>", "Encrypted file server override for shared attachment uploads")
   .option("--json", "Output as JSON")
   .action(async (title: string, opts) => {
     if (!opts.date) {
@@ -733,7 +808,7 @@ eventCmd
       const resolvedColumn = opts.column ? resolveColumnOrExit(boardEntry, opts.column) : null;
       const recurrence = normalizeTaskRecurrence(parseJsonOption("--recurrence-json", opts.recurrenceJson));
       const reminders = normalizeTaskReminders(parseReminderOption(opts.reminders));
-      const documents = normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson));
+      const documents = await resolveAttachmentDocuments({ files: opts.attach as string[], boardId, config, fileServer: opts.fileServer, documentsJson: opts.documentsJson });
       const invitees = normalizeAssigneeArgs(opts.invitee as string[])?.map((a) => ({ pubkey: a.pubkey, relay: a.relay }));
       const created = await runtime.createEvent({
         ...draft,
@@ -785,7 +860,15 @@ eventCmd
           console.log(`invitees: ${event.participants.length}`);
           event.participants.forEach((p) => console.log(`  - ${p.pubkey}${p.role ? ` (${p.role})` : ""}`));
         }
-        if (Array.isArray(event.documents) && event.documents.length > 0) console.log(`documents: ${event.documents.length}`);
+        if (Array.isArray(event.documents) && event.documents.length > 0) {
+          console.log(`documents: ${event.documents.length}`);
+          event.documents.forEach((doc: any, idx: number) => {
+            const name = typeof doc?.name === "string" ? doc.name : `document-${idx + 1}`;
+            const url = typeof doc?.remoteUrl === "string" ? doc.remoteUrl : (typeof doc?.url === "string" ? doc.url : "");
+            const flags = [doc?.encrypted === true ? "encrypted" : null, typeof doc?.kind === "string" ? doc.kind : null].filter(Boolean).join(", ");
+            console.log(`  - ${name}${flags ? ` [${flags}]` : ""}${url ? ` (${url})` : ""}`);
+          });
+        }
         if (event.columnId) console.log(`column: ${event.columnId}`);
         if (event.rsvpStatus) console.log(`rsvp status: ${event.rsvpStatus}`);
       }
@@ -814,6 +897,10 @@ eventCmd
   .option("--reminders <csv>", "Update reminder presets csv")
   .option("--invitee <npubOrHex>", "Replace invitees (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
   .option("--documents-json <json>", "Replace documents/attachments with array JSON")
+  .option("--attach <path>", "Append local file/image attachment (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--remove-attachment <ref>", "Remove attachment by 1-based index or partial name (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--replace-attachments", "Replace all existing attachments with provided attachment inputs")
+  .option("--file-server <url>", "Encrypted file server override for shared attachment uploads")
   .option("--json", "Output as JSON")
   .action(async (eventId: string, opts) => {
     const config = await loadConfig(program.opts().profile as string | undefined);
@@ -824,7 +911,24 @@ eventCmd
       const resolvedColumn = opts.column && boardEntry ? resolveColumnOrExit(boardEntry, opts.column) : null;
       const recurrence = opts.recurrenceJson !== undefined ? normalizeTaskRecurrence(parseJsonOption("--recurrence-json", opts.recurrenceJson)) ?? null : undefined;
       const reminders = opts.reminders !== undefined ? normalizeTaskReminders(parseReminderOption(opts.reminders)) ?? null : undefined;
-      const documents = opts.documentsJson !== undefined ? normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson)) ?? null : undefined;
+      let documents = undefined;
+      if (opts.documentsJson !== undefined || ((opts.attach as string[]).length > 0) || ((opts.removeAttachment as string[]).length > 0) || opts.replaceAttachments) {
+        const existingEvent = await runtime.getEvent(eventId, boardId);
+        if (!existingEvent) {
+          console.error(chalk.red(`Event not found: ${eventId}`));
+          process.exit(1);
+        }
+        documents = await mergeAttachmentDocuments({
+          existing: existingEvent.documents as Record<string, unknown>[] | undefined,
+          files: opts.attach as string[],
+          boardId: (boardId || existingEvent.boardId),
+          config,
+          fileServer: opts.fileServer,
+          documentsJson: opts.documentsJson,
+          removeRefs: opts.removeAttachment as string[],
+          replace: !!opts.replaceAttachments,
+        }) ?? null;
+      }
       const invitees = (opts.invitee as string[]).length > 0
         ? normalizeAssigneeArgs(opts.invitee as string[])?.map((a) => ({ pubkey: a.pubkey, relay: a.relay })) ?? []
         : undefined;
@@ -1376,6 +1480,8 @@ program
   .option("--reminders <csv>", "Reminder presets csv (e.g. 15m,1h)")
   .option("--assignee <npubOrHex>", "Assign to pubkey/npub (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
   .option("--documents-json <json>", "Documents/attachments array JSON")
+  .option("--attach <path>", "Attach local file/image (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--file-server <url>", "Encrypted file server override for shared attachment uploads")
   .option("--due-time <HH:MM>", "Due time (combine with --due to form ISO datetime, sets dueTimeEnabled)")
   .option("--timezone <iana>", "IANA timezone for due time (e.g. America/New_York)")
   .option("--hidden-until <ISO>", "Hide task until this ISO datetime")
@@ -1428,7 +1534,7 @@ program
       }));
       const recurrence = normalizeTaskRecurrence(parseJsonOption("--recurrence-json", opts.recurrenceJson));
       const reminders = normalizeTaskReminders(parseReminderOption(opts.reminders));
-      const documents = normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson));
+      const documents = await resolveAttachmentDocuments({ files: opts.attach as string[], boardId, config, fileServer: opts.fileServer, documentsJson: opts.documentsJson });
       const assignees = normalizeAssigneeArgs(opts.assignee as string[]);
       let dueISO = opts.due as string | undefined;
       let dueTimeEnabled: boolean | undefined;
@@ -1687,6 +1793,10 @@ program
   .option("--reminders <csv>", "Reminder presets csv (e.g. 15m,1h)")
   .option("--assignee <npubOrHex>", "Replace assignees with pubkey/npub values (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
   .option("--documents-json <json>", "Replace documents/attachments with array JSON")
+  .option("--attach <path>", "Append local file/image attachment (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--remove-attachment <ref>", "Remove attachment by 1-based index or partial name (repeatable)", (val: string, arr: string[]) => [...arr, val], [] as string[])
+  .option("--replace-attachments", "Replace all existing attachments with provided attachment inputs")
+  .option("--file-server <url>", "Encrypted file server override for shared attachment uploads")
   .option("--due-time <HH:MM>", "Due time (combine with --due to form ISO datetime, sets dueTimeEnabled)")
   .option("--timezone <iana>", "IANA timezone for due time (e.g. America/New_York)")
   .option("--hidden-until <ISO>", "Hide task until this ISO datetime")
@@ -1706,7 +1816,23 @@ program
       if (opts.note !== undefined) patch.note = opts.note;
       if (opts.recurrenceJson !== undefined) patch.recurrence = normalizeTaskRecurrence(parseJsonOption("--recurrence-json", opts.recurrenceJson)) ?? null;
       if (opts.reminders !== undefined) patch.reminders = normalizeTaskReminders(parseReminderOption(opts.reminders)) ?? null;
-      if (opts.documentsJson !== undefined) patch.documents = normalizeTaskDocuments(parseJsonOption("--documents-json", opts.documentsJson)) ?? null;
+      if (opts.documentsJson !== undefined || ((opts.attach as string[]).length > 0) || ((opts.removeAttachment as string[]).length > 0) || opts.replaceAttachments) {
+        const existingTask = await runtime.getTask(taskId, boardId);
+        if (!existingTask) {
+          console.error(chalk.red(`Task not found: ${taskId}`));
+          process.exit(1);
+        }
+        patch.documents = await mergeAttachmentDocuments({
+          existing: existingTask.documents as Record<string, unknown>[] | undefined,
+          files: opts.attach as string[],
+          boardId,
+          config,
+          fileServer: opts.fileServer,
+          documentsJson: opts.documentsJson,
+          removeRefs: opts.removeAttachment as string[],
+          replace: !!opts.replaceAttachments,
+        }) ?? null;
+      }
       if ((opts.assignee as string[]).length > 0) patch.assignees = normalizeAssigneeArgs(opts.assignee as string[]) ?? [];
       if (opts.column !== undefined) {
         const bEntry = config.boards.find((b) => b.id === boardId);
@@ -1741,6 +1867,184 @@ program
     } finally {
       await runtime.disconnect();
       process.exit(exitCode);
+    }
+  });
+
+
+const attachmentCmd = program.command("attachment").description("Inspect, decrypt, and download task/event attachments");
+
+attachmentCmd
+  .command("task-show <taskId> <attachmentRef>")
+  .description("Alias for attachment show")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--json", "Output attachment as JSON")
+  .action(async (taskId: string, attachmentRef: string, opts) => {
+    await program.parseAsync(["node", "taskify", "attachment", "show", taskId, attachmentRef, ...(opts.board ? ["--board", opts.board] : []), ...(opts.json ? ["--json"] : [])], { from: "user" });
+  });
+
+attachmentCmd
+  .command("task-download <taskId> <attachmentRef>")
+  .description("Alias for attachment download")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--out <path>", "Output path")
+  .action(async (taskId: string, attachmentRef: string, opts) => {
+    await program.parseAsync(["node", "taskify", "attachment", "download", taskId, attachmentRef, ...(opts.board ? ["--board", opts.board] : []), ...(opts.out ? ["--out", opts.out] : [])], { from: "user" });
+  });
+
+attachmentCmd
+  .command("show <taskId> <attachmentRef>")
+  .description("Show a task attachment by 1-based index or partial name")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--json", "Output attachment as JSON")
+  .action(async (taskId: string, attachmentRef: string, opts) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    try {
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) throw new Error(`Task not found: ${taskId}`);
+      const hit = resolveDocumentByRef(task.documents as Record<string, unknown>[] | undefined, attachmentRef);
+      if (!hit) throw new Error(`Attachment not found: ${attachmentRef}`);
+      if (opts.json) renderJson(hit.doc);
+      else {
+        const name = typeof hit.doc.name === "string" ? hit.doc.name : `document-${hit.index + 1}`;
+        const mime = typeof hit.doc.mimeType === "string" ? hit.doc.mimeType : "application/octet-stream";
+        const kind = typeof hit.doc.kind === "string" ? hit.doc.kind : "unknown";
+        const remoteUrl = extractDocumentUrl(hit.doc);
+        console.log(chalk.bold(name));
+        console.log(`index: ${hit.index + 1}`);
+        console.log(`kind: ${kind}`);
+        console.log(`mime: ${mime}`);
+        if (typeof hit.doc.encrypted === "boolean") console.log(`encrypted: ${hit.doc.encrypted}`);
+        if (typeof hit.doc.encryptionBoardId === "string") console.log(`encryptionBoardId: ${hit.doc.encryptionBoardId}`);
+        if (remoteUrl) console.log(`remoteUrl: ${remoteUrl}`);
+      }
+      process.exit(0);
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      process.exit(1);
+    } finally {
+      await runtime.disconnect();
+    }
+  });
+
+attachmentCmd
+  .command("download <taskId> <attachmentRef>")
+  .description("Download a task attachment, decrypting if needed")
+  .option("--board <id|name>", "Board the task belongs to")
+  .option("--out <path>", "Output path")
+  .action(async (taskId: string, attachmentRef: string, opts) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const boardId = await resolveBoardId(opts.board, config);
+    const runtime = initRuntime(config);
+    try {
+      const task = await runtime.getTask(taskId, boardId);
+      if (!task) throw new Error(`Task not found: ${taskId}`);
+      const hit = resolveDocumentByRef(task.documents as Record<string, unknown>[] | undefined, attachmentRef);
+      if (!hit) throw new Error(`Attachment not found: ${attachmentRef}`);
+      const name = typeof hit.doc.name === "string" ? hit.doc.name : `document-${hit.index + 1}`;
+      const mime = typeof hit.doc.mimeType === "string" ? hit.doc.mimeType : "application/octet-stream";
+      const outPath = opts.out || name;
+      let dataUrl = typeof hit.doc.dataUrl === "string" ? hit.doc.dataUrl : "";
+      const remoteUrl = extractDocumentUrl(hit.doc);
+      if ((!dataUrl || dataUrl.startsWith("data:application/octet-stream;base64,")) && remoteUrl) {
+        if (hit.doc.encrypted === true) {
+          dataUrl = await decryptAttachmentToDataUrl(typeof hit.doc.encryptionBoardId === "string" ? hit.doc.encryptionBoardId : boardId, remoteUrl, mime);
+        } else {
+          const res = await fetch(remoteUrl);
+          if (!res.ok) throw new Error(`Failed to fetch attachment (${res.status})`);
+          const bytes = Buffer.from(await res.arrayBuffer());
+          dataUrl = `data:${mime};base64,${bytes.toString("base64")}`;
+        }
+      }
+      if (!dataUrl.startsWith("data:")) throw new Error("Attachment has no retrievable data.");
+      const base64 = dataUrl.split(",", 2)[1] || "";
+      await writeFile(outPath, Buffer.from(base64, "base64"));
+      console.log(chalk.green(`✓ Saved attachment to ${outPath}`));
+      process.exit(0);
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      process.exit(1);
+    } finally {
+      await runtime.disconnect();
+    }
+  });
+
+attachmentCmd
+  .command("event-show <eventId> <attachmentRef>")
+  .description("Show an event attachment by 1-based index or partial name")
+  .option("--board <id|name>", "Board the event belongs to")
+  .option("--json", "Output attachment as JSON")
+  .action(async (eventId: string, attachmentRef: string, opts) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const runtime = initRuntime(config);
+    try {
+      const boardId = opts.board ? await resolveBoardId(opts.board, config) : undefined;
+      const event = await runtime.getEvent(eventId, boardId);
+      if (!event) throw new Error(`Event not found: ${eventId}`);
+      const hit = resolveDocumentByRef(event.documents as Record<string, unknown>[] | undefined, attachmentRef);
+      if (!hit) throw new Error(`Attachment not found: ${attachmentRef}`);
+      if (opts.json) renderJson(hit.doc);
+      else {
+        const name = typeof hit.doc.name === "string" ? hit.doc.name : `document-${hit.index + 1}`;
+        const mime = typeof hit.doc.mimeType === "string" ? hit.doc.mimeType : "application/octet-stream";
+        const remoteUrl = extractDocumentUrl(hit.doc);
+        console.log(chalk.bold(name));
+        console.log(`index: ${hit.index + 1}`);
+        console.log(`event: ${event.title}`);
+        console.log(`mime: ${mime}`);
+        if (typeof hit.doc.encrypted === "boolean") console.log(`encrypted: ${hit.doc.encrypted}`);
+        if (typeof hit.doc.encryptionBoardId === "string") console.log(`encryptionBoardId: ${hit.doc.encryptionBoardId}`);
+        if (remoteUrl) console.log(`remoteUrl: ${remoteUrl}`);
+      }
+      process.exit(0);
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      process.exit(1);
+    } finally {
+      await runtime.disconnect();
+    }
+  });
+
+attachmentCmd
+  .command("event-download <eventId> <attachmentRef>")
+  .description("Download an event attachment, decrypting if needed")
+  .option("--board <id|name>", "Board the event belongs to")
+  .option("--out <path>", "Output path")
+  .action(async (eventId: string, attachmentRef: string, opts) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    const runtime = initRuntime(config);
+    try {
+      const boardId = opts.board ? await resolveBoardId(opts.board, config) : undefined;
+      const event = await runtime.getEvent(eventId, boardId);
+      if (!event) throw new Error(`Event not found: ${eventId}`);
+      const hit = resolveDocumentByRef(event.documents as Record<string, unknown>[] | undefined, attachmentRef);
+      if (!hit) throw new Error(`Attachment not found: ${attachmentRef}`);
+      const name = typeof hit.doc.name === "string" ? hit.doc.name : `document-${hit.index + 1}`;
+      const mime = typeof hit.doc.mimeType === "string" ? hit.doc.mimeType : "application/octet-stream";
+      const outPath = opts.out || name;
+      let dataUrl = typeof hit.doc.dataUrl === "string" ? hit.doc.dataUrl : "";
+      const remoteUrl = extractDocumentUrl(hit.doc);
+      if ((!dataUrl || dataUrl.startsWith("data:application/octet-stream;base64,")) && remoteUrl) {
+        if (hit.doc.encrypted === true) {
+          dataUrl = await decryptAttachmentToDataUrl(typeof hit.doc.encryptionBoardId === "string" ? hit.doc.encryptionBoardId : event.boardId, remoteUrl, mime);
+        } else {
+          const res = await fetch(remoteUrl);
+          if (!res.ok) throw new Error(`Failed to fetch attachment (${res.status})`);
+          const bytes = Buffer.from(await res.arrayBuffer());
+          dataUrl = `data:${mime};base64,${bytes.toString("base64")}`;
+        }
+      }
+      if (!dataUrl.startsWith("data:")) throw new Error("Attachment has no retrievable data.");
+      const base64 = dataUrl.split(",", 2)[1] || "";
+      await writeFile(outPath, Buffer.from(base64, "base64"));
+      console.log(chalk.green(`✓ Saved attachment to ${outPath}`));
+      process.exit(0);
+    } catch (err) {
+      console.error(chalk.red(String(err)));
+      process.exit(1);
+    } finally {
+      await runtime.disconnect();
     }
   });
 
@@ -1954,6 +2258,29 @@ configSet
     console.log(chalk.green("✓ Relay added"));
     process.exit(0);
   });
+
+configSet
+  .command("file-server <url>")
+  .description("Set default public file server URL")
+  .action(async (url: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    config.fileStorageServer = url.trim();
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Public file server set to ${config.fileStorageServer}`));
+    process.exit(0);
+  });
+
+configSet
+  .command("encrypted-file-server <url>")
+  .description("Set default encrypted file server URL")
+  .action(async (url: string) => {
+    const config = await loadConfig(program.opts().profile as string | undefined);
+    config.encryptedFileStorageServer = url.trim();
+    await saveConfig(config);
+    console.log(chalk.green(`✓ Encrypted file server set to ${config.encryptedFileStorageServer}`));
+    process.exit(0);
+  });
+
 
 async function checkRelay(url: string, timeoutMs: number = 5000): Promise<boolean> {
   return new Promise((resolve) => {

--- a/taskify-cli/src/render.ts
+++ b/taskify-cli/src/render.ts
@@ -219,8 +219,9 @@ export function renderTaskCard(task: FullTaskRecord, trustedNpubs: string[], loc
     console.log(`${lbl("Documents:")}${task.documents.length}`);
     task.documents.forEach((doc, idx) => {
       const name = typeof doc.name === "string" ? doc.name : `document-${idx + 1}`;
-      const url = typeof doc.url === "string" ? doc.url : "";
-      console.log(`  - ${name}${url ? ` (${url})` : ""}`);
+      const url = typeof doc.remoteUrl === "string" ? doc.remoteUrl : (typeof doc.url === "string" ? doc.url : "");
+      const flags = [doc.encrypted === true ? "encrypted" : null, typeof doc.kind === "string" ? doc.kind : null].filter(Boolean).join(", ");
+      console.log(`  - ${name}${flags ? ` [${flags}]` : ""}${url ? ` (${url})` : ""}`);
     });
   }
 

--- a/taskify-runtime-nostr/package-lock.json
+++ b/taskify-runtime-nostr/package-lock.json
@@ -7,23 +7,19 @@
     "": {
       "name": "taskify-runtime-nostr",
       "version": "0.1.0",
-      "devDependencies": {
-        "@noble/hashes": "^1.4.0",
-        "@nostr-dev-kit/ndk": "^2.18.1",
-        "nostr-tools": "^2.16.2",
-        "typescript": "^5.9.3"
-      },
-      "peerDependencies": {
+      "dependencies": {
         "@noble/hashes": "^1.4.0",
         "@nostr-dev-kit/ndk": "^2.18.1",
         "nostr-tools": "^2.16.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@codesandbox/nodebox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
       "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
-      "dev": true,
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
         "outvariant": "^1.4.0",
@@ -34,7 +30,6 @@
       "version": "2.19.8",
       "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz",
       "integrity": "sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@codesandbox/nodebox": "0.1.8",
@@ -49,7 +44,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
       "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -62,7 +56,6 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -78,7 +71,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -91,7 +83,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.3.0.tgz",
       "integrity": "sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -101,7 +92,6 @@
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/@nostr-dev-kit/ndk/-/ndk-2.18.1.tgz",
       "integrity": "sha512-LTXXheGfmyN1y8x+8v/Dmkx8YX7LqaoVk0DTSaigETB5RZsxw7dLBKK++kZd4DVIxtj0tRfmSOsTr1E+M4653Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codesandbox/sandpack-client": "^2.19.8",
@@ -126,14 +116,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -143,7 +131,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
       "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "2.0.1",
@@ -158,7 +145,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
       "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1"
@@ -174,7 +160,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -187,7 +172,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -197,7 +181,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
       "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1",
@@ -211,7 +194,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -224,7 +206,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -234,7 +215,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
       "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -247,7 +227,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
       "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -259,7 +238,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
       "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0",
@@ -270,7 +248,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
       "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0"
@@ -280,7 +257,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
       "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "3.23.0"
@@ -290,7 +266,6 @@
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
       "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -301,14 +276,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -318,7 +291,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -328,21 +300,18 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -363,7 +332,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -388,7 +356,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -399,7 +366,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -410,7 +376,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -421,7 +386,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -432,7 +396,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -450,7 +413,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -460,7 +422,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -474,7 +435,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -487,7 +447,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -511,7 +470,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -525,7 +483,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -536,7 +493,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -557,7 +513,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
       "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@scure/base": "1.1.1"
@@ -567,7 +522,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -580,7 +534,6 @@
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -602,7 +555,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -623,7 +575,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -640,7 +591,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -662,7 +612,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -679,7 +628,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -696,7 +644,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -706,14 +653,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nostr-tools": {
       "version": "2.23.3",
       "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.23.3.tgz",
       "integrity": "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA==",
-      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "2.1.1",
@@ -737,7 +682,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
       "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "2.0.1"
@@ -753,7 +697,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -766,7 +709,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
       "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -776,21 +718,18 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
       "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
       "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
       "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "oniguruma-parser": "^0.12.1",
@@ -802,14 +741,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
       "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -820,7 +757,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
       "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -830,7 +766,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -840,14 +775,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
       "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "3.23.0",
@@ -864,7 +797,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -875,7 +807,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
       "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.1.0",
@@ -888,14 +819,12 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
       "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -910,7 +839,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -921,14 +849,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tseep/-/tseep-1.3.1.tgz",
       "integrity": "sha512-ZPtfk1tQnZVyr7BPtbJ93qaAh2lZuIOpTMjhrYa4XctT8xe7t4SAW9LIxrySDuYMsfNNayE51E/WNGrNVgVicQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -942,14 +869,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/typescript-lru-cache/-/typescript-lru-cache-2.0.0.tgz",
       "integrity": "sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -963,7 +888,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -977,7 +901,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -991,7 +914,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1007,7 +929,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1022,7 +943,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1037,7 +957,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -1052,7 +971,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/taskify-runtime-nostr/package.json
+++ b/taskify-runtime-nostr/package.json
@@ -10,15 +10,12 @@
     "pretest": "npm run build",
     "test": "node --test --experimental-strip-types tests/*.test.ts"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@noble/hashes": "^1.4.0",
     "@nostr-dev-kit/ndk": "^2.18.1",
     "nostr-tools": "^2.16.2"
   },
   "devDependencies": {
-    "@noble/hashes": "^1.4.0",
-    "@nostr-dev-kit/ndk": "^2.18.1",
-    "nostr-tools": "^2.16.2",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary
- adds CLI attachment upload/read/download flows for tasks and events
- adds append/remove attachment update semantics
- adds file server config commands
- fixes runtime/package dependency setup so the CLI builds and publishes cleanly
- validates live attachment creation against the Testing board

## Validation
- npm package published as taskify-nostr@0.3.6
- global CLI updated to 0.3.6 from production npm
- taskify-cli build passes
- taskify-runtime-nostr build passes
- live smoke test succeeded creating a task with encrypted attachment on Testing board