### PR TITLE
fix(pwa): rebuild selection mode bulk actions cleanly

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -15534,6 +15534,19 @@ export default function App() {
     });
   }
 
+  const moveSelectedTasksToBoard = useCallback((boardId: string) => {
+    if (!selectedTasks.length) return;
+    selectedTasks.forEach((task) => moveTaskToBoard(task.id, boardId));
+    const boardName = boards.find((board) => board.id === boardId)?.name || "board";
+    const eventCount = selectedEvents.length;
+    if (eventCount > 0) {
+      showToast(`Moved ${selectedTasks.length} task${selectedTasks.length === 1 ? "" : "s"} to ${boardName}. ${eventCount} selected event${eventCount === 1 ? " was" : "s were"} unchanged.`);
+    } else {
+      showToast(selectedTasks.length === 1 ? `Task moved to ${boardName}` : `${selectedTasks.length} tasks moved to ${boardName}`);
+    }
+    exitSelectionMode();
+  }, [boards, exitSelectionMode, selectedEvents.length, selectedTasks, showToast]);
+
   const selectionMoveTargets = useMemo(() => (
     boards.filter((board) => board.kind !== "bible").map((board) => ({
       id: board.id,


### PR DESCRIPTION
## Summary
- rebuild the selection mode bulk action patch cleanly on the latest base
- restore the missing bulk move callback and related selection mode actions
- avoid the broken follow-up cherry-pick artifacts from earlier PR attempts

## Context
- prior follow-up branches were inconsistent and still left the runtime path broken
- this branch carries the clean rebuild plus the missing callback restoration

## Testing
- targeted runtime fix rebuild